### PR TITLE
Add UC-11 raw dataset candidates view for admin flow.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@
 /src/Backend/Sudoku/Sudoku/examples/
 /.ai/SystemPlikowWSerwerze.md
 /.ai/AnalizaOdpowiedzialnosciBE-ML.md
+
+/node_modules/
+

--- a/src/Frontend/src/App.tsx
+++ b/src/Frontend/src/App.tsx
@@ -10,6 +10,7 @@ import {
   putPreprocessBoard,
   putPreprocessCells,
 } from "./api/examples";
+import { Uc11RawCandidatesSection } from "./components/Uc11RawCandidatesSection";
 import type {
   CellsGridApiResponse,
   ExampleFileApiResponse,
@@ -903,6 +904,7 @@ export default function App() {
           </article>
         </section>
       ) : null}
+      <Uc11RawCandidatesSection apiBaseUrl={apiBaseUrl} />
       <section className="result-card" aria-live="polite">
         <h2>Wynik</h2>
 

--- a/src/Frontend/src/api/datasetsRawCandidates.ts
+++ b/src/Frontend/src/api/datasetsRawCandidates.ts
@@ -1,0 +1,112 @@
+import type {
+  ErrorApiResponse,
+  RawDatasetCandidateApiResponse,
+} from "../types/api";
+
+export class RawDatasetCandidatesApiError extends Error {
+  readonly status: number;
+  readonly errorType: string | undefined;
+
+  constructor(message: string, status: number, errorType?: string) {
+    super(message);
+    this.name = "RawDatasetCandidatesApiError";
+    this.status = status;
+    this.errorType = errorType;
+  }
+}
+
+function tryParseJson(raw: string): unknown {
+  if (!raw.trim()) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function buildAuthHeaders(accessToken?: string | null): HeadersInit {
+  if (!accessToken) {
+    return {};
+  }
+
+  return {
+    Authorization: `Bearer ${accessToken}`,
+  };
+}
+
+function isErrorApiResponse(value: unknown): value is ErrorApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.message === "string" && typeof record.errorType === "string"
+  );
+}
+
+function isRawDatasetCandidateApiResponse(
+  value: unknown
+): value is RawDatasetCandidateApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return typeof record.name === "string" && typeof record.type === "string";
+}
+
+function buildErrorFromResponse(
+  rawBody: string,
+  status: number
+): RawDatasetCandidatesApiError {
+  const parsed = tryParseJson(rawBody);
+
+  if (isErrorApiResponse(parsed)) {
+    return new RawDatasetCandidatesApiError(
+      parsed.message,
+      status,
+      parsed.errorType
+    );
+  }
+
+  return new RawDatasetCandidatesApiError(
+    rawBody.trim()
+      ? `Backend zwrócił odpowiedź HTTP ${status}.`
+      : `Backend zwrócił odpowiedź HTTP ${status} bez treści.`,
+    status
+  );
+}
+
+export async function getRawDatasetCandidates(
+  apiBaseUrl: string,
+  accessToken?: string | null,
+  signal?: AbortSignal
+): Promise<RawDatasetCandidateApiResponse[]> {
+  const response = await fetch(`${apiBaseUrl}/datasets/raw-candidates`, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      ...buildAuthHeaders(accessToken),
+    },
+    signal,
+  });
+
+  const rawBody = await response.text();
+  const parsed = tryParseJson(rawBody);
+
+  if (response.status === 200) {
+    if (!Array.isArray(parsed) || !parsed.every(isRawDatasetCandidateApiResponse)) {
+      throw new Error(
+        "Backend zwrócił niepoprawny kształt RawDatasetCandidateApiResponse[]."
+      );
+    }
+
+    return parsed;
+  }
+
+  throw buildErrorFromResponse(rawBody, response.status);
+}

--- a/src/Frontend/src/components/Uc11RawCandidatesSection.tsx
+++ b/src/Frontend/src/components/Uc11RawCandidatesSection.tsx
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  getRawDatasetCandidates,
+  RawDatasetCandidatesApiError,
+} from "../api/datasetsRawCandidates";
+import type { RawDatasetCandidateApiResponse } from "../types/api";
+
+type LoadableState =
+  | {
+      kind: "idle";
+      data: RawDatasetCandidateApiResponse[] | null;
+      error: null;
+      errorType: null;
+      httpStatus: null;
+    }
+  | {
+      kind: "loading";
+      data: RawDatasetCandidateApiResponse[] | null;
+      error: null;
+      errorType: null;
+      httpStatus: null;
+    }
+  | {
+      kind: "success";
+      data: RawDatasetCandidateApiResponse[];
+      error: null;
+      errorType: null;
+      httpStatus: number;
+    }
+  | {
+      kind: "error";
+      data: RawDatasetCandidateApiResponse[] | null;
+      error: string;
+      errorType: string | null;
+      httpStatus: number | null;
+    };
+
+const defaultState: LoadableState = {
+  kind: "idle",
+  data: null,
+  error: null,
+  errorType: null,
+  httpStatus: null,
+};
+
+function resolveTypeLabel(type: string): string {
+  if (type === "board") {
+    return "Plansze sudoku";
+  }
+
+  if (type === "digit") {
+    return "Zbior cyfr";
+  }
+
+  return "Nieznany typ";
+}
+
+function clearAdminSession(): void {
+  const sessionKeys = [
+    "sudokuAdminAccessToken",
+    "sudokuAdminToken",
+    "adminAccessToken",
+    "accessToken",
+  ];
+
+  for (const key of sessionKeys) {
+    window.sessionStorage.removeItem(key);
+    window.localStorage.removeItem(key);
+  }
+}
+
+type Uc11RawCandidatesSectionProps = {
+  apiBaseUrl: string;
+  onUnauthorized?: () => void;
+};
+
+export function Uc11RawCandidatesSection({
+  apiBaseUrl,
+  onUnauthorized,
+}: Uc11RawCandidatesSectionProps) {
+  const tokenFromEnv = import.meta.env.VITE_ADMIN_TOKEN?.trim() ?? "";
+  const adminToken = tokenFromEnv || null;
+  const [state, setState] = useState<LoadableState>(defaultState);
+
+  const loadCandidates = useCallback(async () => {
+    setState((previous) => ({
+      kind: "loading",
+      data: previous.data,
+      error: null,
+      errorType: null,
+      httpStatus: null,
+    }));
+
+    try {
+      const response = await getRawDatasetCandidates(apiBaseUrl, adminToken);
+      setState({
+        kind: "success",
+        data: response,
+        error: null,
+        errorType: null,
+        httpStatus: 200,
+      });
+    } catch (error) {
+      if (error instanceof RawDatasetCandidatesApiError && error.status === 401) {
+        clearAdminSession();
+        onUnauthorized?.();
+      }
+
+      setState((previous) => ({
+        kind: "error",
+        data: previous.data,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Nie udało się pobrać kandydatów datasetowych.",
+        errorType:
+          error instanceof RawDatasetCandidatesApiError
+            ? error.errorType ?? null
+            : null,
+        httpStatus:
+          error instanceof RawDatasetCandidatesApiError ? error.status : null,
+      }));
+    }
+  }, [adminToken, apiBaseUrl, onUnauthorized]);
+
+  useEffect(() => {
+    void loadCandidates();
+  }, [loadCandidates]);
+
+  const candidates = state.data ?? [];
+  const boardCount = useMemo(
+    () => candidates.filter((item) => item.type === "board").length,
+    [candidates]
+  );
+  const digitCount = useMemo(
+    () => candidates.filter((item) => item.type === "digit").length,
+    [candidates]
+  );
+
+  return (
+    <section className="hero-card uc11-section">
+      <p className="eyebrow">UC-11 — Surowe kandydaty datasetowe</p>
+      <h2>Lista źródeł do dalszego przygotowania</h2>
+      <p className="hero-copy">
+        Widok przygotowuje dane wejściowe pod kolejny krok workflow datasetowego.
+      </p>
+
+      <div className="uc11-actions">
+        <button
+          className="secondary-button"
+          type="button"
+          disabled={state.kind === "loading"}
+          onClick={() => void loadCandidates()}
+        >
+          {state.kind === "loading" ? "Odświeżanie..." : "Odśwież listę"}
+        </button>
+      </div>
+
+      {state.kind === "loading" ? (
+        <p className="status-banner status-loading">Pobieranie kandydatów z backendu...</p>
+      ) : null}
+
+      {state.kind === "error" ? (
+        <>
+          <p className="status-banner status-error">{state.error}</p>
+          {state.httpStatus === 401 ? (
+            <p className="muted-copy">
+              Sesja administracyjna została wyczyszczona. Zaloguj się ponownie.
+            </p>
+          ) : null}
+        </>
+      ) : null}
+
+      {state.kind === "success" ? (
+        <>
+          <p className="muted-copy">
+            Wykryto {candidates.length} źródeł: board {boardCount}, digit {digitCount}.
+          </p>
+          {candidates.length === 0 ? (
+            <p className="status-banner status-loading">
+              Brak wykrytych datasetów w źródłach raw.
+            </p>
+          ) : (
+            <ul className="uc11-candidates-list">
+              {candidates.map((item) => (
+                <li key={`${item.type}-${item.name}`} className="uc11-candidate-item">
+                  <div>
+                    <strong>{item.name}</strong>
+                    <p className="muted-copy">
+                      Typ techniczny zwrócony przez backend: <code>{item.type}</code>
+                    </p>
+                  </div>
+                  <span
+                    className={`uc11-type-badge ${item.type === "board" ? "is-board" : item.type === "digit" ? "is-digit" : ""}`}
+                  >
+                    {resolveTypeLabel(item.type)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/src/Frontend/src/index.css
+++ b/src/Frontend/src/index.css
@@ -374,6 +374,62 @@ h2 {
   word-break: break-word;
 }
 
+.uc11-section {
+  display: grid;
+  gap: 1rem;
+}
+
+.uc11-actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.uc11-candidates-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.uc11-candidate-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.58);
+}
+
+.uc11-candidate-item strong {
+  color: #e0f2fe;
+}
+
+.uc11-type-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 0.2rem 0.55rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.01em;
+  color: #cbd5e1;
+  white-space: nowrap;
+}
+
+.uc11-type-badge.is-board {
+  border-color: rgba(125, 211, 252, 0.8);
+  color: #e0f2fe;
+  background: rgba(14, 116, 144, 0.22);
+}
+
+.uc11-type-badge.is-digit {
+  border-color: rgba(74, 222, 128, 0.8);
+  color: #dcfce7;
+  background: rgba(22, 101, 52, 0.22);
+}
 @media (max-width: 640px) {
   .page-shell {
     width: min(100% - 1rem, 960px);

--- a/src/Frontend/src/types/api.ts
+++ b/src/Frontend/src/types/api.ts
@@ -28,3 +28,8 @@ export type ErrorApiResponse = {
   errorType: string;
   message: string;
 };
+
+export type RawDatasetCandidateApiResponse = {
+  name: string;
+  type: string;
+};


### PR DESCRIPTION
This introduces a typed API client and a dedicated UI section with loading/empty/error states plus 401 session cleanup, so admins can verify available raw dataset sources before UC-12.
