### PR TITLE
uc-08/09: add training catalog and run details view

### DIFF
--- a/src/Frontend/src/App.tsx
+++ b/src/Frontend/src/App.tsx
@@ -12,6 +12,7 @@ import {
   putPreprocessCells,
 } from "./api/examples";
 import { Uc06TrainingSection } from "./components/Uc06TrainingSection";
+import { Uc08CatalogSection } from "./components/Uc08CatalogSection";
 import { Uc11RawCandidatesSection } from "./components/Uc11RawCandidatesSection";
 import { Uc12DatasetPreparationSection } from "./components/Uc12DatasetPreparationSection";
 import { useAdminSession } from "./context/AdminSessionContext";
@@ -275,7 +276,7 @@ function toImageDataUrl(image: ImageApiResponse): string {
 }
 
 type AppView = "health" | "examples" | "datasets";
-type DatasetsStep = "uc11" | "uc12" | "uc06";
+type DatasetsStep = "uc11" | "uc12" | "uc06" | "uc08";
 
 export default function App() {
   const apiBaseUrl = normalizeBaseUrl(import.meta.env.VITE_API_BASE_URL);
@@ -332,7 +333,13 @@ export default function App() {
         ? "Przyklady"
         : "Datasety";
   const datasetsStepLabel =
-    datasetsStep === "uc11" ? "UC-11" : datasetsStep === "uc12" ? "UC-12" : "UC-06";
+    datasetsStep === "uc11"
+      ? "UC-11 — Przeglad kandydatow raw"
+      : datasetsStep === "uc12"
+        ? "UC-12 — Budowa datasetu processed"
+        : datasetsStep === "uc06"
+          ? "UC-06 — Start i monitoring treningu"
+          : "UC-08 — Katalog runow i modeli";
 
   const loadExamplesList = useCallback(async () => {
     setExamplesListState((previous) => ({
@@ -1262,10 +1269,11 @@ export default function App() {
             <>
               <section className="hero-card datasets-module-header">
                 <p className="eyebrow">Workflow datasetowy</p>
-                <h2>UC-11 -&gt; UC-12 -&gt; UC-06</h2>
+                <h2>UC-11 -&gt; UC-12 -&gt; UC-06 -&gt; UC-08</h2>
                 <p className="hero-copy">
                   Nawiguj krokami: najpierw kandydaci raw, potem budowa datasetu
-                  processed, a na koncu testowy start treningu i SignalR.
+                  processed, potem start treningu i SignalR, a na koncu katalog
+                  runow oraz modeli.
                 </p>
                 <div
                   className="datasets-stepper"
@@ -1279,7 +1287,7 @@ export default function App() {
                     className={`datasets-step ${datasetsStep === "uc11" ? "is-active" : ""}`}
                     onClick={() => setDatasetsStep("uc11")}
                   >
-                    1. UC-11
+                    1. Przeglad kandydatow raw (UC-11)
                   </button>
                   <button
                     type="button"
@@ -1288,7 +1296,7 @@ export default function App() {
                     className={`datasets-step ${datasetsStep === "uc12" ? "is-active" : ""}`}
                     onClick={() => setDatasetsStep("uc12")}
                   >
-                    2. UC-12
+                    2. Budowa datasetu processed (UC-12)
                   </button>
                   <button
                     type="button"
@@ -1297,7 +1305,16 @@ export default function App() {
                     className={`datasets-step ${datasetsStep === "uc06" ? "is-active" : ""}`}
                     onClick={() => setDatasetsStep("uc06")}
                   >
-                    3. UC-06
+                    3. Start i monitoring treningu (UC-06)
+                  </button>
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={datasetsStep === "uc08"}
+                    className={`datasets-step ${datasetsStep === "uc08" ? "is-active" : ""}`}
+                    onClick={() => setDatasetsStep("uc08")}
+                  >
+                    4. Katalog runow i modeli (UC-08)
                   </button>
                 </div>
               </section>
@@ -1318,6 +1335,13 @@ export default function App() {
               </div>
               <div hidden={datasetsStep !== "uc06"} aria-hidden={datasetsStep !== "uc06"}>
                 <Uc06TrainingSection
+                  apiBaseUrl={apiBaseUrl}
+                  accessToken={authToken?.accessToken ?? null}
+                  onUnauthorized={() => handleAdminUnauthorized("invalid_token")}
+                />
+              </div>
+              <div hidden={datasetsStep !== "uc08"} aria-hidden={datasetsStep !== "uc08"}>
+                <Uc08CatalogSection
                   apiBaseUrl={apiBaseUrl}
                   accessToken={authToken?.accessToken ?? null}
                   onUnauthorized={() => handleAdminUnauthorized("invalid_token")}

--- a/src/Frontend/src/api/trainings.ts
+++ b/src/Frontend/src/api/trainings.ts
@@ -4,7 +4,21 @@ import type {
   ErrorApiResponse,
   RegistryModelListItemApiResponse,
   RegistryModelsListApiResponse,
+  TrainingClassMetricApiResponse,
+  TrainingConfusionMatrixApiResponse,
+  TrainingDatasetSampleCountsApiResponse,
+  TrainingMetricsSummaryApiResponse,
+  TrainingMetricHistoryPointApiResponse,
   TrainingRunApiResponse,
+  TrainingRunConfigurationApiResponse,
+  TrainingRunDatasetDetailsApiResponse,
+  TrainingRunDetailsApiResponse,
+  TrainingRunListItemApiResponse,
+  TrainingRunModelReferenceApiResponse,
+  TrainingRunProgressApiResponse,
+  TrainingRunReportApiResponse,
+  TrainingReportSummaryApiResponse,
+  TrainingRunsListApiResponse,
 } from "../types/api";
 
 export class TrainingsApiError extends Error {
@@ -73,6 +87,285 @@ function isTrainingRunApiResponse(
     typeof record.benchmarkName === "string" &&
     typeof record.seed === "number" &&
     typeof record.progressChannelUrl === "string"
+  );
+}
+
+function isTrainingRunProgressApiResponse(
+  value: unknown,
+): value is TrainingRunProgressApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    (typeof record.percent === "number" || record.percent === null) &&
+    (typeof record.epochCurrent === "number" || record.epochCurrent === null) &&
+    (typeof record.epochTotal === "number" || record.epochTotal === null) &&
+    (typeof record.etaSeconds === "number" || record.etaSeconds === null) &&
+    (typeof record.trainLoss === "number" ||
+      record.trainLoss === null ||
+      record.trainLoss === undefined) &&
+    (typeof record.validationLoss === "number" ||
+      record.validationLoss === null ||
+      record.validationLoss === undefined) &&
+    (typeof record.trainAccuracy === "number" ||
+      record.trainAccuracy === null ||
+      record.trainAccuracy === undefined) &&
+    (typeof record.validationAccuracy === "number" ||
+      record.validationAccuracy === null ||
+      record.validationAccuracy === undefined)
+  );
+}
+
+function isTrainingMetricsSummaryApiResponse(
+  value: unknown,
+): value is TrainingMetricsSummaryApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    (typeof record.accuracy === "number" || record.accuracy === null) &&
+    (typeof record.macroF1 === "number" || record.macroF1 === null)
+  );
+}
+
+function isTrainingRunListItemApiResponse(
+  value: unknown,
+): value is TrainingRunListItemApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.runName === "string" &&
+    typeof record.status === "string" &&
+    typeof record.createdAtUtc === "string" &&
+    (typeof record.updatedAtUtc === "string" || record.updatedAtUtc === null) &&
+    (typeof record.startedAtUtc === "string" || record.startedAtUtc === null) &&
+    (typeof record.finishedAtUtc === "string" || record.finishedAtUtc === null) &&
+    typeof record.baseModelName === "string" &&
+    typeof record.producedModelName === "string" &&
+    typeof record.processedDatasetName === "string" &&
+    typeof record.trainingMode === "string" &&
+    typeof record.trainingProfileName === "string" &&
+    typeof record.augmentationProfileName === "string" &&
+    typeof record.benchmarkName === "string" &&
+    (typeof record.reportStatus === "string" || record.reportStatus === null) &&
+    (record.progress === null || isTrainingRunProgressApiResponse(record.progress)) &&
+    (record.metricsSummary === null ||
+      isTrainingMetricsSummaryApiResponse(record.metricsSummary)) &&
+    Array.isArray(record.warnings) &&
+    record.warnings.every((warning) => typeof warning === "string")
+  );
+}
+
+function isTrainingRunModelReferenceApiResponse(
+  value: unknown,
+): value is TrainingRunModelReferenceApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.name === "string" &&
+    typeof record.displayName === "string" &&
+    typeof record.sourceType === "string" &&
+    (typeof record.sourceRunName === "string" || record.sourceRunName === null) &&
+    (typeof record.parentModelName === "string" || record.parentModelName === null) &&
+    typeof record.inputProfile === "string" &&
+    typeof record.canUseForInference === "boolean" &&
+    typeof record.canStartTraining === "boolean"
+  );
+}
+
+function isTrainingDatasetSampleCountsApiResponse(
+  value: unknown,
+): value is TrainingDatasetSampleCountsApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.train === "number" &&
+    typeof record.val === "number" &&
+    typeof record.test === "number"
+  );
+}
+
+function isTrainingRunDatasetDetailsApiResponse(
+  value: unknown,
+): value is TrainingRunDatasetDetailsApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.processedDatasetName === "string" &&
+    (typeof record.preprocessingProfile === "string" ||
+      record.preprocessingProfile === null) &&
+    (record.sampleCounts === null ||
+      isTrainingDatasetSampleCountsApiResponse(record.sampleCounts))
+  );
+}
+
+function isTrainingRunConfigurationApiResponse(
+  value: unknown,
+): value is TrainingRunConfigurationApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.trainingMode === "string" &&
+    typeof record.trainingProfileName === "string" &&
+    typeof record.augmentationProfileName === "string" &&
+    typeof record.benchmarkName === "string" &&
+    typeof record.seed === "number" &&
+    (typeof record.sourceRevision === "string" || record.sourceRevision === null)
+  );
+}
+
+function isTrainingReportSummaryApiResponse(
+  value: unknown,
+): value is TrainingReportSummaryApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.accuracy === "number" &&
+    typeof record.precisionMacro === "number" &&
+    typeof record.recallMacro === "number" &&
+    typeof record.f1Macro === "number" &&
+    (typeof record.trainingDurationSeconds === "number" ||
+      record.trainingDurationSeconds === null) &&
+    (typeof record.averageInferenceTimeMs === "number" ||
+      record.averageInferenceTimeMs === null)
+  );
+}
+
+function isTrainingClassMetricApiResponse(
+  value: unknown,
+): value is TrainingClassMetricApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.label === "string" &&
+    typeof record.precision === "number" &&
+    typeof record.recall === "number" &&
+    typeof record.f1 === "number" &&
+    typeof record.support === "number"
+  );
+}
+
+function isTrainingMetricHistoryPointApiResponse(
+  value: unknown,
+): value is TrainingMetricHistoryPointApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.epoch === "number" &&
+    (typeof record.trainLoss === "number" || record.trainLoss === null) &&
+    (typeof record.validationLoss === "number" || record.validationLoss === null) &&
+    (typeof record.trainAccuracy === "number" || record.trainAccuracy === null) &&
+    (typeof record.validationAccuracy === "number" ||
+      record.validationAccuracy === null)
+  );
+}
+
+function isTrainingConfusionMatrixApiResponse(
+  value: unknown,
+): value is TrainingConfusionMatrixApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    Array.isArray(record.classNames) &&
+    record.classNames.every((className) => typeof className === "string") &&
+    Array.isArray(record.matrix) &&
+    record.matrix.every(
+      (row) =>
+        Array.isArray(row) && row.every((cellValue) => typeof cellValue === "number"),
+    )
+  );
+}
+
+function isTrainingRunReportApiResponse(
+  value: unknown,
+): value is TrainingRunReportApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.status === "string" &&
+    (record.summary === null || isTrainingReportSummaryApiResponse(record.summary)) &&
+    Array.isArray(record.perClassMetrics) &&
+    record.perClassMetrics.every((item) => isTrainingClassMetricApiResponse(item)) &&
+    Array.isArray(record.history) &&
+    record.history.every((item) => isTrainingMetricHistoryPointApiResponse(item)) &&
+    (record.confusionMatrix === null ||
+      isTrainingConfusionMatrixApiResponse(record.confusionMatrix))
+  );
+}
+
+function isTrainingRunDetailsApiResponse(
+  value: unknown,
+): value is TrainingRunDetailsApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.runName === "string" &&
+    typeof record.status === "string" &&
+    (typeof record.stage === "string" || record.stage === null) &&
+    typeof record.createdAtUtc === "string" &&
+    (typeof record.startedAtUtc === "string" || record.startedAtUtc === null) &&
+    (typeof record.finishedAtUtc === "string" || record.finishedAtUtc === null) &&
+    isTrainingRunModelReferenceApiResponse(record.baseModel) &&
+    (record.producedModel === null ||
+      isTrainingRunModelReferenceApiResponse(record.producedModel)) &&
+    isTrainingRunDatasetDetailsApiResponse(record.dataset) &&
+    isTrainingRunConfigurationApiResponse(record.configuration) &&
+    (record.progress === null || isTrainingRunProgressApiResponse(record.progress)) &&
+    isTrainingRunReportApiResponse(record.report) &&
+    Array.isArray(record.warnings) &&
+    record.warnings.every((warning) => typeof warning === "string")
+  );
+}
+
+function isTrainingRunsListApiResponse(
+  value: unknown,
+): value is TrainingRunsListApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    Array.isArray(record.items) &&
+    record.items.every((item) => isTrainingRunListItemApiResponse(item)) &&
+    typeof record.totalCount === "number"
   );
 }
 
@@ -228,6 +521,70 @@ export async function getActiveTrainingRun(
     if (!isTrainingRunApiResponse(parsed)) {
       throw new Error(
         "Backend zwrocil niepoprawny ksztalt TrainingRunApiResponse.",
+      );
+    }
+
+    return parsed;
+  }
+
+  throw buildErrorFromResponse(rawBody, response.status);
+}
+
+export async function getTrainingRuns(
+  apiBaseUrl: string,
+  accessToken?: string | null,
+  signal?: AbortSignal,
+): Promise<TrainingRunsListApiResponse> {
+  const response = await fetch(`${apiBaseUrl}/trainings`, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      ...buildAuthHeaders(accessToken),
+    },
+    signal,
+  });
+
+  const rawBody = await response.text();
+  const parsed = tryParseJson(rawBody);
+
+  if (response.status === 200) {
+    if (!isTrainingRunsListApiResponse(parsed)) {
+      throw new Error(
+        "Backend zwrocil niepoprawny ksztalt TrainingRunsListApiResponse.",
+      );
+    }
+
+    return parsed;
+  }
+
+  throw buildErrorFromResponse(rawBody, response.status);
+}
+
+export async function getTrainingRunDetails(
+  apiBaseUrl: string,
+  runName: string,
+  accessToken?: string | null,
+  signal?: AbortSignal,
+): Promise<TrainingRunDetailsApiResponse> {
+  const response = await fetch(
+    `${apiBaseUrl}/trainings/${encodeURIComponent(runName)}`,
+    {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        ...buildAuthHeaders(accessToken),
+      },
+      signal,
+    },
+  );
+
+  const rawBody = await response.text();
+  const parsed = tryParseJson(rawBody);
+
+  if (response.status === 200) {
+    if (!isTrainingRunDetailsApiResponse(parsed)) {
+      throw new Error(
+        "Backend zwrocil niepoprawny ksztalt TrainingRunDetailsApiResponse.",
       );
     }
 

--- a/src/Frontend/src/api/trainings.ts
+++ b/src/Frontend/src/api/trainings.ts
@@ -1,9 +1,11 @@
 import type {
+  ActiveModelApiResponse,
   CancelTrainingRunApiResponse,
   CreateTrainingRunApiEntry,
   ErrorApiResponse,
   RegistryModelListItemApiResponse,
   RegistryModelsListApiResponse,
+  SetActiveModelApiEntry,
   TrainingClassMetricApiResponse,
   TrainingConfusionMatrixApiResponse,
   TrainingDatasetSampleCountsApiResponse,
@@ -412,6 +414,24 @@ function isRegistryModelsListApiResponse(
   );
 }
 
+function isActiveModelApiResponse(value: unknown): value is ActiveModelApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.modelName === "string" &&
+    typeof record.displayName === "string" &&
+    typeof record.sourceType === "string" &&
+    (typeof record.sourceRunName === "string" || record.sourceRunName === null) &&
+    (typeof record.parentModelName === "string" || record.parentModelName === null) &&
+    typeof record.inputProfile === "string" &&
+    typeof record.canUseForInference === "boolean" &&
+    (typeof record.activatedAtUtc === "string" || record.activatedAtUtc === null)
+  );
+}
+
 function isCancelTrainingRunApiResponse(
   value: unknown,
 ): value is CancelTrainingRunApiResponse {
@@ -615,6 +635,73 @@ export async function getRegistryModels(
     if (!isRegistryModelsListApiResponse(parsed)) {
       throw new Error(
         "Backend zwrocil niepoprawny ksztalt RegistryModelsListApiResponse.",
+      );
+    }
+
+    return parsed;
+  }
+
+  throw buildErrorFromResponse(rawBody, response.status);
+}
+
+export async function getActiveModel(
+  apiBaseUrl: string,
+  accessToken?: string | null,
+  signal?: AbortSignal,
+): Promise<ActiveModelApiResponse | null> {
+  const response = await fetch(`${apiBaseUrl}/models/active`, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      ...buildAuthHeaders(accessToken),
+    },
+    signal,
+  });
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  const rawBody = await response.text();
+  const parsed = tryParseJson(rawBody);
+
+  if (response.status === 200) {
+    if (!isActiveModelApiResponse(parsed)) {
+      throw new Error(
+        "Backend zwrocil niepoprawny ksztalt ActiveModelApiResponse.",
+      );
+    }
+
+    return parsed;
+  }
+
+  throw buildErrorFromResponse(rawBody, response.status);
+}
+
+export async function putActiveModel(
+  apiBaseUrl: string,
+  entry: SetActiveModelApiEntry,
+  accessToken?: string | null,
+  signal?: AbortSignal,
+): Promise<ActiveModelApiResponse> {
+  const response = await fetch(`${apiBaseUrl}/models/active`, {
+    method: "PUT",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...buildAuthHeaders(accessToken),
+    },
+    body: JSON.stringify(entry),
+    signal,
+  });
+
+  const rawBody = await response.text();
+  const parsed = tryParseJson(rawBody);
+
+  if (response.status === 200) {
+    if (!isActiveModelApiResponse(parsed)) {
+      throw new Error(
+        "Backend zwrocil niepoprawny ksztalt ActiveModelApiResponse.",
       );
     }
 

--- a/src/Frontend/src/components/Uc08CatalogSection.tsx
+++ b/src/Frontend/src/components/Uc08CatalogSection.tsx
@@ -1,12 +1,15 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import {
+  getActiveModel,
   getTrainingRunDetails,
   getRegistryModels,
   getTrainingRuns,
+  putActiveModel,
   TrainingsApiError,
 } from "../api/trainings";
 import type {
+  ActiveModelApiResponse,
   RegistryModelListItemApiResponse,
   TrainingRunDetailsApiResponse,
   TrainingRunListItemApiResponse,
@@ -72,6 +75,52 @@ const defaultDetailsState: LoadableState<TrainingRunDetailsApiResponse> = {
   httpStatus: null,
 };
 
+const defaultActiveModelState: LoadableState<ActiveModelApiResponse | null> = {
+  kind: "idle",
+  data: null,
+  error: null,
+  errorType: null,
+  httpStatus: null,
+};
+
+type ActiveModelUpdateState =
+  | {
+      kind: "idle";
+      modelName: null;
+      message: null;
+      errorType: null;
+      httpStatus: null;
+    }
+  | {
+      kind: "loading";
+      modelName: string;
+      message: null;
+      errorType: null;
+      httpStatus: null;
+    }
+  | {
+      kind: "success";
+      modelName: string;
+      message: string;
+      errorType: null;
+      httpStatus: number;
+    }
+  | {
+      kind: "error";
+      modelName: string;
+      message: string;
+      errorType: string | null;
+      httpStatus: number | null;
+    };
+
+const defaultActiveModelUpdateState: ActiveModelUpdateState = {
+  kind: "idle",
+  modelName: null,
+  message: null,
+  errorType: null,
+  httpStatus: null,
+};
+
 function formatTimestamp(timestampUtc: string | null): string {
   if (!timestampUtc) {
     return "-";
@@ -106,6 +155,10 @@ export function Uc08CatalogSection({
   const [modelsState, setModelsState] = useState(defaultModelsState);
   const [selectedRunName, setSelectedRunName] = useState<string | null>(null);
   const [detailsState, setDetailsState] = useState(defaultDetailsState);
+  const [activeModelState, setActiveModelState] = useState(defaultActiveModelState);
+  const [activeModelUpdateState, setActiveModelUpdateState] = useState(
+    defaultActiveModelUpdateState,
+  );
 
   const loadCatalog = useCallback(async () => {
     if (!accessToken) {
@@ -176,9 +229,118 @@ export function Uc08CatalogSection({
     }
   }, [accessToken, apiBaseUrl, onUnauthorized]);
 
+  const loadActiveModelState = useCallback(async () => {
+    if (!accessToken) {
+      setActiveModelState(defaultActiveModelState);
+      return;
+    }
+
+    setActiveModelState((previous) => ({
+      kind: "loading",
+      data: previous.data,
+      error: null,
+      errorType: null,
+      httpStatus: null,
+    }));
+
+    try {
+      const activeModel = await getActiveModel(apiBaseUrl, accessToken);
+      setActiveModelState({
+        kind: "success",
+        data: activeModel,
+        error: null,
+        errorType: null,
+        httpStatus: activeModel ? 200 : 204,
+      });
+    } catch (error) {
+      if (
+        error instanceof TrainingsApiError &&
+        (error.status === 401 || error.status === 403)
+      ) {
+        onUnauthorized?.();
+      }
+
+      setActiveModelState({
+        kind: "error",
+        data: null,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Nie udalo sie odczytac aktywnego modelu.",
+        errorType: error instanceof TrainingsApiError ? error.errorType ?? null : null,
+        httpStatus: error instanceof TrainingsApiError ? error.status : null,
+      });
+    }
+  }, [accessToken, apiBaseUrl, onUnauthorized]);
+
   useEffect(() => {
     void loadCatalog();
-  }, [loadCatalog]);
+    void loadActiveModelState();
+  }, [loadCatalog, loadActiveModelState]);
+
+  const setModelAsActive = useCallback(
+    async (modelName: string) => {
+      if (!accessToken) {
+        setActiveModelUpdateState({
+          kind: "error",
+          modelName,
+          message: "Brak aktywnej sesji administratora.",
+          errorType: "unauthorized",
+          httpStatus: 401,
+        });
+        return;
+      }
+
+      setActiveModelUpdateState({
+        kind: "loading",
+        modelName,
+        message: null,
+        errorType: null,
+        httpStatus: null,
+      });
+
+      try {
+        const updatedActiveModel = await putActiveModel(
+          apiBaseUrl,
+          { modelName },
+          accessToken,
+        );
+        setActiveModelState({
+          kind: "success",
+          data: updatedActiveModel,
+          error: null,
+          errorType: null,
+          httpStatus: 200,
+        });
+        setActiveModelUpdateState({
+          kind: "success",
+          modelName,
+          message: `Aktywny model ustawiony na: ${updatedActiveModel.modelName}.`,
+          errorType: null,
+          httpStatus: 200,
+        });
+      } catch (error) {
+        if (
+          error instanceof TrainingsApiError &&
+          (error.status === 401 || error.status === 403)
+        ) {
+          onUnauthorized?.();
+        }
+
+        setActiveModelUpdateState({
+          kind: "error",
+          modelName,
+          message:
+            error instanceof Error
+              ? error.message
+              : "Nie udalo sie ustawic aktywnego modelu.",
+          errorType: error instanceof TrainingsApiError ? error.errorType ?? null : null,
+          httpStatus: error instanceof TrainingsApiError ? error.status : null,
+        });
+      }
+    },
+    [accessToken, apiBaseUrl, onUnauthorized],
+  );
 
   const loadRunDetails = useCallback(
     async (runName: string) => {
@@ -244,6 +406,10 @@ export function Uc08CatalogSection({
   );
   const modelNames = useMemo(() => new Set(models.map((model) => model.name)), [models]);
   const runNames = useMemo(() => new Set(runs.map((run) => run.runName)), [runs]);
+  const activeModelName =
+    activeModelState.kind === "success" && activeModelState.data
+      ? activeModelState.data.modelName
+      : null;
 
   return (
     <section className="hero-card uc12-section">
@@ -258,12 +424,22 @@ export function Uc08CatalogSection({
         <button
           className="secondary-button"
           type="button"
-          disabled={runsState.kind === "loading" || modelsState.kind === "loading"}
-          onClick={() => void loadCatalog()}
+          disabled={
+            runsState.kind === "loading" ||
+            modelsState.kind === "loading" ||
+            activeModelState.kind === "loading"
+          }
+          onClick={() => {
+            setActiveModelUpdateState(defaultActiveModelUpdateState);
+            void loadCatalog();
+            void loadActiveModelState();
+          }}
         >
-          {runsState.kind === "loading" || modelsState.kind === "loading"
+          {runsState.kind === "loading" ||
+          modelsState.kind === "loading" ||
+          activeModelState.kind === "loading"
             ? "Odswiezanie..."
-            : "Odswiez katalog"}
+            : "Odswiez katalog i aktywny model"}
         </button>
       </div>
 
@@ -341,6 +517,58 @@ export function Uc08CatalogSection({
       </article>
 
       <article className="uc12-panel">
+        <h3>UC-10 — Aktywny model inferencyjny</h3>
+
+        {activeModelState.kind === "loading" ? (
+          <p className="status-banner status-loading">Pobieranie aktywnego modelu...</p>
+        ) : null}
+
+        {activeModelState.kind === "error" ? (
+          <>
+            <p className="status-banner status-error">{activeModelState.error}</p>
+            <p className="muted-copy">
+              HTTP: {activeModelState.httpStatus ?? "-"} | typ:{" "}
+              {activeModelState.errorType ?? "-"}
+            </p>
+          </>
+        ) : null}
+
+        {activeModelState.kind === "success" && activeModelState.data ? (
+          <p className="muted-copy">
+            Aktualnie aktywny model: <code>{activeModelState.data.modelName}</code> | source:{" "}
+            {activeModelState.data.sourceType} | activatedAt:{" "}
+            {formatTimestamp(activeModelState.data.activatedAtUtc)}
+          </p>
+        ) : null}
+
+        {activeModelState.kind === "success" && !activeModelState.data ? (
+          <p className="muted-copy">
+            Brak aktywnego modelu. Wybierz model z listy rejestru poniżej.
+          </p>
+        ) : null}
+
+        {activeModelUpdateState.kind === "loading" ? (
+          <p className="status-banner status-loading">
+            Ustawianie aktywnego modelu: <code>{activeModelUpdateState.modelName}</code>...
+          </p>
+        ) : null}
+
+        {activeModelUpdateState.kind === "success" ? (
+          <p className="status-banner status-success">{activeModelUpdateState.message}</p>
+        ) : null}
+
+        {activeModelUpdateState.kind === "error" ? (
+          <>
+            <p className="status-banner status-error">{activeModelUpdateState.message}</p>
+            <p className="muted-copy">
+              HTTP: {activeModelUpdateState.httpStatus ?? "-"} | typ:{" "}
+              {activeModelUpdateState.errorType ?? "-"}
+            </p>
+          </>
+        ) : null}
+      </article>
+
+      <article className="uc12-panel">
         <h3>Rejestr modeli</h3>
         {models.length === 0 ? (
           <p className="muted-copy">Brak modeli w rejestrze.</p>
@@ -365,6 +593,10 @@ export function Uc08CatalogSection({
                     {String(model.canUseForInference)}
                   </span>
                   <span>
+                    activeModelState:{" "}
+                    <code>{activeModelName === model.name ? "active" : "inactive"}</code>
+                  </span>
+                  <span>
                     run relation:{" "}
                     <code>
                       {hasSourceRun === null
@@ -373,6 +605,24 @@ export function Uc08CatalogSection({
                           ? "run_found"
                           : "run_not_found"}
                     </code>
+                  </span>
+                  <span className="examples-row-actions">
+                    <button
+                      type="button"
+                      className="secondary-button"
+                      disabled={
+                        !model.canUseForInference ||
+                        activeModelUpdateState.kind === "loading" ||
+                        activeModelName === model.name
+                      }
+                      onClick={() => void setModelAsActive(model.name)}
+                    >
+                      {activeModelName === model.name
+                        ? "Model aktywny"
+                        : model.canUseForInference
+                          ? "Ustaw jako aktywny"
+                          : "Niedozwolony do aktywacji"}
+                    </button>
                   </span>
                 </li>
               );

--- a/src/Frontend/src/components/Uc08CatalogSection.tsx
+++ b/src/Frontend/src/components/Uc08CatalogSection.tsx
@@ -1,0 +1,529 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  getTrainingRunDetails,
+  getRegistryModels,
+  getTrainingRuns,
+  TrainingsApiError,
+} from "../api/trainings";
+import type {
+  RegistryModelListItemApiResponse,
+  TrainingRunDetailsApiResponse,
+  TrainingRunListItemApiResponse,
+} from "../types/api";
+
+type LoadableState<T> =
+  | {
+      kind: "idle";
+      data: T | null;
+      error: null;
+      errorType: null;
+      httpStatus: null;
+    }
+  | {
+      kind: "loading";
+      data: T | null;
+      error: null;
+      errorType: null;
+      httpStatus: null;
+    }
+  | {
+      kind: "success";
+      data: T;
+      error: null;
+      errorType: null;
+      httpStatus: number;
+    }
+  | {
+      kind: "error";
+      data: T | null;
+      error: string;
+      errorType: string | null;
+      httpStatus: number | null;
+    };
+
+type Uc08CatalogSectionProps = {
+  apiBaseUrl: string;
+  accessToken?: string | null;
+  onUnauthorized?: () => void;
+};
+
+const defaultRunsState: LoadableState<TrainingRunListItemApiResponse[]> = {
+  kind: "idle",
+  data: null,
+  error: null,
+  errorType: null,
+  httpStatus: null,
+};
+
+const defaultModelsState: LoadableState<RegistryModelListItemApiResponse[]> = {
+  kind: "idle",
+  data: null,
+  error: null,
+  errorType: null,
+  httpStatus: null,
+};
+
+const defaultDetailsState: LoadableState<TrainingRunDetailsApiResponse> = {
+  kind: "idle",
+  data: null,
+  error: null,
+  errorType: null,
+  httpStatus: null,
+};
+
+function formatTimestamp(timestampUtc: string | null): string {
+  if (!timestampUtc) {
+    return "-";
+  }
+
+  const parsedDate = new Date(timestampUtc);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return timestampUtc;
+  }
+
+  return new Intl.DateTimeFormat("pl-PL", {
+    dateStyle: "medium",
+    timeStyle: "medium",
+    timeZone: "UTC",
+  }).format(parsedDate);
+}
+
+function formatMetric(value: number | null | undefined): string {
+  if (typeof value !== "number") {
+    return "-";
+  }
+
+  return value.toFixed(4);
+}
+
+export function Uc08CatalogSection({
+  apiBaseUrl,
+  accessToken,
+  onUnauthorized,
+}: Uc08CatalogSectionProps) {
+  const [runsState, setRunsState] = useState(defaultRunsState);
+  const [modelsState, setModelsState] = useState(defaultModelsState);
+  const [selectedRunName, setSelectedRunName] = useState<string | null>(null);
+  const [detailsState, setDetailsState] = useState(defaultDetailsState);
+
+  const loadCatalog = useCallback(async () => {
+    if (!accessToken) {
+      setRunsState(defaultRunsState);
+      setModelsState(defaultModelsState);
+      return;
+    }
+
+    setRunsState((previous) => ({
+      kind: "loading",
+      data: previous.data,
+      error: null,
+      errorType: null,
+      httpStatus: null,
+    }));
+    setModelsState((previous) => ({
+      kind: "loading",
+      data: previous.data,
+      error: null,
+      errorType: null,
+      httpStatus: null,
+    }));
+
+    try {
+      const [runsResponse, modelsResponse] = await Promise.all([
+        getTrainingRuns(apiBaseUrl, accessToken),
+        getRegistryModels(apiBaseUrl, accessToken),
+      ]);
+
+      setRunsState({
+        kind: "success",
+        data: runsResponse.items,
+        error: null,
+        errorType: null,
+        httpStatus: 200,
+      });
+      setModelsState({
+        kind: "success",
+        data: modelsResponse.items,
+        error: null,
+        errorType: null,
+        httpStatus: 200,
+      });
+    } catch (error) {
+      if (error instanceof TrainingsApiError && error.status === 401) {
+        onUnauthorized?.();
+      }
+
+      const message =
+        error instanceof Error ? error.message : "Nie udalo sie odczytac katalogu.";
+      const errorType = error instanceof TrainingsApiError ? error.errorType ?? null : null;
+      const httpStatus = error instanceof TrainingsApiError ? error.status : null;
+
+      setRunsState({
+        kind: "error",
+        data: null,
+        error: message,
+        errorType,
+        httpStatus,
+      });
+      setModelsState({
+        kind: "error",
+        data: null,
+        error: message,
+        errorType,
+        httpStatus,
+      });
+    }
+  }, [accessToken, apiBaseUrl, onUnauthorized]);
+
+  useEffect(() => {
+    void loadCatalog();
+  }, [loadCatalog]);
+
+  const loadRunDetails = useCallback(
+    async (runName: string) => {
+      if (!accessToken) {
+        setDetailsState(defaultDetailsState);
+        return;
+      }
+
+      setSelectedRunName(runName);
+      setDetailsState((previous) => ({
+        kind: "loading",
+        data: previous.data,
+        error: null,
+        errorType: null,
+        httpStatus: null,
+      }));
+
+      try {
+        const details = await getTrainingRunDetails(apiBaseUrl, runName, accessToken);
+        setDetailsState({
+          kind: "success",
+          data: details,
+          error: null,
+          errorType: null,
+          httpStatus: 200,
+        });
+      } catch (error) {
+        if (error instanceof TrainingsApiError && error.status === 401) {
+          onUnauthorized?.();
+        }
+
+        setDetailsState({
+          kind: "error",
+          data: null,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Nie udalo sie odczytac szczegolow runu.",
+          errorType: error instanceof TrainingsApiError ? error.errorType ?? null : null,
+          httpStatus: error instanceof TrainingsApiError ? error.status : null,
+        });
+      }
+    },
+    [accessToken, apiBaseUrl, onUnauthorized],
+  );
+
+  const runs = runsState.data ?? [];
+  const models = modelsState.data ?? [];
+  const activeRunsCount = useMemo(
+    () =>
+      runs.filter((run) =>
+        ["queued", "starting", "running", "cancelling"].includes(run.status),
+      ).length,
+    [runs],
+  );
+  const bootstrapModelsCount = useMemo(
+    () => models.filter((model) => model.sourceType === "bootstrap").length,
+    [models],
+  );
+  const trainingModelsCount = useMemo(
+    () => models.filter((model) => model.sourceType !== "bootstrap").length,
+    [models],
+  );
+  const modelNames = useMemo(() => new Set(models.map((model) => model.name)), [models]);
+  const runNames = useMemo(() => new Set(runs.map((run) => run.runName)), [runs]);
+
+  return (
+    <section className="hero-card uc12-section">
+      <p className="eyebrow">UC-08 — Katalog treningow i modeli</p>
+      <h2>Lista runow i rejestr modeli</h2>
+      <p className="hero-copy">
+        Widok laczy dane katalogowe z <code>GET /api/trainings</code> i{" "}
+        <code>GET /api/models/registry</code>.
+      </p>
+
+      <div className="examples-row-actions">
+        <button
+          className="secondary-button"
+          type="button"
+          disabled={runsState.kind === "loading" || modelsState.kind === "loading"}
+          onClick={() => void loadCatalog()}
+        >
+          {runsState.kind === "loading" || modelsState.kind === "loading"
+            ? "Odswiezanie..."
+            : "Odswiez katalog"}
+        </button>
+      </div>
+
+      {runsState.kind === "error" ? (
+        <p className="status-banner status-error">{runsState.error}</p>
+      ) : null}
+
+      <article className="uc12-panel">
+        <h3>Podsumowanie katalogu</h3>
+        <dl className="result-grid">
+          <div>
+            <dt>Treningi lacznie</dt>
+            <dd>{runs.length}</dd>
+          </div>
+          <div>
+            <dt>Treningi aktywne</dt>
+            <dd>{activeRunsCount}</dd>
+          </div>
+          <div>
+            <dt>Modele bootstrap</dt>
+            <dd>{bootstrapModelsCount}</dd>
+          </div>
+          <div>
+            <dt>Modele z treningu</dt>
+            <dd>{trainingModelsCount}</dd>
+          </div>
+        </dl>
+      </article>
+
+      <article className="uc12-panel">
+        <h3>Runy treningowe</h3>
+        {runs.length === 0 ? (
+          <p className="muted-copy">Brak runow treningowych do wyswietlenia.</p>
+        ) : (
+          <ul className="uc12-processed-list">
+            {runs.map((run) => {
+              const hasProducedModel = modelNames.has(run.producedModelName);
+
+              return (
+                <li key={run.runName}>
+                  <strong>
+                    {run.runName} ({run.status})
+                  </strong>
+                  <span>
+                    dataset: {run.processedDatasetName} | base: {run.baseModelName} | produced:{" "}
+                    {run.producedModelName}
+                  </span>
+                  <span>
+                    created: {formatTimestamp(run.createdAtUtc)} | updated:{" "}
+                    {formatTimestamp(run.updatedAtUtc)}
+                  </span>
+                  <span>
+                    accuracy: {formatMetric(run.metricsSummary?.accuracy)} | macroF1:{" "}
+                    {formatMetric(run.metricsSummary?.macroF1)} | progress:{" "}
+                    {run.progress?.percent ?? "-"}%
+                  </span>
+                  <span>
+                    model registry link:{" "}
+                    <code>{hasProducedModel ? "model_found" : "model_not_found"}</code>
+                  </span>
+                  <span className="examples-row-actions">
+                    <button
+                      type="button"
+                      className="secondary-button"
+                      onClick={() => void loadRunDetails(run.runName)}
+                    >
+                      Szczegoly runu (UC-09)
+                    </button>
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </article>
+
+      <article className="uc12-panel">
+        <h3>Rejestr modeli</h3>
+        {models.length === 0 ? (
+          <p className="muted-copy">Brak modeli w rejestrze.</p>
+        ) : (
+          <ul className="uc12-processed-list">
+            {models.map((model) => {
+              const hasSourceRun = model.sourceRunName
+                ? runNames.has(model.sourceRunName)
+                : null;
+
+              return (
+                <li key={model.name}>
+                  <strong>
+                    {model.displayName} ({model.name})
+                  </strong>
+                  <span>
+                    sourceType: {model.sourceType} | sourceRunName:{" "}
+                    {model.sourceRunName ?? "-"} | parent: {model.parentModelName ?? "-"}
+                  </span>
+                  <span>
+                    canStartTraining: {String(model.canStartTraining)} | canUseForInference:{" "}
+                    {String(model.canUseForInference)}
+                  </span>
+                  <span>
+                    run relation:{" "}
+                    <code>
+                      {hasSourceRun === null
+                        ? "bootstrap_without_run"
+                        : hasSourceRun
+                          ? "run_found"
+                          : "run_not_found"}
+                    </code>
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </article>
+
+      <article className="uc12-panel">
+        <h3>UC-09 — Szczegoly wybranego runu</h3>
+        {!selectedRunName ? (
+          <p className="muted-copy">
+            Wybierz run z listy "Runy treningowe", aby odczytac szczegoly.
+          </p>
+        ) : null}
+        {selectedRunName ? (
+          <p className="muted-copy">
+            Wybrany run: <code>{selectedRunName}</code>
+          </p>
+        ) : null}
+
+        {detailsState.kind === "loading" ? (
+          <p className="status-banner status-loading">
+            Pobieranie szczegolow runu treningowego...
+          </p>
+        ) : null}
+
+        {detailsState.kind === "error" ? (
+          <>
+            <p className="status-banner status-error">{detailsState.error}</p>
+            <p className="muted-copy">
+              HTTP: {detailsState.httpStatus ?? "-"} | typ: {detailsState.errorType ?? "-"}
+            </p>
+          </>
+        ) : null}
+
+        {detailsState.kind === "success" ? (
+          <>
+            <dl className="result-grid">
+              <div>
+                <dt>Status</dt>
+                <dd>{detailsState.data.status}</dd>
+              </div>
+              <div>
+                <dt>Stage</dt>
+                <dd>{detailsState.data.stage ?? "-"}</dd>
+              </div>
+              <div>
+                <dt>Created</dt>
+                <dd>{formatTimestamp(detailsState.data.createdAtUtc)}</dd>
+              </div>
+              <div>
+                <dt>Finished</dt>
+                <dd>{formatTimestamp(detailsState.data.finishedAtUtc)}</dd>
+              </div>
+              <div>
+                <dt>Base model</dt>
+                <dd>{detailsState.data.baseModel.name}</dd>
+              </div>
+              <div>
+                <dt>Produced model</dt>
+                <dd>{detailsState.data.producedModel?.name ?? "-"}</dd>
+              </div>
+              <div>
+                <dt>Dataset</dt>
+                <dd>{detailsState.data.dataset.processedDatasetName}</dd>
+              </div>
+              <div>
+                <dt>Benchmark</dt>
+                <dd>{detailsState.data.configuration.benchmarkName}</dd>
+              </div>
+            </dl>
+
+            <p className="muted-copy">
+              reportStatus: <code>{detailsState.data.report.status}</code> | accuracy:{" "}
+              {formatMetric(detailsState.data.report.summary?.accuracy)} | precisionMacro:{" "}
+              {formatMetric(detailsState.data.report.summary?.precisionMacro)} | recallMacro:{" "}
+              {formatMetric(detailsState.data.report.summary?.recallMacro)} | f1Macro:{" "}
+              {formatMetric(detailsState.data.report.summary?.f1Macro)}
+            </p>
+
+            {detailsState.data.report.history.length > 0 ? (
+              <div className="examples-table-wrap">
+                <table className="examples-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">Epoch</th>
+                      <th scope="col">Train loss</th>
+                      <th scope="col">Validation loss</th>
+                      <th scope="col">Train accuracy</th>
+                      <th scope="col">Validation accuracy</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {detailsState.data.report.history.map((point) => (
+                      <tr key={`history-${point.epoch}`}>
+                        <td>{point.epoch}</td>
+                        <td>{formatMetric(point.trainLoss)}</td>
+                        <td>{formatMetric(point.validationLoss)}</td>
+                        <td>{formatMetric(point.trainAccuracy)}</td>
+                        <td>{formatMetric(point.validationAccuracy)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="muted-copy">Brak historii metryk epoch dla tego runu.</p>
+            )}
+
+            {detailsState.data.report.confusionMatrix ? (
+              <div className="examples-table-wrap">
+                <table className="examples-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">actual/predicted</th>
+                      {detailsState.data.report.confusionMatrix.classNames.map((className) => (
+                        <th key={`cm-header-${className}`} scope="col">
+                          {className}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {detailsState.data.report.confusionMatrix.matrix.map((row, rowIndex) => (
+                      <tr key={`cm-row-${rowIndex}`}>
+                        <td>{detailsState.data.report.confusionMatrix?.classNames[rowIndex] ?? rowIndex}</td>
+                        {row.map((value, cellIndex) => (
+                          <td key={`cm-cell-${rowIndex}-${cellIndex}`}>{value}</td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="muted-copy">
+                Brak macierzy pomylek (report nie jest gotowy albo jest uszkodzony).
+              </p>
+            )}
+
+            {detailsState.data.warnings.length > 0 ? (
+              <ul className="uc12-warnings-list">
+                {detailsState.data.warnings.map((warning, index) => (
+                  <li key={`run-warning-${index}`}>{warning}</li>
+                ))}
+              </ul>
+            ) : null}
+          </>
+        ) : null}
+      </article>
+    </section>
+  );
+}

--- a/src/Frontend/src/types/api.ts
+++ b/src/Frontend/src/types/api.ts
@@ -95,6 +95,11 @@ export type ProcessedDatasetsListApiResponse = {
   totalCount: number;
 };
 
+export type TrainingMetricsSummaryApiResponse = {
+  accuracy: number | null;
+  macroF1: number | null;
+};
+
 export type CreateTrainingRunApiEntry = {
   baseModelName: string;
   processedDatasetName: string;
@@ -148,6 +153,121 @@ export type TrainingRunProgressApiResponse = {
   epochCurrent: number | null;
   epochTotal: number | null;
   etaSeconds: number | null;
+  trainLoss?: number | null;
+  validationLoss?: number | null;
+  trainAccuracy?: number | null;
+  validationAccuracy?: number | null;
+};
+
+export type TrainingRunListItemApiResponse = {
+  runName: string;
+  status: string;
+  createdAtUtc: string;
+  updatedAtUtc: string | null;
+  startedAtUtc: string | null;
+  finishedAtUtc: string | null;
+  baseModelName: string;
+  producedModelName: string;
+  processedDatasetName: string;
+  trainingMode: string;
+  trainingProfileName: string;
+  augmentationProfileName: string;
+  benchmarkName: string;
+  reportStatus: string | null;
+  progress: TrainingRunProgressApiResponse | null;
+  metricsSummary: TrainingMetricsSummaryApiResponse | null;
+  warnings: string[];
+};
+
+export type TrainingRunsListApiResponse = {
+  items: TrainingRunListItemApiResponse[];
+  totalCount: number;
+};
+
+export type TrainingRunModelReferenceApiResponse = {
+  name: string;
+  displayName: string;
+  sourceType: string;
+  sourceRunName: string | null;
+  parentModelName: string | null;
+  inputProfile: string;
+  canUseForInference: boolean;
+  canStartTraining: boolean;
+};
+
+export type TrainingDatasetSampleCountsApiResponse = {
+  train: number;
+  val: number;
+  test: number;
+};
+
+export type TrainingRunDatasetDetailsApiResponse = {
+  processedDatasetName: string;
+  preprocessingProfile: string | null;
+  sampleCounts: TrainingDatasetSampleCountsApiResponse | null;
+};
+
+export type TrainingRunConfigurationApiResponse = {
+  trainingMode: string;
+  trainingProfileName: string;
+  augmentationProfileName: string;
+  benchmarkName: string;
+  seed: number;
+  sourceRevision: string | null;
+};
+
+export type TrainingReportSummaryApiResponse = {
+  accuracy: number;
+  precisionMacro: number;
+  recallMacro: number;
+  f1Macro: number;
+  trainingDurationSeconds: number | null;
+  averageInferenceTimeMs: number | null;
+};
+
+export type TrainingClassMetricApiResponse = {
+  label: string;
+  precision: number;
+  recall: number;
+  f1: number;
+  support: number;
+};
+
+export type TrainingMetricHistoryPointApiResponse = {
+  epoch: number;
+  trainLoss: number | null;
+  validationLoss: number | null;
+  trainAccuracy: number | null;
+  validationAccuracy: number | null;
+};
+
+export type TrainingConfusionMatrixApiResponse = {
+  classNames: string[];
+  matrix: number[][];
+};
+
+export type TrainingRunReportApiResponse = {
+  status: string;
+  summary: TrainingReportSummaryApiResponse | null;
+  perClassMetrics: TrainingClassMetricApiResponse[];
+  history: TrainingMetricHistoryPointApiResponse[];
+  confusionMatrix: TrainingConfusionMatrixApiResponse | null;
+};
+
+export type TrainingRunDetailsApiResponse = {
+  runName: string;
+  status: string;
+  stage: string | null;
+  createdAtUtc: string;
+  startedAtUtc: string | null;
+  finishedAtUtc: string | null;
+  baseModel: TrainingRunModelReferenceApiResponse;
+  producedModel: TrainingRunModelReferenceApiResponse | null;
+  dataset: TrainingRunDatasetDetailsApiResponse;
+  configuration: TrainingRunConfigurationApiResponse;
+  progress: TrainingRunProgressApiResponse | null;
+  report: TrainingRunReportApiResponse;
+  warnings: string[];
 };
 
 export type TrainingRunResultApiResponse = {

--- a/src/Frontend/src/types/api.ts
+++ b/src/Frontend/src/types/api.ts
@@ -126,6 +126,21 @@ export type RegistryModelsListApiResponse = {
   totalCount: number;
 };
 
+export type ActiveModelApiResponse = {
+  modelName: string;
+  displayName: string;
+  sourceType: string;
+  sourceRunName: string | null;
+  parentModelName: string | null;
+  inputProfile: string;
+  canUseForInference: boolean;
+  activatedAtUtc: string | null;
+};
+
+export type SetActiveModelApiEntry = {
+  modelName: string;
+};
+
 export type TrainingRunApiResponse = {
   runName: string;
   status: string;


### PR DESCRIPTION
Introduce the UC-08 catalog step with training/model listing and integrate UC-09 run details loading from GET /api/trainings/{runName}, including report metrics, history, and confusion matrix rendering.