### PR TITLE
uc-06: align training UI with active run workflow

### DIFF
--- a/src/Frontend/src/api/trainings.ts
+++ b/src/Frontend/src/api/trainings.ts
@@ -2,6 +2,8 @@ import type {
   CancelTrainingRunApiResponse,
   CreateTrainingRunApiEntry,
   ErrorApiResponse,
+  RegistryModelListItemApiResponse,
+  RegistryModelsListApiResponse,
   TrainingRunApiResponse,
 } from "../types/api";
 
@@ -74,6 +76,47 @@ function isTrainingRunApiResponse(
   );
 }
 
+function isRegistryModelListItemApiResponse(
+  value: unknown,
+): value is RegistryModelListItemApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.name === "string" &&
+    typeof record.displayName === "string" &&
+    typeof record.sourceType === "string" &&
+    (typeof record.sourceRunName === "string" || record.sourceRunName === null) &&
+    (typeof record.parentModelName === "string" || record.parentModelName === null) &&
+    typeof record.trainingMode === "string" &&
+    typeof record.inputProfile === "string" &&
+    typeof record.trainingProfileName === "string" &&
+    typeof record.augmentationProfileName === "string" &&
+    typeof record.createdAtUtc === "string" &&
+    typeof record.canStartTraining === "boolean" &&
+    typeof record.canUseForInference === "boolean" &&
+    Array.isArray(record.warnings) &&
+    record.warnings.every((warning) => typeof warning === "string")
+  );
+}
+
+function isRegistryModelsListApiResponse(
+  value: unknown,
+): value is RegistryModelsListApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    Array.isArray(record.items) &&
+    record.items.every((item) => isRegistryModelListItemApiResponse(item)) &&
+    typeof record.totalCount === "number"
+  );
+}
+
 function isCancelTrainingRunApiResponse(
   value: unknown,
 ): value is CancelTrainingRunApiResponse {
@@ -86,9 +129,27 @@ function isCancelTrainingRunApiResponse(
     typeof record.runName === "string" &&
     (typeof record.status === "string" || record.status === null) &&
     typeof record.requestDisposition === "string" &&
-    typeof record.message === "string" &&
-    (typeof record.progressChannelUrl === "string" ||
-      record.progressChannelUrl === null)
+    (typeof record.cancellationRequestedAtUtc === "string" ||
+      record.cancellationRequestedAtUtc === null)
+  );
+}
+
+function isLegacyCancelTrainingRunApiResponse(
+  value: unknown,
+): value is {
+  runName: string;
+  status: string | null;
+  requestDisposition: string;
+} {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.runName === "string" &&
+    (typeof record.status === "string" || record.status === null) &&
+    typeof record.requestDisposition === "string"
   );
 }
 
@@ -140,6 +201,70 @@ export async function postCreateTrainingRun(
   throw buildErrorFromResponse(rawBody, response.status);
 }
 
+export async function getActiveTrainingRun(
+  apiBaseUrl: string,
+  accessToken?: string | null,
+  signal?: AbortSignal,
+): Promise<TrainingRunApiResponse | null> {
+  const response = await fetch(`${apiBaseUrl}/trainings/active`, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      ...buildAuthHeaders(accessToken),
+    },
+    signal,
+  });
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  const rawBody = await response.text();
+  const parsed = tryParseJson(rawBody);
+
+  if (response.status === 200) {
+    if (!isTrainingRunApiResponse(parsed)) {
+      throw new Error(
+        "Backend zwrocil niepoprawny ksztalt TrainingRunApiResponse.",
+      );
+    }
+
+    return parsed;
+  }
+
+  throw buildErrorFromResponse(rawBody, response.status);
+}
+
+export async function getRegistryModels(
+  apiBaseUrl: string,
+  accessToken?: string | null,
+  signal?: AbortSignal,
+): Promise<RegistryModelsListApiResponse> {
+  const response = await fetch(`${apiBaseUrl}/models/registry`, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      ...buildAuthHeaders(accessToken),
+    },
+    signal,
+  });
+
+  const rawBody = await response.text();
+  const parsed = tryParseJson(rawBody);
+
+  if (response.status === 200) {
+    if (!isRegistryModelsListApiResponse(parsed)) {
+      throw new Error(
+        "Backend zwrocil niepoprawny ksztalt RegistryModelsListApiResponse.",
+      );
+    }
+
+    return parsed;
+  }
+
+  throw buildErrorFromResponse(rawBody, response.status);
+}
+
 export async function postCancelTrainingRun(
   apiBaseUrl: string,
   runName: string,
@@ -163,6 +288,15 @@ export async function postCancelTrainingRun(
 
   if (response.status === 202) {
     if (!isCancelTrainingRunApiResponse(parsed)) {
+      if (isLegacyCancelTrainingRunApiResponse(parsed)) {
+        return {
+          runName: parsed.runName,
+          status: parsed.status,
+          requestDisposition: parsed.requestDisposition,
+          cancellationRequestedAtUtc: null,
+        };
+      }
+
       throw new Error(
         "Backend zwrocil niepoprawny ksztalt CancelTrainingRunApiResponse.",
       );

--- a/src/Frontend/src/components/Uc06TrainingSection.tsx
+++ b/src/Frontend/src/components/Uc06TrainingSection.tsx
@@ -7,14 +7,19 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
+  getActiveTrainingRun,
+  getRegistryModels,
   postCancelTrainingRun,
   postCreateTrainingRun,
   TrainingsApiError,
 } from "../api/trainings";
+import { getProcessedDatasets } from "../api/datasets";
 import type {
   CancelTrainingRunApiResponse,
+  ProcessedDatasetListItemApiResponse,
+  RegistryModelListItemApiResponse,
   TrainingRunApiResponse,
-  TrainingRunRealtimeApiResponse,
+  TrainingRunSocketEventApiResponse,
 } from "../types/api";
 
 type Uc06TrainingSectionProps = {
@@ -23,67 +28,98 @@ type Uc06TrainingSectionProps = {
   onUnauthorized?: () => void;
 };
 
-type TrainingRequestState =
+type RemoteDataState<T> =
   | {
       kind: "idle";
-      response: TrainingRunApiResponse | null;
+      data: T | null;
       error: null;
       errorType: null;
       httpStatus: null;
     }
   | {
       kind: "loading";
-      response: TrainingRunApiResponse | null;
+      data: T | null;
       error: null;
       errorType: null;
       httpStatus: null;
     }
   | {
       kind: "success";
-      response: TrainingRunApiResponse;
+      data: T;
       error: null;
       errorType: null;
       httpStatus: number;
     }
   | {
       kind: "error";
-      response: TrainingRunApiResponse | null;
+      data: T | null;
       error: string;
       errorType: string | null;
       httpStatus: number | null;
     };
 
-type CancelRequestState =
+type RequestState<T> =
   | {
       kind: "idle";
-      response: CancelTrainingRunApiResponse | null;
+      response: T | null;
       error: null;
       errorType: null;
       httpStatus: null;
     }
   | {
       kind: "loading";
-      response: CancelTrainingRunApiResponse | null;
+      response: T | null;
       error: null;
       errorType: null;
       httpStatus: null;
     }
   | {
       kind: "success";
-      response: CancelTrainingRunApiResponse;
+      response: T;
       error: null;
       errorType: null;
       httpStatus: number;
     }
   | {
       kind: "error";
-      response: CancelTrainingRunApiResponse | null;
+      response: T | null;
       error: string;
       errorType: string | null;
       httpStatus: number | null;
     };
 
-const defaultTrainingState: TrainingRequestState = {
+type SocketState =
+  | "disconnected"
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "completed";
+
+const defaultModelsState: RemoteDataState<RegistryModelListItemApiResponse[]> = {
+  kind: "idle",
+  data: null,
+  error: null,
+  errorType: null,
+  httpStatus: null,
+};
+
+const defaultDatasetsState: RemoteDataState<ProcessedDatasetListItemApiResponse[]> = {
+  kind: "idle",
+  data: null,
+  error: null,
+  errorType: null,
+  httpStatus: null,
+};
+
+const defaultActiveRunState: RemoteDataState<TrainingRunApiResponse | null> = {
+  kind: "idle",
+  data: null,
+  error: null,
+  errorType: null,
+  httpStatus: null,
+};
+
+const defaultStartState: RequestState<TrainingRunApiResponse> = {
   kind: "idle",
   response: null,
   error: null,
@@ -91,7 +127,7 @@ const defaultTrainingState: TrainingRequestState = {
   httpStatus: null,
 };
 
-const defaultCancelState: CancelRequestState = {
+const defaultCancelState: RequestState<CancelTrainingRunApiResponse> = {
   kind: "idle",
   response: null,
   error: null,
@@ -99,13 +135,11 @@ const defaultCancelState: CancelRequestState = {
   httpStatus: null,
 };
 
-const trainingRequest = {
-  baseModelName: "cnn-baseline",
-  processedDatasetName: "uc12-dataset-v2",
-};
+const activeStatuses = ["queued", "starting", "running", "cancelling"];
+const terminalStatuses = ["succeeded", "failed", "cancelled"];
 
 function isTerminalStatus(status: string): boolean {
-  return ["succeeded", "failed", "cancelled"].includes(status);
+  return terminalStatuses.includes(status);
 }
 
 function formatTimestamp(timestampUtc: string | null): string {
@@ -125,13 +159,22 @@ function formatTimestamp(timestampUtc: string | null): string {
   }).format(parsedDate);
 }
 
-function formatPercent(value: number | null | undefined): string {
-  return typeof value === "number" ? `${value.toFixed(1)}%` : "-";
+function formatProgressPercent(value: number | null | undefined): string {
+  if (typeof value !== "number") {
+    return "-";
+  }
+
+  const clamped = Math.max(0, Math.min(100, value));
+  return `${clamped.toFixed(1)}%`;
 }
 
-function buildHubUrl(progressChannelUrl: string): string {
+function buildHubUrl(progressChannelUrl: string, apiBaseUrl: string): string {
   if (progressChannelUrl.startsWith("http://") || progressChannelUrl.startsWith("https://")) {
     return progressChannelUrl;
+  }
+
+  if (apiBaseUrl.startsWith("http://") || apiBaseUrl.startsWith("https://")) {
+    return new URL(progressChannelUrl, apiBaseUrl).toString();
   }
 
   return progressChannelUrl.startsWith("/")
@@ -139,18 +182,200 @@ function buildHubUrl(progressChannelUrl: string): string {
     : `/${progressChannelUrl}`;
 }
 
+function toSyntheticStage(status: string): string {
+  if (status === "queued" || status === "starting") {
+    return "queued";
+  }
+
+  if (status === "succeeded" || status === "cancelled") {
+    return "finished";
+  }
+
+  if (status === "failed") {
+    return "evaluation";
+  }
+
+  return "training";
+}
+
+function normalizeSocketEvent(
+  payload: unknown,
+): TrainingRunSocketEventApiResponse | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const record = payload as Record<string, unknown>;
+  if (
+    typeof record.eventType === "string" &&
+    typeof record.sequence === "number" &&
+    typeof record.runName === "string" &&
+    typeof record.status === "string" &&
+    typeof record.stage === "string" &&
+    typeof record.occurredAtUtc === "string" &&
+    (typeof record.message === "string" || record.message === null) &&
+    (typeof record.progress === "object" || record.progress === null) &&
+    Array.isArray(record.warnings) &&
+    (typeof record.result === "object" || record.result === null) &&
+    (typeof record.failure === "object" || record.failure === null)
+  ) {
+    return record as unknown as TrainingRunSocketEventApiResponse;
+  }
+
+  const isLegacyPayload =
+    typeof record.messageKind === "string" &&
+    typeof record.runName === "string" &&
+    typeof record.status === "string" &&
+    typeof record.createdAtUtc === "string";
+  if (!isLegacyPayload) {
+    return null;
+  }
+
+  const status = String(record.status);
+  const eventType =
+    record.messageKind === "snapshot"
+      ? "snapshot"
+      : typeof record.lastEventType === "string"
+        ? record.lastEventType
+        : "statusChanged";
+  const sequence =
+    typeof record.lastAcceptedSequence === "number"
+      ? record.lastAcceptedSequence
+      : 0;
+  const occurredAtUtc =
+    typeof record.updatedAtUtc === "string"
+      ? record.updatedAtUtc
+      : String(record.createdAtUtc);
+  const legacyProgress =
+    record.progress && typeof record.progress === "object"
+      ? (record.progress as Record<string, unknown>)
+      : null;
+  const warnings: string[] = [];
+  if (Array.isArray(record.warnings)) {
+    for (const warning of record.warnings) {
+      if (typeof warning === "string") {
+        warnings.push(warning);
+      }
+    }
+  }
+  if (Array.isArray(record.cleanupWarnings)) {
+    for (const warning of record.cleanupWarnings) {
+      if (typeof warning === "string") {
+        warnings.push(warning);
+      }
+    }
+  }
+
+  const result =
+    status === "succeeded"
+      ? {
+          producedModelName:
+            typeof record.producedModelName === "string"
+              ? record.producedModelName
+              : String(record.runName),
+          reportStatus:
+            typeof record.reportStatus === "string" ? record.reportStatus : "ready",
+          canUseProducedModelForInference: true,
+          primaryArtifactRelativePath:
+            typeof record.reportRelativePath === "string"
+              ? record.reportRelativePath
+              : "artifacts/model.keras",
+          summaryRelativePath:
+            typeof record.reportRelativePath === "string"
+              ? record.reportRelativePath
+              : null,
+          metricsRelativePath: null,
+          confusionMatrixRelativePath: null,
+        }
+      : null;
+  const failure =
+    status === "failed"
+      ? {
+          errorType: "training_run_failed",
+          message:
+            typeof record.failureReason === "string" && record.failureReason.trim()
+              ? record.failureReason
+              : "Run treningowy zakonczyl sie bledem technicznym.",
+          canUseProducedModelForInference: false,
+        }
+      : null;
+
+  return {
+    eventType,
+    sequence,
+    runName: String(record.runName),
+    status,
+    stage: toSyntheticStage(status),
+    occurredAtUtc,
+    message: null,
+    progress: legacyProgress
+      ? {
+          percent:
+            typeof legacyProgress.percent === "number"
+              ? legacyProgress.percent
+              : null,
+          epochCurrent:
+            typeof legacyProgress.epoch === "number" ? legacyProgress.epoch : null,
+          epochTotal:
+            typeof legacyProgress.totalEpochs === "number"
+              ? legacyProgress.totalEpochs
+              : null,
+          etaSeconds: null,
+        }
+      : null,
+    warnings,
+    result,
+    failure,
+  };
+}
+
+function toStartErrorHint(status: number | null): string | null {
+  if (status === null) {
+    return null;
+  }
+
+  const hints: Record<number, string> = {
+    400: "Sprawdz wybor modelu i datasetu.",
+    401: "Sesja administracyjna wygasla. Zaloguj sie ponownie.",
+    404: "Model bazowy albo dataset zostal usuniety.",
+    409: "Aktywny run juz istnieje. Interfejs powinien przelaczyc sie do monitoringu.",
+    422: "Wybrany model lub dataset nie przechodzi walidacji treningu.",
+    500: "Blad techniczny backendu. Zachowaj wybor i sproboj ponownie.",
+    503: "Integracja backendu z ML jest chwilowo niedostepna.",
+    504: "Start runu przekroczyl limit czasu.",
+  };
+
+  return hints[status] ?? null;
+}
+
+function toCancelDispositionHint(response: CancelTrainingRunApiResponse): string {
+  const dispositionCopy: Record<string, string> = {
+    cancellationRequested: "Zadanie anulowania zostalo przyjete.",
+    alreadyCancelling: "Run byl juz w trakcie anulowania.",
+    noopAlreadyFinished: "Run byl juz zakonczony - cancel nie zmienil stanu.",
+    noopNoMatchingRun: "Nie znaleziono dopasowanego runu - cancel potraktowano jako no-op.",
+  };
+
+  return dispositionCopy[response.requestDisposition] ?? "Backend przyjal zadanie cancel.";
+}
+
 export function Uc06TrainingSection({
   apiBaseUrl,
   accessToken,
   onUnauthorized,
 }: Uc06TrainingSectionProps) {
-  const [trainingState, setTrainingState] = useState(defaultTrainingState);
+  const [modelsState, setModelsState] = useState(defaultModelsState);
+  const [datasetsState, setDatasetsState] = useState(defaultDatasetsState);
+  const [activeRunState, setActiveRunState] = useState(defaultActiveRunState);
+  const [startState, setStartState] = useState(defaultStartState);
   const [cancelState, setCancelState] = useState(defaultCancelState);
-  const [connectionState, setConnectionState] = useState("disconnected");
-  const [realtimeEvents, setRealtimeEvents] = useState<
-    TrainingRunRealtimeApiResponse[]
-  >([]);
+  const [selectedModelName, setSelectedModelName] = useState("");
+  const [selectedDatasetName, setSelectedDatasetName] = useState("");
+  const [activeRun, setActiveRun] = useState<TrainingRunApiResponse | null>(null);
+  const [connectionState, setConnectionState] = useState<SocketState>("disconnected");
+  const [socketEvents, setSocketEvents] = useState<TrainingRunSocketEventApiResponse[]>([]);
   const connectionRef = useRef<HubConnection | null>(null);
+  const latestSequenceRef = useRef<number>(-1);
 
   const disconnectRealtime = useCallback(async () => {
     const connection = connectionRef.current;
@@ -161,18 +386,152 @@ export function Uc06TrainingSection({
       return;
     }
 
-    await connection.stop();
+    await connection.stop().catch(() => undefined);
     setConnectionState("disconnected");
+  }, []);
+
+  const handleUnauthorizedIfNeeded = useCallback(
+    (error: TrainingsApiError) => {
+      if (error.status === 401) {
+        onUnauthorized?.();
+        return true;
+      }
+
+      return false;
+    },
+    [onUnauthorized],
+  );
+
+  const loadSelectionData = useCallback(async () => {
+    if (!accessToken) {
+      setModelsState(defaultModelsState);
+      setDatasetsState(defaultDatasetsState);
+      return;
+    }
+
+    setModelsState((previous) => ({
+      kind: "loading",
+      data: previous.data,
+      error: null,
+      errorType: null,
+      httpStatus: null,
+    }));
+    setDatasetsState((previous) => ({
+      kind: "loading",
+      data: previous.data,
+      error: null,
+      errorType: null,
+      httpStatus: null,
+    }));
+
+    try {
+      const [modelsResponse, datasetsResponse] = await Promise.all([
+        getRegistryModels(apiBaseUrl, accessToken),
+        getProcessedDatasets(apiBaseUrl, accessToken),
+      ]);
+      setModelsState({
+        kind: "success",
+        data: modelsResponse.items,
+        error: null,
+        errorType: null,
+        httpStatus: 200,
+      });
+      setDatasetsState({
+        kind: "success",
+        data: datasetsResponse.items,
+        error: null,
+        errorType: null,
+        httpStatus: 200,
+      });
+
+      if (!selectedModelName && modelsResponse.items.length > 0) {
+        const firstTrainable =
+          modelsResponse.items.find((item) => item.canStartTraining) ?? null;
+        if (firstTrainable) {
+          setSelectedModelName(firstTrainable.name);
+        }
+      }
+      if (!selectedDatasetName && datasetsResponse.items.length > 0) {
+        setSelectedDatasetName(datasetsResponse.items[0].name);
+      }
+    } catch (error) {
+      if (error instanceof TrainingsApiError && handleUnauthorizedIfNeeded(error)) {
+        return;
+      }
+
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Nie udalo sie pobrac list modeli i datasetow.";
+      const httpStatus = error instanceof TrainingsApiError ? error.status : null;
+      const errorType =
+        error instanceof TrainingsApiError ? error.errorType ?? null : null;
+
+      setModelsState({
+        kind: "error",
+        data: null,
+        error: message,
+        errorType,
+        httpStatus,
+      });
+      setDatasetsState({
+        kind: "error",
+        data: null,
+        error: message,
+        errorType,
+        httpStatus,
+      });
+    }
+  }, [
+    accessToken,
+    apiBaseUrl,
+    handleUnauthorizedIfNeeded,
+    selectedDatasetName,
+    selectedModelName,
+  ]);
+
+  const ingestSocketPayload = useCallback((payload: unknown) => {
+    const event = normalizeSocketEvent(payload);
+    if (!event) {
+      return;
+    }
+
+    if (event.sequence < latestSequenceRef.current) {
+      return;
+    }
+    latestSequenceRef.current = event.sequence;
+
+    setSocketEvents((previous) => [event, ...previous.slice(0, 49)]);
+    if (terminalStatuses.includes(event.status)) {
+      setConnectionState("completed");
+    } else {
+      setConnectionState("connected");
+    }
+    setActiveRun((previous) => {
+      if (!previous || previous.runName !== event.runName) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        status: event.status,
+      };
+    });
   }, []);
 
   const connectRealtime = useCallback(
     async (run: TrainingRunApiResponse) => {
+      if (!accessToken) {
+        return;
+      }
+
       await disconnectRealtime();
-      setRealtimeEvents([]);
+      latestSequenceRef.current = -1;
+      setSocketEvents([]);
       setConnectionState("connecting");
 
       const connection = new HubConnectionBuilder()
-        .withUrl(buildHubUrl(run.progressChannelUrl), {
+        .withUrl(buildHubUrl(run.progressChannelUrl, apiBaseUrl), {
           accessTokenFactory: () => accessToken ?? "",
         })
         .configureLogging(LogLevel.Information)
@@ -181,40 +540,133 @@ export function Uc06TrainingSection({
 
       connection.on(
         "trainingSnapshot",
-        (message: TrainingRunRealtimeApiResponse) => {
-          setRealtimeEvents((previous) => [message, ...previous]);
-          setConnectionState(
-            isTerminalStatus(message.status) ? "completed" : "connected",
-          );
-        },
+        (message: unknown) => {
+          ingestSocketPayload(message);
+        }
       );
       connection.on(
         "trainingEvent",
-        (message: TrainingRunRealtimeApiResponse) => {
-          setRealtimeEvents((previous) => [message, ...previous]);
-          setConnectionState(
-            isTerminalStatus(message.status) ? "completed" : "connected",
-          );
-        },
+        (message: unknown) => {
+          ingestSocketPayload(message);
+        }
       );
       connection.onreconnecting(() => setConnectionState("reconnecting"));
       connection.onreconnected(() => setConnectionState("connected"));
       connection.onclose(() => setConnectionState("disconnected"));
 
       connectionRef.current = connection;
-      await connection.start();
-      setConnectionState("connected");
+      try {
+        await connection.start();
+        setConnectionState("connected");
+      } catch {
+        setConnectionState("disconnected");
+      }
     },
-    [accessToken, disconnectRealtime],
+    [accessToken, apiBaseUrl, disconnectRealtime, ingestSocketPayload],
   );
+
+  const recoverFromActiveRun = useCallback(async () => {
+    if (!accessToken) {
+      setActiveRunState(defaultActiveRunState);
+      setActiveRun(null);
+      return;
+    }
+
+    setActiveRunState((previous) => ({
+      kind: "loading",
+      data: previous.data,
+      error: null,
+      errorType: null,
+      httpStatus: null,
+    }));
+
+    try {
+      const run = await getActiveTrainingRun(apiBaseUrl, accessToken);
+      setActiveRun(run);
+      setActiveRunState({
+        kind: "success",
+        data: run,
+        error: null,
+        errorType: null,
+        httpStatus: run ? 200 : 204,
+      });
+
+      if (!run) {
+        await disconnectRealtime();
+        await loadSelectionData();
+        return;
+      }
+
+      if (run.status === "starting") {
+        for (let attempt = 0; attempt < 6; attempt += 1) {
+          await new Promise((resolve) => {
+            window.setTimeout(resolve, 1200);
+          });
+          const polledRun = await getActiveTrainingRun(apiBaseUrl, accessToken);
+          if (!polledRun || polledRun.status !== "starting") {
+            setActiveRun(polledRun);
+            setActiveRunState({
+              kind: "success",
+              data: polledRun,
+              error: null,
+              errorType: null,
+              httpStatus: polledRun ? 200 : 204,
+            });
+            if (!polledRun) {
+              await disconnectRealtime();
+              await loadSelectionData();
+              return;
+            }
+
+            await connectRealtime(polledRun);
+            return;
+          }
+        }
+      } else {
+        await connectRealtime(run);
+      }
+    } catch (error) {
+      if (error instanceof TrainingsApiError && handleUnauthorizedIfNeeded(error)) {
+        return;
+      }
+
+      setActiveRunState({
+        kind: "error",
+        data: null,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Nie udalo sie odzyskac aktywnego runu treningowego.",
+        errorType: error instanceof TrainingsApiError ? error.errorType ?? null : null,
+        httpStatus: error instanceof TrainingsApiError ? error.status : null,
+      });
+    }
+  }, [
+    accessToken,
+    apiBaseUrl,
+    connectRealtime,
+    disconnectRealtime,
+    handleUnauthorizedIfNeeded,
+    loadSelectionData,
+  ]);
 
   const startTraining = useCallback(async () => {
     if (!accessToken) {
       onUnauthorized?.();
       return;
     }
+    if (!selectedModelName || !selectedDatasetName) {
+      setStartState({
+        kind: "error",
+        response: null,
+        error: "Wybierz model bazowy i dataset processed.",
+        errorType: null,
+        httpStatus: null,
+      });
+      return;
+    }
 
-    setTrainingState((previous) => ({
+    setStartState((previous) => ({
       kind: "loading",
       response: previous.response,
       error: null,
@@ -225,10 +677,13 @@ export function Uc06TrainingSection({
     try {
       const response = await postCreateTrainingRun(
         apiBaseUrl,
-        trainingRequest,
+        {
+          baseModelName: selectedModelName,
+          processedDatasetName: selectedDatasetName,
+        },
         accessToken,
       );
-      setTrainingState({
+      setStartState({
         kind: "success",
         response,
         error: null,
@@ -236,13 +691,35 @@ export function Uc06TrainingSection({
         httpStatus: 202,
       });
       setCancelState(defaultCancelState);
+      setActiveRun(response);
+      setActiveRunState({
+        kind: "success",
+        data: response,
+        error: null,
+        errorType: null,
+        httpStatus: 200,
+      });
       await connectRealtime(response);
     } catch (error) {
-      if (error instanceof TrainingsApiError && error.status === 401) {
-        onUnauthorized?.();
+      if (error instanceof TrainingsApiError) {
+        if (handleUnauthorizedIfNeeded(error)) {
+          return;
+        }
+        if (error.status === 409 && error.errorType === "training_run_already_active") {
+          setStartState({
+            kind: "error",
+            response: null,
+            error:
+              "Inny run treningowy jest juz aktywny. Przelaczam widok do monitoringu.",
+            errorType: error.errorType,
+            httpStatus: error.status,
+          });
+          await recoverFromActiveRun();
+          return;
+        }
       }
 
-      setTrainingState((previous) => ({
+      setStartState((previous) => ({
         kind: "error",
         response: previous.response,
         error:
@@ -253,7 +730,16 @@ export function Uc06TrainingSection({
         httpStatus: error instanceof TrainingsApiError ? error.status : null,
       }));
     }
-  }, [accessToken, apiBaseUrl, connectRealtime, onUnauthorized]);
+  }, [
+    accessToken,
+    apiBaseUrl,
+    connectRealtime,
+    handleUnauthorizedIfNeeded,
+    onUnauthorized,
+    recoverFromActiveRun,
+    selectedDatasetName,
+    selectedModelName,
+  ]);
 
   const cancelTraining = useCallback(async () => {
     if (!accessToken) {
@@ -261,7 +747,7 @@ export function Uc06TrainingSection({
       return;
     }
 
-    const run = trainingState.response;
+    const run = activeRun;
     if (!run) {
       return;
     }
@@ -287,16 +773,22 @@ export function Uc06TrainingSection({
         errorType: null,
         httpStatus: 202,
       });
-
-      if (
-        connectionRef.current?.state !== HubConnectionState.Connected &&
-        response.progressChannelUrl
-      ) {
+      if (response.requestDisposition !== "noopNoMatchingRun" && response.status) {
+        setActiveRun((previous) =>
+          previous
+            ? {
+                ...previous,
+                status: response.status ?? previous.status,
+              }
+            : previous,
+        );
+      }
+      if (connectionRef.current?.state !== HubConnectionState.Connected) {
         await connectRealtime(run);
       }
     } catch (error) {
-      if (error instanceof TrainingsApiError && error.status === 401) {
-        onUnauthorized?.();
+      if (error instanceof TrainingsApiError && handleUnauthorizedIfNeeded(error)) {
+        return;
       }
 
       setCancelState((previous) => ({
@@ -312,11 +804,25 @@ export function Uc06TrainingSection({
     }
   }, [
     accessToken,
+    activeRun,
     apiBaseUrl,
     connectRealtime,
+    handleUnauthorizedIfNeeded,
     onUnauthorized,
-    trainingState.response,
   ]);
+
+  useEffect(() => {
+    if (!accessToken) {
+      setActiveRun(null);
+      setSocketEvents([]);
+      setStartState(defaultStartState);
+      setCancelState(defaultCancelState);
+      void disconnectRealtime();
+      return;
+    }
+
+    void recoverFromActiveRun();
+  }, [accessToken, disconnectRealtime, recoverFromActiveRun]);
 
   useEffect(() => {
     return () => {
@@ -327,64 +833,136 @@ export function Uc06TrainingSection({
     };
   }, []);
 
-  const latestEvent = realtimeEvents[0] ?? null;
-  const latestStatus = latestEvent?.status ?? trainingState.response?.status ?? null;
+  const latestEvent = socketEvents[0] ?? null;
+  const latestStatus = latestEvent?.status ?? activeRun?.status ?? null;
+  const isActiveRunPresent = latestStatus ? activeStatuses.includes(latestStatus) : false;
   const canCancel =
-    Boolean(trainingState.response) &&
+    Boolean(activeRun) &&
     latestStatus !== null &&
     !isTerminalStatus(latestStatus) &&
     latestStatus !== "cancelling";
+  const trainableModels = (modelsState.data ?? []).filter((model) => model.canStartTraining);
+  const availableDatasets = datasetsState.data ?? [];
+  const startErrorHint =
+    startState.kind === "error" ? toStartErrorHint(startState.httpStatus) : null;
 
   return (
     <section className="hero-card uc06-section">
-      <p className="eyebrow">UC-06 — Start treningu i SignalR</p>
-      <h2>Minimalny monitoring runu treningowego</h2>
+      <p className="eyebrow">UC-06 — Start treningu i monitoring postepu</p>
+      <h2>Run treningowy oparty o model i dataset</h2>
       <p className="hero-copy">
-        Ten widok wysyla testowy request do <code>POST /api/trainings</code> i
-        nasluchuje eventow z <code>/ws/trainings/{"{runName}"}</code>.
+        Ekran odzyskuje aktywny run przez <code>GET /api/trainings/active</code>,
+        uruchamia nowy trening przez <code>POST /api/trainings</code> i monitoruje
+        postep przez <code>/ws/trainings/{"{runName}"}</code>.
       </p>
 
-      <div className="uc12-panel">
-        <h3>Request testowy</h3>
-        <pre className="uc06-json-preview">
-{JSON.stringify(trainingRequest, null, 2)}
-        </pre>
-        <div className="examples-row-actions">
+      {!accessToken ? (
+        <p className="status-banner status-loading">
+          UC-06 wymaga sesji administracyjnej. Zaloguj sie, aby kontynuowac.
+        </p>
+      ) : null}
+
+      {activeRunState.kind === "loading" ? (
+        <p className="status-banner status-loading">
+          Odczytywanie aktywnego runu treningowego...
+        </p>
+      ) : null}
+
+      {activeRunState.kind === "error" ? (
+        <p className="status-banner status-error">{activeRunState.error}</p>
+      ) : null}
+
+      {accessToken && activeRun === null ? (
+        <article className="uc12-panel">
+          <h3>Formularz startu runu</h3>
+          <p className="muted-copy">
+            Wybierz dokladnie jeden model bazowy i jeden dataset processed.
+          </p>
+
+          <div className="examples-row-actions">
+            <button
+              className="secondary-button"
+              type="button"
+              onClick={() => void loadSelectionData()}
+              disabled={modelsState.kind === "loading" || datasetsState.kind === "loading"}
+            >
+              {modelsState.kind === "loading" || datasetsState.kind === "loading"
+                ? "Odswiezanie..."
+                : "Odswiez listy"}
+            </button>
+          </div>
+
+          {modelsState.kind === "error" ? (
+            <p className="status-banner status-error">{modelsState.error}</p>
+          ) : null}
+          {datasetsState.kind === "error" ? (
+            <p className="status-banner status-error">{datasetsState.error}</p>
+          ) : null}
+          {modelsState.kind === "success" && trainableModels.length === 0 ? (
+            <p className="status-banner status-loading">
+              Brak modeli bazowych gotowych do treningu w rejestrze (
+              <code>/api/models/registry</code> zwrocil pusta liste albo modele z{" "}
+              <code>canStartTraining=false</code>).
+            </p>
+          ) : null}
+          {datasetsState.kind === "success" && availableDatasets.length === 0 ? (
+            <p className="status-banner status-loading">
+              Brak datasetow processed w systemie (
+              <code>/api/datasets/processed</code> zwrocil pusta liste).
+            </p>
+          ) : null}
+
+          <label className="uc12-field">
+            <span>Model bazowy z rejestru</span>
+            <select
+              value={selectedModelName}
+              onChange={(event) => setSelectedModelName(event.target.value)}
+              disabled={trainableModels.length === 0}
+            >
+              <option value="">-- wybierz model --</option>
+              {trainableModels.map((model) => (
+                <option key={model.name} value={model.name}>
+                  {model.displayName} ({model.name}) | input: {model.inputProfile}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="uc12-field">
+            <span>Dataset processed (.npz)</span>
+            <select
+              value={selectedDatasetName}
+              onChange={(event) => setSelectedDatasetName(event.target.value)}
+              disabled={availableDatasets.length === 0}
+            >
+              <option value="">-- wybierz dataset --</option>
+              {availableDatasets.map((dataset) => (
+                <option key={dataset.name} value={dataset.name}>
+                  {dataset.fileName} | profile: {dataset.preprocessingProfile}
+                </option>
+              ))}
+            </select>
+          </label>
+
           <button
             className="primary-button"
             type="button"
-            disabled={trainingState.kind === "loading"}
+            disabled={
+              startState.kind === "loading" ||
+              !selectedModelName ||
+              !selectedDatasetName
+            }
             onClick={() => void startTraining()}
           >
-            {trainingState.kind === "loading"
-              ? "Uruchamianie..."
-              : "Uruchom trening UC-06"}
+            {startState.kind === "loading" ? "Uruchamianie..." : "Start treningu"}
           </button>
-          <button
-            className="secondary-button"
-            type="button"
-            onClick={() => void disconnectRealtime()}
-          >
-            Rozlacz SignalR
-          </button>
-          <button
-            className="secondary-button"
-            type="button"
-            disabled={!canCancel || cancelState.kind === "loading"}
-            onClick={() => void cancelTraining()}
-          >
-            {cancelState.kind === "loading" ? "Anulowanie..." : "Anuluj trening"}
-          </button>
-        </div>
-      </div>
+        </article>
+      ) : null}
 
-      {trainingState.kind === "error" ? (
+      {startState.kind === "error" ? (
         <>
-          <p className="status-banner status-error">{trainingState.error}</p>
-          <p className="muted-copy">
-            HTTP: {trainingState.httpStatus ?? "-"}, typ:{" "}
-            {trainingState.errorType ?? "-"}
-          </p>
+          <p className="status-banner status-error">{startState.error}</p>
+          {startErrorHint ? <p className="muted-copy">{startErrorHint}</p> : null}
         </>
       ) : null}
 
@@ -400,33 +978,58 @@ export function Uc06TrainingSection({
 
       {cancelState.kind === "success" ? (
         <p className="status-banner status-loading">
-          {cancelState.response.message} Disposition:{" "}
-          {cancelState.response.requestDisposition}, status:{" "}
+          {toCancelDispositionHint(cancelState.response)} Disposition:{" "}
+          {cancelState.response.requestDisposition}. Status:{" "}
           {cancelState.response.status ?? "-"}.
         </p>
       ) : null}
 
-      {trainingState.kind === "success" ? (
+      {activeRun ? (
         <div className="uc12-panel">
-          <h3>Odpowiedz BE</h3>
+          <h3>Monitoring aktywnego runu</h3>
           <dl className="result-grid">
             <div>
               <dt>Run</dt>
-              <dd>{trainingState.response.runName}</dd>
+              <dd>{activeRun.runName}</dd>
             </div>
             <div>
-              <dt>Status startowy</dt>
-              <dd>{trainingState.response.status}</dd>
+              <dt>Status</dt>
+              <dd>{latestStatus ?? activeRun.status}</dd>
             </div>
             <div>
               <dt>Model wynikowy</dt>
-              <dd>{trainingState.response.producedModelName}</dd>
+              <dd>{activeRun.producedModelName}</dd>
             </div>
             <div>
-              <dt>SignalR</dt>
+              <dt>SignalR kanal</dt>
               <dd>{connectionState}</dd>
             </div>
+            <div>
+              <dt>Dataset</dt>
+              <dd>{activeRun.processedDatasetName}</dd>
+            </div>
+            <div>
+              <dt>Utworzono (UTC)</dt>
+              <dd>{formatTimestamp(activeRun.createdAtUtc)}</dd>
+            </div>
           </dl>
+          <div className="examples-row-actions">
+            <button
+              className="secondary-button"
+              type="button"
+              onClick={() => void disconnectRealtime()}
+            >
+              Rozlacz SignalR
+            </button>
+            <button
+              className="secondary-button"
+              type="button"
+              disabled={!canCancel || cancelState.kind === "loading"}
+              onClick={() => void cancelTraining()}
+            >
+              {cancelState.kind === "loading" ? "Anulowanie..." : "Anuluj run"}
+            </button>
+          </div>
         </div>
       ) : null}
 
@@ -440,37 +1043,49 @@ export function Uc06TrainingSection({
                 : "status-loading"
           }`}
         >
-          Aktualny status: {latestEvent.status}. Postep:{" "}
-          {formatPercent(latestEvent.progress?.percent)}.
+          Aktualny status: {latestEvent.status} (event: {latestEvent.eventType}). Postep:{" "}
+          {formatProgressPercent(latestEvent.progress?.percent)}.
           {latestEvent.status === "succeeded"
             ? " Trening zakonczony sukcesem."
             : latestEvent.status === "cancelled"
               ? " Trening anulowany."
-            : ""}
+              : latestEvent.status === "failed"
+                ? " Trening zakonczony bledem."
+                : ""}
         </p>
       ) : null}
 
-      {realtimeEvents.length > 0 ? (
+      {latestEvent?.result && latestEvent.result.reportStatus !== "ready" ? (
+        <p className="status-banner status-loading">
+          Raport koncowy ma status <code>{latestEvent.result.reportStatus}</code>, ale model
+          moze byc nadal uzywalny do inferencji.
+        </p>
+      ) : null}
+
+      {socketEvents.length > 0 ? (
         <div className="uc12-panel">
           <h3>Odebrane komunikaty SignalR</h3>
           <ul className="uc06-events-list">
-            {realtimeEvents.map((event, index) => (
-              <li key={`${event.messageKind}-${event.lastAcceptedSequence ?? index}`}>
+            {socketEvents.map((event) => (
+              <li key={`${event.eventType}-${event.sequence}`}>
                 <strong>
-                  {event.messageKind} / {event.status}
+                  {event.eventType} / {event.status}
                 </strong>
                 <span>
-                  seq: {event.lastAcceptedSequence ?? "-"}, event:{" "}
-                  {event.lastEventType ?? "-"}, czas:{" "}
-                  {formatTimestamp(event.updatedAtUtc ?? event.createdAtUtc)}
+                  seq: {event.sequence}, stage: {event.stage}, czas:{" "}
+                  {formatTimestamp(event.occurredAtUtc)}
                 </span>
                 <span>
-                  epoch: {event.progress?.epoch ?? "-"} /{" "}
-                  {event.progress?.totalEpochs ?? "-"}, accuracy:{" "}
-                  {event.metricsSummary?.accuracy ?? event.progress?.validationAccuracy ?? "-"}
+                  epoch: {event.progress?.epochCurrent ?? "-"} /{" "}
+                  {event.progress?.epochTotal ?? "-"}, ETA: {event.progress?.etaSeconds ?? "-"} s
                 </span>
-                {event.reportRelativePath ? (
-                  <span>Raport: {event.reportRelativePath}</span>
+                {event.result ? (
+                  <span>model: {event.result.producedModelName}</span>
+                ) : null}
+                {event.failure ? (
+                  <span>
+                    failure: {event.failure.errorType} - {event.failure.message}
+                  </span>
                 ) : null}
               </li>
             ))}
@@ -479,6 +1094,12 @@ export function Uc06TrainingSection({
       ) : (
         <p className="muted-copy">Brak odebranych komunikatow SignalR.</p>
       )}
+
+      {isActiveRunPresent && connectionState === "disconnected" ? (
+        <p className="status-banner status-loading">
+          Polaczenie SignalR zostalo utracone. Run trwa po stronie backendu - odswiez aktywny run.
+        </p>
+      ) : null}
     </section>
   );
 }

--- a/src/Frontend/src/index.css
+++ b/src/Frontend/src/index.css
@@ -612,6 +612,14 @@ h2 {
   padding: 0.55rem 0.7rem;
 }
 
+.uc12-field select {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.65);
+  color: #e2e8f0;
+  padding: 0.55rem 0.7rem;
+}
+
 .uc12-candidates-list {
   display: grid;
   gap: 0.5rem;

--- a/src/Frontend/src/types/api.ts
+++ b/src/Frontend/src/types/api.ts
@@ -100,6 +100,27 @@ export type CreateTrainingRunApiEntry = {
   processedDatasetName: string;
 };
 
+export type RegistryModelListItemApiResponse = {
+  name: string;
+  displayName: string;
+  sourceType: string;
+  sourceRunName: string | null;
+  parentModelName: string | null;
+  trainingMode: string;
+  inputProfile: string;
+  trainingProfileName: string;
+  augmentationProfileName: string;
+  createdAtUtc: string;
+  canStartTraining: boolean;
+  canUseForInference: boolean;
+  warnings: string[];
+};
+
+export type RegistryModelsListApiResponse = {
+  items: RegistryModelListItemApiResponse[];
+  totalCount: number;
+};
+
 export type TrainingRunApiResponse = {
   runName: string;
   status: string;
@@ -119,48 +140,42 @@ export type CancelTrainingRunApiResponse = {
   runName: string;
   status: string | null;
   requestDisposition: string;
-  message: string;
-  progressChannelUrl: string | null;
+  cancellationRequestedAtUtc: string | null;
 };
 
 export type TrainingRunProgressApiResponse = {
   percent: number | null;
-  epoch: number | null;
-  totalEpochs: number | null;
-  trainLoss: number | null;
-  validationLoss: number | null;
-  trainAccuracy: number | null;
-  validationAccuracy: number | null;
+  epochCurrent: number | null;
+  epochTotal: number | null;
+  etaSeconds: number | null;
 };
 
-export type TrainingMetricsSummaryApiResponse = {
-  accuracy: number | null;
-  macroF1: number | null;
+export type TrainingRunResultApiResponse = {
+  producedModelName: string;
+  reportStatus: string;
+  canUseProducedModelForInference: boolean;
+  primaryArtifactRelativePath: string;
+  summaryRelativePath: string | null;
+  metricsRelativePath: string | null;
+  confusionMatrixRelativePath: string | null;
 };
 
-export type TrainingRunRealtimeApiResponse = {
-  messageKind: string;
+export type TrainingRunFailureApiResponse = {
+  errorType: string;
+  message: string;
+  canUseProducedModelForInference: boolean;
+};
+
+export type TrainingRunSocketEventApiResponse = {
+  eventType: string;
+  sequence: number;
   runName: string;
   status: string;
-  createdAtUtc: string;
-  updatedAtUtc: string | null;
-  startedAtUtc: string | null;
-  finishedAtUtc: string | null;
-  baseModelName: string;
-  producedModelName: string;
-  processedDatasetName: string;
-  trainingMode: string;
-  trainingProfileName: string;
-  augmentationProfileName: string;
-  benchmarkName: string;
-  seed: number;
-  lastAcceptedSequence: number | null;
-  lastEventType: string | null;
+  stage: string;
+  occurredAtUtc: string;
+  message: string | null;
   progress: TrainingRunProgressApiResponse | null;
-  metricsSummary: TrainingMetricsSummaryApiResponse | null;
-  reportStatus: string | null;
-  reportRelativePath: string | null;
   warnings: string[];
-  cleanupWarnings: string[];
-  failureReason: string | null;
+  result: TrainingRunResultApiResponse | null;
+  failure: TrainingRunFailureApiResponse | null;
 };


### PR DESCRIPTION
Replace the UC-06 test stub with the real admin flow by loading active runs, registry models, and processed datasets, then handling start/cancel and SignalR monitoring with robust status messaging.
