### PR TITLE
Implement multiple new endpoints for dataset preparations in the backend

### DIFF
--- a/.ai/implementation-plan/be/uc-18-be-delete-api-datasets-preparations-preparation-name-board-source-name-files-board-folder-name.md
+++ b/.ai/implementation-plan/be/uc-18-be-delete-api-datasets-preparations-preparation-name-board-source-name-files-board-folder-name.md
@@ -1,0 +1,694 @@
+# UC-18-BE - Plan implementacyjny dla `DELETE /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}`
+
+## 1) Przeznaczenie endpointa
+- Endpoint usuwa pojedynczy logiczny element `board` z istniejącego preparation datasetu.
+- Zasób logiczny to cały folder:
+  - `{PreparationsDirectoryPath}/{preparationName}/board/{sourceName}/{boardFolderName}/`
+- Po usunięciu folderu backend aktualizuje manifest:
+  - `{PreparationsDirectoryPath}/{preparationName}/board/{sourceName}/file.json`
+- Endpoint działa wyłącznie w warstwie `BE`.
+- Endpoint nie wywołuje `ML`, nie uruchamia preprocessingu i nie przebudowuje całego preparation.
+- Celem use-case'a jest usunięcie planszy z widoku i utrzymanie spójności manifestu bez zostawiania martwych referencji w `file.json`.
+
+## 2) Zakres, założenia i zależności
+- Plan dotyczy wyłącznie backendu w `src/Backend/Sudoku`.
+- Nie sugerujemy się stanem `FE` i `ML`, poza obowiązującymi kontraktami i tym, co już istnieje w backendzie.
+- Historyjki zależne:
+  - `UC-13` dostarcza autoryzację admina.
+  - `UC-17 POST /api/datasets/preparations` tworzy preparation i zapisuje artefakty.
+  - `UC-17 GET /api/datasets/preparations` oraz `GET /api/datasets/preparations/{preparationName}` dostarczają wybór preparation i jego status.
+  - `UC-18 GET /api/datasets/preparations/{preparationName}/board/folders` dostarcza `sourceName`.
+  - `UC-18 GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files` dostarcza `boardFolderName`.
+  - `UC-18 GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}/image` reuse'uje te same reguły walidacji i wyszukiwania zasobu.
+  - `UC-19` pośrednio zależy od spójności preparation po czyszczeniu danych.
+- Kluczowa zasada architektoniczna:
+  - `Application` ma orkiestrację usunięcia i decyzję o kolejności kroków.
+  - `Infrastructure` ma tylko wykonać operacje I/O na storage.
+
+## 3) Co już istnieje i co należy reuse'ować
+
+### 3.1 Istniejące elementy backendu
+- `src/Backend/Sudoku/Sudoku/Controllers/DatasetsController.cs`
+  - ma już endpointy:
+    - `GET /api/datasets/preparations`
+    - `GET /api/datasets/preparations/{preparationName}`
+    - `GET /api/datasets/preparations/{preparationName}/board/folders`
+    - `GET /api/datasets/preparations/{preparationName}/digit/folders`
+    - `GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files`
+    - `GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}/image`
+- `src/Backend/Sudoku/Application/Abstractions/IDatasetPreparationsGateway.cs`
+  - odczyt metadata preparation.
+- `src/Backend/Sudoku/Application/Abstractions/IDatasetPreparationArtifactsGateway.cs`
+  - odczyt:
+    - `board/folders.json`
+    - `board/{sourceName}/file.json`
+    - artefaktów w folderze planszy
+- `src/Backend/Sudoku/Application/Abstractions/IFileStorageGateway.cs`
+  - ma już potrzebne operacje techniczne:
+    - `ReplaceAsync(...)`
+    - `DeleteDirectoryAsync(...)`
+- `src/Backend/Sudoku/Application/Datasets/DatasetPreparationNameValidationRules.cs`
+  - wspólna walidacja `preparationName`.
+- `src/Backend/Sudoku/Application/Datasets/DatasetPreparationSourceNameValidationRules.cs`
+  - wspólna walidacja `sourceName`.
+- `src/Backend/Sudoku/Application/Datasets/DatasetPreparationBoardFolderNameValidationRules.cs`
+  - wspólna walidacja `boardFolderName`.
+- `src/Backend/Sudoku/Application/Datasets/DatasetPreparationNotFoundException.cs`
+  - semantyczne `404` dla brakującego preparation.
+- `src/Backend/Sudoku/Application/Datasets/DatasetPreparationSourceNotFoundException.cs`
+  - semantyczne `404` dla brakującego `sourceName`.
+- `src/Backend/Sudoku/Application/Datasets/DatasetPreparationBoardFileNotFoundException.cs`
+  - semantyczne `404` dla brakującego `boardFolderName` w manifeście.
+- `src/Backend/Sudoku/Application/Datasets/DatasetPreparationArtifactsNotReadyException.cs`
+  - semantyczne `409` dla preparation niegotowego do pracy na artefaktach.
+- `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardFilesQueryHandler.cs`
+  - gotowy wzorzec:
+    - sprawdzenie istnienia preparation,
+    - sprawdzenie statusu `completed`,
+    - weryfikacja `sourceName` względem `board/folders.json`,
+    - odczyt `file.json`
+- `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardImageQueryHandler.cs`
+  - gotowy wzorzec:
+    - weryfikacja `boardFolderName` względem `file.json`,
+    - rozróżnienie między brakiem wpisu w manifeście a błędem technicznym artefaktu
+- `src/Backend/Sudoku/Infrastructure/Storage/DatasetPreparationArtifactsGateway.cs`
+  - odczytuje manifesty i artefakty.
+- `src/Backend/Sudoku/Infrastructure/Storage/LocalFileStorageGateway.cs`
+  - ma już bezpieczne:
+    - atomowe `ReplaceAsync(...)` przez plik tymczasowy,
+    - `DeleteDirectoryAsync(...)`
+- `src/Backend/Sudoku/.github/workflows/backend-cd.yml`
+  - już podstawia `DatasetsPreparation.PreparationsDirectoryPath`.
+
+### 3.2 Wniosek architektoniczny
+- Nie tworzymy nowego osobnego gatewaya tylko dla `DELETE`.
+- Nie przenosimy logiki workflow usunięcia do `Infrastructure`.
+- Rozszerzamy istniejący `IDatasetPreparationArtifactsGateway` o generyczne operacje zapisu manifestu i usunięcia folderu planszy.
+- Handler w `Application` ma sterować kolejnością:
+  - policzenie nowego manifestu,
+  - zapis manifestu,
+  - usunięcie katalogu,
+  - ewentualny rollback manifestu przy błędzie drugiego kroku.
+
+## 4) Kontrakty FE/BE/ML
+
+### 4.1 FE -> BE
+- Metoda i ścieżka:
+  - `DELETE /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}`
+- Route params:
+  - `preparationName: string`
+  - `sourceName: string`
+  - `boardFolderName: string`
+- Query:
+  - brak
+- Body:
+  - brak
+- Autoryzacja:
+  - taka sama jak dla innych endpointów administracyjnych z `UC-13`
+
+### 4.2 BE -> FE
+- `200 OK` -> `DeleteDatasetPreparationBoardFileApiResponse`
+- `400 Bad Request` -> `ErrorApiResponse`
+- `401 Unauthorized` -> `ErrorApiResponse`
+- `404 Not Found` -> `ErrorApiResponse`
+- `409 Conflict` -> `ErrorApiResponse`
+- `500 Internal Server Error` -> `ErrorApiResponse`
+
+`DeleteDatasetPreparationBoardFileApiResponse`:
+- `preparationName`
+- `sourceName`
+- `boardFolderName`
+- `deleted`
+- `remainingItemsCount`
+
+Przykład:
+
+```json
+{
+  "preparationName": "preparation-001",
+  "sourceName": "v1_training",
+  "boardFolderName": "Image1079",
+  "deleted": true,
+  "remainingItemsCount": 241
+}
+```
+
+### 4.3 BE -> ML
+- Brak nowej komunikacji.
+- `DELETE` działa wyłącznie na lokalnym storage preparation zarządzanym przez backend.
+
+### 4.4 ML -> BE
+- Brak nowej komunikacji HTTP.
+- Jedyna zależność pośrednia: wcześniejszy workflow preparation musiał wcześniej utworzyć folder planszy i wpisać go do `file.json`.
+
+### 4.5 Plikowy kontrakt wejściowy dla BE
+- Manifest źródeł:
+  - `{PreparationsDirectoryPath}/{preparationName}/board/folders.json`
+- Manifest plansz:
+  - `{PreparationsDirectoryPath}/{preparationName}/board/{sourceName}/file.json`
+- Folder logicznego zasobu:
+  - `{PreparationsDirectoryPath}/{preparationName}/board/{sourceName}/{boardFolderName}/`
+
+Format `file.json`:
+
+```json
+[
+  "Image1",
+  "Image2",
+  "Image1079"
+]
+```
+
+## 5) Model API wejściowy i wyjściowy
+- Wejście z `FE`:
+  - route params: `preparationName`, `sourceName`, `boardFolderName`
+  - body: brak
+- Wyjście do `FE`:
+  - `[NOWY]` `DeleteDatasetPreparationBoardFileApiResponse`
+  - `[REUSE]` `ErrorApiResponse`
+- `BE <-> ML`:
+  - brak komunikacji dla tego endpointa
+
+## 6) Zachowanie per warstwa
+
+### 6.1 API
+- Nowa akcja w `DatasetsController`:
+  - `[HttpDelete("preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}")]`
+- Kontroler:
+  - binduje route params,
+  - wysyła `DeleteDatasetPreparationBoardFileCommand`,
+  - mapuje wynik do `DeleteDatasetPreparationBoardFileApiResponse`,
+  - mapuje wyjątki na `400/404/409/500`.
+- `Api` nie:
+  - odczytuje `file.json`,
+  - usuwa katalogów,
+  - nie buduje ścieżek filesystemu,
+  - nie robi rollbacku,
+  - nie odpytuje `ML`.
+
+### 6.2 Application
+- `Application` odpowiada za:
+  - walidację `preparationName`,
+  - walidację `sourceName`,
+  - walidację `boardFolderName`,
+  - sprawdzenie istnienia preparation,
+  - sprawdzenie statusu `completed`,
+  - sprawdzenie, czy `sourceName` istnieje w `board/folders.json`,
+  - sprawdzenie, czy `boardFolderName` istnieje w `board/{sourceName}/file.json`,
+  - wyliczenie nowej zawartości `file.json`,
+  - orkiestrację zapisu manifestu i usunięcia katalogu,
+  - próbę rollbacku manifestu, jeśli usunięcie katalogu nie powiedzie się po zapisaniu manifestu,
+  - budowę DTO wyniku.
+- `Application` nie:
+  - używa `File.*` ani `Directory.*`,
+  - nie serializuje JSON bezpośrednio do pliku,
+  - nie zna detali niskopoziomowego storage.
+
+### 6.3 Models / Domain
+- Brak potrzeby wprowadzania nowego modelu domenowego.
+- Reuse:
+  - `Models/Datasets/DatasetPreparationStatus.cs`
+- To jest use-case operacyjny nad istniejącym preparation, nie nowy byt domenowy.
+
+### 6.4 Infrastructure
+- `Infrastructure` ma:
+  - odczytać listy z manifestów,
+  - zapisać nową zawartość `file.json`,
+  - usunąć katalog `boardFolderName`,
+  - nie znać semantyki `404/409`,
+  - nie podejmować decyzji o kolejności biznesowej poza wykonaniem przekazanych operacji.
+- Preferowana forma rozszerzenia portu:
+  - `ReplaceBoardFileNamesAsync(...)`
+  - `DeleteBoardDirectoryAsync(...)`
+- Dzięki temu `Infrastructure` pozostaje generyczne i reuse'owalne dla kolejnych use-case'ów czyszczących artefakty preparation.
+
+## 7) Pliki per warstwa i odpowiedzialności
+
+### 7.1 API (`src/Backend/Sudoku/Sudoku`)
+- `[MODYFIKACJA]` `Controllers/DatasetsController.cs`
+  - dodać akcję `DeletePreparationBoardFileAsync(string? preparationName, string? sourceName, string? boardFolderName, CancellationToken)`
+  - wysłać `DeleteDatasetPreparationBoardFileCommand`
+  - mapować:
+    - `ValidationException -> 400`
+    - `DatasetPreparationNotFoundException -> 404`
+    - `DatasetPreparationSourceNotFoundException -> 404`
+    - `DatasetPreparationBoardFileNotFoundException -> 404`
+    - `DatasetPreparationArtifactsNotReadyException -> 409`
+    - `IOException | UnauthorizedAccessException | InvalidDataException | JsonException | FileStorageItemNotFoundException -> 500`
+- `[NOWY]` `Contracts/DeleteDatasetPreparationBoardFileApiResponse.cs`
+  - publiczny kontrakt odpowiedzi dla `DELETE`
+- `[REUSE]` `Contracts/ErrorApiResponse.cs`
+  - wspólny kontrakt błędu
+
+### 7.2 Application (`src/Backend/Sudoku/Application`)
+- `[NOWY]` `Datasets/DeleteDatasetPreparationBoardFileCommand.cs`
+  - command MediatR
+- `[NOWY]` `Datasets/DeleteDatasetPreparationBoardFileCommandValidator.cs`
+  - walidacja `preparationName`, `sourceName`, `boardFolderName`
+- `[NOWY]` `Datasets/DeleteDatasetPreparationBoardFileCommandHandler.cs`
+  - pełna logika use-case'a
+- `[NOWY]` `Datasets/DeleteDatasetPreparationBoardFileCommandResultDto.cs`
+  - wynik use-case'a:
+    - `preparationName`
+    - `sourceName`
+    - `boardFolderName`
+    - `deleted`
+    - `remainingItemsCount`
+- `[NOWY]` `Datasets/DeleteDatasetPreparationBoardFileErrorTypes.cs`
+  - stałe `errorType`
+- `[REUSE]` `Datasets/DatasetPreparationNameValidationRules.cs`
+  - walidacja `preparationName`
+- `[REUSE]` `Datasets/DatasetPreparationSourceNameValidationRules.cs`
+  - walidacja `sourceName`
+- `[REUSE]` `Datasets/DatasetPreparationBoardFolderNameValidationRules.cs`
+  - walidacja `boardFolderName`
+- `[REUSE]` `Datasets/DatasetPreparationNotFoundException.cs`
+  - `404`
+- `[REUSE]` `Datasets/DatasetPreparationSourceNotFoundException.cs`
+  - `404`
+- `[REUSE]` `Datasets/DatasetPreparationBoardFileNotFoundException.cs`
+  - `404`
+- `[REUSE]` `Datasets/DatasetPreparationArtifactsNotReadyException.cs`
+  - `409`
+- `[MODYFIKACJA]` `Abstractions/IDatasetPreparationArtifactsGateway.cs`
+  - dodać:
+    - `ReplaceBoardFileNamesAsync(string preparationName, string sourceName, IReadOnlyList<string> boardFileNames, CancellationToken cancellationToken = default)`
+    - `DeleteBoardDirectoryAsync(string preparationName, string sourceName, string boardFolderName, CancellationToken cancellationToken = default)`
+- `[REUSE]` `Abstractions/IDatasetPreparationsGateway.cs`
+  - odczyt metadata preparation
+- `[REUSE]` `Datasets/GetDatasetPreparationBoardFilesQueryHandler.cs`
+  - wzorzec sprawdzania source i manifestu
+- `[REUSE]` `Datasets/GetDatasetPreparationBoardImageQueryHandler.cs`
+  - wzorzec rozróżnienia `404` logicznego od `500` technicznego
+
+### 7.3 Models (`src/Backend/Sudoku/Models`)
+- `[REUSE]` `Models/Datasets/DatasetPreparationStatus.cs`
+  - statusy preparation
+- `[BRAK NOWYCH PLIKÓW]`
+  - endpoint nie wnosi nowego bytu domenowego
+
+### 7.4 Infrastructure (`src/Backend/Sudoku/Infrastructure`)
+- `[MODYFIKACJA]` `Storage/DatasetPreparationArtifactsGateway.cs`
+  - zaimplementować `ReplaceBoardFileNamesAsync(...)`
+  - zaimplementować `DeleteBoardDirectoryAsync(...)`
+  - reuse'ować istniejące helpery do budowy ścieżek `preparationName/board/sourceName`
+  - serializować `string[]` do `file.json` przez `JsonSerializerDefaults.Web`
+- `[REUSE]` `Storage/LocalFileStorageGateway.cs`
+  - wykona właściwe:
+    - atomowe `ReplaceAsync(...)`
+    - `DeleteDirectoryAsync(...)`
+- `[REUSE]` `DependencyInjection.cs`
+  - brak nowego serwisu, tylko reuse istniejącej rejestracji gatewaya artefaktów
+
+### 7.5 Testy (`src/Backend/Sudoku/Application.Tests`)
+- `[NOWY]` `DeleteDatasetPreparationBoardFileCommandValidatorTests.cs`
+  - testy walidatora
+- `[NOWY]` `DeleteDatasetPreparationBoardFileCommandHandlerTests.cs`
+  - testy handlera
+- `[MODYFIKACJA]` `DatasetsControllerTests.cs`
+  - testy nowej akcji HTTP
+- `[REUSE]` `GetDatasetPreparationBoardFilesQueryHandlerTests.cs`
+  - wzorzec stubów preparation/artifacts
+- `[REUSE]` `GetDatasetPreparationBoardImageQueryHandlerTests.cs`
+  - wzorzec semantyki `boardFolderName`
+
+### 7.6 Workflow i config
+- `[REUSE]` `Sudoku/appsettings.local.json`
+  - lokalny `PreparationsDirectoryPath` ustawiony na sztywno
+- `[REUSE]` `Sudoku/appsettings.production.json`
+  - overlay produkcyjny
+- `[REUSE]` `.github/workflows/backend-cd.yml`
+  - już podstawia `BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH`
+
+## 8) Przepływ w obrębie backendu
+1. `FE` wywołuje `DELETE /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}`.
+2. Autoryzacja z `UC-13` przepuszcza tylko admina.
+3. `DatasetsController.DeletePreparationBoardFileAsync(...)` binduje route params.
+4. Kontroler wysyła `DeleteDatasetPreparationBoardFileCommand(preparationName, sourceName, boardFolderName)`.
+5. `ValidationBehavior` uruchamia validator.
+6. Handler odczytuje metadata przez `IDatasetPreparationsGateway.GetByNameAsync(...)`.
+7. Gdy preparation nie istnieje:
+  - `DatasetPreparationNotFoundException`
+8. Gdy preparation nie ma statusu `completed`:
+  - `DatasetPreparationArtifactsNotReadyException`
+9. Handler czyta `board/folders.json` przez `IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync(...)`.
+10. Gdy `sourceName` nie należy do manifestu:
+  - `DatasetPreparationSourceNotFoundException`
+11. Handler czyta `board/{sourceName}/file.json` przez `GetBoardFileNamesAsync(...)`.
+12. Gdy `boardFolderName` nie należy do manifestu:
+  - `DatasetPreparationBoardFileNotFoundException`
+13. Handler buduje nową listę bez usuwanego wpisu.
+14. Handler zapisuje nową zawartość `file.json`.
+15. Handler usuwa katalog `boardFolderName`.
+16. Jeśli krok 15 nie powiedzie się, handler próbuje przywrócić poprzedni manifest.
+17. Handler zwraca wynik z `deleted=true` i `remainingItemsCount`.
+18. Kontroler mapuje DTO do `DeleteDatasetPreparationBoardFileApiResponse` i zwraca `200 OK`.
+
+## 9) Główne funkcje
+- `DatasetsController.DeletePreparationBoardFileAsync(...)`
+- `DatasetsController.ToDeleteDatasetPreparationBoardFileApiResponse(...)`
+- `DeleteDatasetPreparationBoardFileCommandHandler.Handle(...)`
+- `DeleteDatasetPreparationBoardFileCommandValidator.Validate(...)`
+- `DeleteDatasetPreparationBoardFileCommandHandler.EnsurePreparationCompleted(...)`
+- `DeleteDatasetPreparationBoardFileCommandHandler.EnsureBoardSourceExists(...)`
+- `DeleteDatasetPreparationBoardFileCommandHandler.EnsureBoardFolderExists(...)`
+- `DeleteDatasetPreparationBoardFileCommandHandler.BuildRemainingBoardFileNames(...)`
+- `DeleteDatasetPreparationBoardFileCommandHandler.PersistManifestThenDeleteBoardAsync(...)`
+- `DeleteDatasetPreparationBoardFileCommandHandler.TryRollbackBoardManifestAsync(...)`
+
+## 10) Wyjątki, fallbacki i zachowanie błędowe
+
+### 10.1 Statusy HTTP
+- `200 OK`
+  - preparation istnieje,
+  - ma status `completed`,
+  - `sourceName` istnieje,
+  - `boardFolderName` istnieje w `file.json`,
+  - manifest został zaktualizowany,
+  - katalog został usunięty
+- `400 Bad Request`
+  - niepoprawny `preparationName`
+  - niepoprawny `sourceName`
+  - niepoprawny `boardFolderName`
+- `401 Unauthorized`
+  - brak poprawnej autoryzacji
+- `404 Not Found`
+  - preparation nie istnieje
+  - `sourceName` nie istnieje w `board/folders.json`
+  - `boardFolderName` nie istnieje w `board/{sourceName}/file.json`
+- `409 Conflict`
+  - preparation istnieje, ale nie jest gotowe do pracy na artefaktach
+- `500 Internal Server Error`
+  - błąd odczytu `board/folders.json`
+  - błąd odczytu `file.json`
+  - błąd zapisu zaktualizowanego `file.json`
+  - błąd usunięcia katalogu planszy
+  - błąd rollbacku manifestu
+  - niespójny storage dla preparation `completed`
+
+### 10.2 `errorType`
+- `invalid_dataset_preparation_name`
+- `invalid_dataset_preparation_source_name`
+- `invalid_dataset_preparation_board_folder_name`
+- `dataset_preparation_not_found`
+- `dataset_preparation_source_not_found`
+- `dataset_preparation_board_file_not_found`
+- `dataset_preparation_artifacts_not_ready`
+- `dataset_preparation_board_file_delete_failed`
+
+### 10.3 Fallbacki
+- Dozwolone:
+  - usunięcie ostatniego wpisu i zapis pustej listy `[]`
+  - próba rollbacku manifestu, jeśli usunięcie katalogu nie powiedzie się po zapisie `file.json`
+- Niedozwolone:
+  - skan katalogów w celu odbudowy `file.json`
+  - odpytywanie `ML`
+  - kasowanie całego `sourceName`
+  - mapowanie braku wpisu w manifeście na `500`
+  - ukrywanie częściowej awarii bez loga i bez `500`
+
+### 10.4 Najważniejsze rozróżnienie błędów
+- brak wpisu w `file.json` -> `404`
+- awaria zapisu manifestu lub usunięcia katalogu -> `500`
+
+## 11) Specyficzna logika i pseudokod
+
+### 11.1 Główna decyzja implementacyjna
+- Dla tego use-case'a ważniejsze jest, aby nie zostawić martwego wpisu w `file.json`, niż żeby kolejność była czysto filesystemowa.
+- Dlatego rekomendowana orkiestracja:
+  1. oblicz nowy manifest,
+  2. zapisz nowy manifest,
+  3. usuń katalog planszy,
+  4. jeśli krok 3 się nie uda, spróbuj rollbacku manifestu.
+- To lepiej spełnia wymaganie `UC-18`, że widok nie ma pokazywać nieistniejących już logicznie plansz.
+
+### 11.2 Pseudokod handlera
+
+```text
+handle(command):
+  validate(command)
+
+  metadata = datasetPreparationsGateway.getByName(command.preparationName)
+  if metadata is null:
+    throw dataset_preparation_not_found
+
+  if metadata.status != "completed":
+    throw dataset_preparation_artifacts_not_ready
+
+  boardSources = artifactsGateway.getSourceFolderNames(command.preparationName, "board")
+  if command.sourceName not in boardSources:
+    throw dataset_preparation_source_not_found
+
+  boardFileNames = artifactsGateway.getBoardFileNames(command.preparationName, command.sourceName)
+  if command.boardFolderName not in boardFileNames:
+    throw dataset_preparation_board_file_not_found
+
+  remainingBoardFileNames = boardFileNames without command.boardFolderName
+
+  try:
+    artifactsGateway.replaceBoardFileNames(
+      command.preparationName,
+      command.sourceName,
+      remainingBoardFileNames
+    )
+
+    artifactsGateway.deleteBoardDirectory(
+      command.preparationName,
+      command.sourceName,
+      command.boardFolderName
+    )
+  catch delete_error:
+    try rollback:
+      artifactsGateway.replaceBoardFileNames(
+        command.preparationName,
+        command.sourceName,
+        boardFileNames
+      )
+    catch rollback_error:
+      log rollback failure
+
+    throw delete_failed
+
+  return result(
+    preparationName,
+    sourceName,
+    boardFolderName,
+    deleted=true,
+    remainingItemsCount=remainingBoardFileNames.length
+  )
+```
+
+### 11.3 Pseudokod gatewaya artefaktów
+
+```text
+replaceBoardFileNames(preparationName, sourceName, boardFileNames):
+  directoryPath = combine(preparationsDirectoryPath, preparationName, "board", sourceName)
+  payload = serialize_json(boardFileNames)
+  fileStorageGateway.replace(directoryPath, "file.json", payload)
+
+deleteBoardDirectory(preparationName, sourceName, boardFolderName):
+  directoryPath = combine(preparationsDirectoryPath, preparationName, "board", sourceName)
+  fileStorageGateway.deleteDirectory(directoryPath, boardFolderName)
+```
+
+### 11.4 Pseudokod walidacji
+
+```text
+validate(command):
+  validatePreparationName(command.preparationName)
+  validateSourceName(command.sourceName)
+  validateBoardFolderName(command.boardFolderName)
+```
+
+## 12) Mermaid flowchart - flow modeli
+
+```mermaid
+flowchart TD
+    A["route params<br/>DatasetsController.DeletePreparationBoardFileAsync()"] --> B["DeleteDatasetPreparationBoardFileCommand<br/>command aplikacyjne"]
+    B --> C["DatasetPreparationMetadataDto<br/>IDatasetPreparationsGateway.GetByNameAsync()"]
+    C --> D["IReadOnlyList<string><br/>IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync()"]
+    D --> E["IReadOnlyList<string><br/>IDatasetPreparationArtifactsGateway.GetBoardFileNamesAsync()"]
+    E --> F["IReadOnlyList<string><br/>remainingBoardFileNames po filtracji"]
+    F --> G["DeleteDatasetPreparationBoardFileCommandResultDto<br/>deleted + remainingItemsCount"]
+    G --> H["DeleteDatasetPreparationBoardFileApiResponse<br/>publiczna odpowiedź FE"]
+```
+
+## 13) Mermaid flowchart - logika aplikacji z funkcjami
+
+```mermaid
+flowchart TD
+    A["DatasetsController.DeletePreparationBoardFileAsync()"] --> B["DeleteDatasetPreparationBoardFileCommandValidator.Validate()"]
+    B --> C["DeleteDatasetPreparationBoardFileCommandHandler.Handle()"]
+    C --> D["IDatasetPreparationsGateway.GetByNameAsync()"]
+    D --> E["EnsurePreparationCompleted()"]
+    E --> F["IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync()"]
+    F --> G["EnsureBoardSourceExists()"]
+    G --> H["IDatasetPreparationArtifactsGateway.GetBoardFileNamesAsync()"]
+    H --> I["EnsureBoardFolderExists()"]
+    I --> J["BuildRemainingBoardFileNames()"]
+    J --> K["IDatasetPreparationArtifactsGateway.ReplaceBoardFileNamesAsync()"]
+    K --> L["IDatasetPreparationArtifactsGateway.DeleteBoardDirectoryAsync()"]
+    L --> M["TryRollbackBoardManifestAsync() w razie błędu"]
+    L --> N["ToDeleteDatasetPreparationBoardFileApiResponse() po sukcesie"]
+```
+
+## 14) Logging
+- `Information`
+  - start: `preparationName`, `sourceName`, `boardFolderName`
+  - success: `preparationName`, `sourceName`, `boardFolderName`, `remainingItemsCount`
+- `Warning`
+  - preparation nie istnieje
+  - preparation nie jest gotowe
+  - `sourceName` lub `boardFolderName` nie należą do manifestów
+  - rollback manifestu został uruchomiony
+- `Error`
+  - błąd odczytu lub zapisu `file.json`
+  - błąd usunięcia katalogu
+  - błąd rollbacku manifestu
+- Guardraile:
+  - nie logować całej zawartości `file.json`
+  - nie logować pełnych ścieżek systemowych w odpowiedzi HTTP
+  - logi mają być lekkie i operacyjne
+
+## 15) Workflow GitHub i konfiguracja runtime
+- Endpoint nie wymaga nowych sekretów ani nowych zmiennych środowiskowych.
+- Endpoint nie wymaga zmian po stronie `ML`.
+- Lokalnie:
+  - `PreparationsDirectoryPath` zostaje ustawione na sztywno w `appsettings.local.json`
+- Produkcyjnie:
+  - `.github/workflows/backend-cd.yml` już podstawia `BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH` do `appsettings.production.json`
+- Istotna reguła runtime:
+  - deploy może zmieniać `appsettings.production.json`,
+  - deploy nie może nadpisywać ani czyścić `shared/data`, bo tam żyją runtime artifacts preparation
+
+## 16) Inne istotne reguły
+- Nie zmieniać istniejących nazw klas i pól używanych przez już wdrożone endpointy `UC-18`.
+- Reuse'ować istniejące:
+  - `DatasetPreparationSourceNameValidationRules`
+  - `DatasetPreparationBoardFolderNameValidationRules`
+  - `DatasetPreparationSourceNotFoundException`
+  - `DatasetPreparationBoardFileNotFoundException`
+- Nie opierać się na fizycznym istnieniu katalogu jako źródle prawdy o zasobie.
+- Źródłem prawdy dla istnienia planszy jest `file.json`.
+- `Infrastructure` nie powinno decydować, czy rollback jest potrzebny.
+- `Application` ma przekazywać `remainingBoardFileNames` do `Infrastructure`; nie odwrotnie.
+
+## 17) Kolejność implementacji kodu
+1. Dodać `DeleteDatasetPreparationBoardFileErrorTypes`.
+2. Dodać `DeleteDatasetPreparationBoardFileCommand`.
+3. Dodać `DeleteDatasetPreparationBoardFileCommandResultDto`.
+4. Dodać `DeleteDatasetPreparationBoardFileCommandValidator`.
+5. Rozszerzyć `IDatasetPreparationArtifactsGateway` o zapis manifestu i usuwanie folderu planszy.
+6. Rozszerzyć `DatasetPreparationArtifactsGateway` o:
+   - `ReplaceBoardFileNamesAsync(...)`
+   - `DeleteBoardDirectoryAsync(...)`
+7. Dodać `DeleteDatasetPreparationBoardFileCommandHandler`.
+8. Dodać `DeleteDatasetPreparationBoardFileApiResponse`.
+9. Rozszerzyć `DatasetsController` o akcję `DELETE`.
+10. Dodać testy walidatora.
+11. Dodać testy handlera.
+12. Rozszerzyć testy kontrolera.
+13. Wykonać smoke test dla:
+   - poprawnego usunięcia,
+   - usunięcia ostatniego wpisu,
+   - braku preparation,
+   - braku source,
+   - braku board folderu w manifeście,
+   - awarii zapisu manifestu,
+   - awarii usunięcia katalogu,
+   - awarii rollbacku
+
+## 18) Guardraile implementacyjne
+- Nie kasować katalogu w kontrolerze.
+- Nie pisać bezpośrednio do `file.json` z poziomu kontrolera ani handlera przez `File.*`.
+- Nie tworzyć osobnego gatewaya tylko dla tego jednego endpointu.
+- Nie skanować katalogów jako fallback dla brakującego manifestu.
+- Nie odpytywać `ML`.
+- Nie zmieniać kolejności elementów w `file.json`, poza usunięciem jednego wpisu.
+- Nie sortować manifestu na nowo.
+- Nie mapować błędu usunięcia katalogu na `404`, jeśli wpis istniał w manifeście.
+- Nie ignorować awarii rollbacku; trzeba ją zalogować jako `Error`.
+
+## 19) Zależności pomiędzy historyjkami
+- `UC-13`
+  - autoryzacja admina
+- `UC-17 POST /api/datasets/preparations`
+  - tworzy preparation i zapisuje artefakty wejściowe dla `UC-18`
+- `UC-17 GET /api/datasets/preparations`
+  - wybór preparation
+- `UC-17 GET /api/datasets/preparations/{preparationName}`
+  - źródło statusu preparation
+- `UC-18 GET /api/datasets/preparations/{preparationName}/board/folders`
+  - dostarcza `sourceName`
+- `UC-18 GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files`
+  - dostarcza `boardFolderName`
+- `UC-18 GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}/image`
+  - reuse'uje ten sam model weryfikacji zasobu
+- `UC-19`
+  - polega na tym, że preparation po czyszczeniu pozostaje spójne i nie ma martwych wpisów
+
+## 20) Plan testów minimum
+
+### 20.1 Validator
+- pusty `preparationName` -> `400`
+- pusty `sourceName` -> `400`
+- pusty `boardFolderName` -> `400`
+- `preparationName` z `..` -> `400`
+- `sourceName` z separatorem ścieżki -> `400`
+- `boardFolderName` z separatorem ścieżki -> `400`
+- poprawny request -> walidacja przechodzi
+
+### 20.2 Handler
+- happy path:
+  - preparation `completed`
+  - source istnieje
+  - board folder istnieje
+  - manifest zapisany
+  - katalog usunięty
+- usunięcie ostatniego wpisu:
+  - wynik `remainingItemsCount = 0`
+  - zapis `[]` do `file.json`
+- brak preparation -> `DatasetPreparationNotFoundException`
+- status `queued` / `running` / `failed` -> `DatasetPreparationArtifactsNotReadyException`
+- brak `sourceName` w `board/folders.json` -> `DatasetPreparationSourceNotFoundException`
+- brak `boardFolderName` w `file.json` -> `DatasetPreparationBoardFileNotFoundException`
+- awaria `ReplaceBoardFileNamesAsync(...)` -> błąd techniczny propagowany do `500`
+- awaria `DeleteBoardDirectoryAsync(...)` po zapisaniu manifestu:
+  - rollback manifestu zostaje wywołany
+  - błąd końcowy jest techniczny
+- awaria rollbacku:
+  - nadal błąd techniczny
+  - dodatkowy log `Error`
+
+### 20.3 API
+- `200 OK` i poprawne mapowanie `DeleteDatasetPreparationBoardFileApiResponse`
+- `400` dla błędu walidacji
+- `401` bez autoryzacji
+- `404` dla braku preparation
+- `404` dla braku source
+- `404` dla braku board folderu w manifeście
+- `409` dla niegotowego preparation
+- `500` dla błędu zapisu manifestu
+- `500` dla błędu usunięcia katalogu
+
+### 20.4 Manual smoke
+- usunięcie istniejącej planszy i ponowny odczyt listy
+- usunięcie ostatniej planszy w source
+- próba usunięcia elementu spoza `file.json`
+- próba usunięcia dla preparation `running`
+- awaria techniczna przy usuwaniu katalogu i potwierdzenie logu rollbacku
+
+## 21) Podsumowanie decyzji architektonicznych
+- Publiczny kontrakt `DELETE` powinien zwracać body z `deleted` i `remainingItemsCount`, bo use-case dotyczy mutacji listy logicznych elementów preparation.
+- `Application` ma posiadać pełną logikę semantyczną i kolejność działań.
+- `Infrastructure` ma tylko wykonać odczyt, zapis manifestu i usunięcie katalogu.
+- Najważniejsza decyzja antyduplikacyjna:
+  - rozszerzyć `IDatasetPreparationArtifactsGateway`,
+  - nie tworzyć nowego endpoint-specific gatewaya
+- Najważniejsze rozróżnienie spójności:
+  - brak wpisu w manifeście to `404`,
+  - awaria zapisu/usuwania to `500`
+- Najważniejsza decyzja workflow:
+  - utrzymać spójność `file.json` jako źródła prawdy widoku,
+  - w razie częściowej awarii próbować rollbacku manifestu,
+  - nie angażować `ML`

--- a/.ai/implementation-plan/be/uc-18-be-get-api-datasets-preparations-preparation-name-board-folders.md
+++ b/.ai/implementation-plan/be/uc-18-be-get-api-datasets-preparations-preparation-name-board-folders.md
@@ -1,0 +1,644 @@
+# UC-18-BE - Plan implementacyjny dla `GET /api/datasets/preparations/{preparationName}/board/folders`
+
+## 1) Przeznaczenie endpointa
+- Endpoint `GET /api/datasets/preparations/{preparationName}/board/folders` zwraca listę nazw źródeł typu `board` dla wybranego preparation.
+- Jest to pierwszy krok wejścia w przeglądanie wyników preparation w `UC-18`:
+  - użytkownik wybiera preparation,
+  - `FE` pobiera listę folderów źródłowych typu `board`,
+  - dopiero po wyborze konkretnego źródła pobierane są listy plansz.
+- Endpoint jest `read-only`:
+  - nie uruchamia preprocessingu,
+  - nie wywołuje `ML`,
+  - nie przebudowuje manifestów,
+  - nie skanuje katalogów heurystycznie.
+- `BE` pozostaje `source of truth` dla odpowiedzi HTTP, ale źródłem danych plikowych jest gotowy manifest `board/folders.json` w storage preparation.
+
+## 2) Zakres i główne założenia
+- Plan dotyczy wyłącznie części `BE` w `src/Backend/Sudoku`.
+- Nie sugerujemy się aktualnym stanem `FE` ani bieżącą implementacją `ML`, poza obowiązującymi kontraktami i artefaktami już zdefiniowanymi przez `UC-17` / `UC-18`.
+- Endpoint ma pozostać zgodny z obecnym stylem backendu:
+  - `ASP.NET Controller`,
+  - `MediatR`,
+  - `FluentValidation`,
+  - cienki `Api`,
+  - logika w `Application`,
+  - adaptery i JSON/file I/O w `Infrastructure`.
+- Kontrakt publiczny ma reuse'ować shape opisany już w `UC-18`:
+  - `DatasetPreparationFoldersApiResponse`
+  - `preparationName`
+  - `type`
+  - `items`
+  - `totalCount`
+- Nie tworzymy nowej komunikacji `BE -> ML`.
+- Nie dokładamy nowej konfiguracji runtime tylko dlatego, że dochodzi nowy endpoint.
+
+## 3) Co już istnieje i należy reuse'ować
+
+### 3.1 Gotowe elementy backendu
+- `DatasetsController`
+  - ma już `GET /api/datasets/preparations`
+  - ma już `GET /api/datasets/preparations/{preparationName}`
+- `GetDatasetPreparationDetailsQueryValidator`
+  - zawiera gotowe reguły walidacji `preparationName`
+- `IDatasetPreparationsGateway`
+  - ma już `GetByNameAsync(preparationName)`
+- `DatasetPreparationsGateway`
+  - czyta `preparation.metadata.json`
+- `DatasetsPreparationOptions`
+  - ma już `PreparationsDirectoryPath`
+  - ma już `BoardsSubdirectory`
+  - ma już `DigitsSubdirectory`
+- `IFileStorageGateway`
+  - ma gotowe operacje odczytu plików
+- `LocalFileStorageGateway`
+  - pilnuje bezpieczeństwa ścieżek i dostępu do storage
+- `DatasetPreparationNotFoundException`
+  - jest już semantycznym wyjątkiem `404`
+- `ErrorApiResponse`
+  - jest wspólnym kontraktem błędu
+
+### 3.2 Artefakty runtime już zdefiniowane poza BE
+- `UC-18` zakłada odczyt:
+  - `board/folders.json`
+  - `digit/folders.json`
+- `UC-17 ML` definiuje, że `ML` zapisuje te manifesty deterministycznie i `BE` ich nie generuje.
+
+### 3.3 Wniosek architektoniczny
+- Nie wolno czytać listy folderów przez skan katalogu `board/`.
+- Nie wolno opierać odpowiedzi na tym, co aktualnie ma `FE`.
+- Nie wolno mieszać odczytu `preparation.metadata.json` z odczytem artefaktów runtime w jednym gateway tylko dlatego, że oba dotyczą preparation.
+- Najlepszym reuse dla kolejnych endpointów `UC-18` jest:
+  - pozostawić `IDatasetPreparationsGateway` jako gateway metadanych,
+  - dodać osobny, generyczny port artefaktów preparation do odczytu manifestów.
+
+## 4) Kontrakty API FE i ML
+
+### 4.1 FE -> BE
+- Metoda i ścieżka:
+  - `GET /api/datasets/preparations/{preparationName}/board/folders`
+- Request body:
+  - brak
+- Route param:
+  - `preparationName: string`
+- Autoryzacja:
+  - token administratora z `UC-13`
+
+### 4.2 BE -> FE
+- `200 OK` -> `DatasetPreparationFoldersApiResponse`
+- `400 Bad Request` -> `ErrorApiResponse`
+- `401 Unauthorized` -> `ErrorApiResponse`
+- `404 Not Found` -> `ErrorApiResponse`
+- `409 Conflict` -> `ErrorApiResponse`
+- `500 Internal Server Error` -> `ErrorApiResponse`
+
+`DatasetPreparationFoldersApiResponse`:
+- `preparationName: string`
+- `type: string`
+- `items: string[]`
+- `totalCount: number`
+
+Przykład `200 OK`:
+
+```json
+{
+  "preparationName": "preparation-001",
+  "type": "board",
+  "items": [
+    "v1_training",
+    "v2_training"
+  ],
+  "totalCount": 2
+}
+```
+
+### 4.3 BE -> ML
+- Brak nowej komunikacji.
+- Endpoint działa wyłącznie na gotowych artefaktach zapisanych wcześniej do storage.
+
+### 4.4 ML -> BE
+- Brak nowej komunikacji dla tego endpointu.
+- Jedyną zależnością jest wcześniejsze zapisanie `board/folders.json` przez istniejący flow preparation.
+
+## 5) Model API wejściowy i wyjściowy w komunikacji z FE i ML
+
+### 5.1 FE -> BE
+- brak body,
+- `preparationName` w route.
+
+### 5.2 BE -> FE
+- `[NOWY]` `DatasetPreparationFoldersApiResponse`
+- `[REUSE]` `ErrorApiResponse`
+
+### 5.3 BE -> ML
+- brak komunikacji
+
+### 5.4 ML -> BE
+- brak komunikacji HTTP
+
+### 5.5 Plikowy kontrakt wejściowy dla BE
+- Wejściowy manifest dla tego endpointu:
+  - `{DatasetsPreparation.PreparationsDirectoryPath}/{preparationName}/board/folders.json`
+- Format:
+
+```json
+[
+  "v1_training",
+  "v2_training"
+]
+```
+
+### 5.6 Reguła kontraktowa
+- `type` w odpowiedzi dla tego endpointu musi mieć wartość `"board"`.
+- Kolejność `items` ma pozostać taka jak w `folders.json`.
+- `BE` nie sortuje, nie filtruje i nie rekonstruuje listy na podstawie katalogów.
+
+## 6) Zachowanie per warstwa
+
+### API (`Sudoku`)
+- `DatasetsController` dostaje nową akcję:
+  - `[HttpGet("preparations/{preparationName}/board/folders")]`
+- Kontroler:
+  - binduje `preparationName`,
+  - wysyła query do `MediatR`,
+  - mapuje wynik do `DatasetPreparationFoldersApiResponse`,
+  - mapuje wyjątki na `400/404/409/500`.
+- API nie:
+  - buduje ścieżek do plików,
+  - nie parsuje `folders.json`,
+  - nie dotyka `IFileStorageGateway`,
+  - nie odpytuje `ML`.
+
+### Application (`Application`)
+- `Application` odpowiada za:
+  - walidację `preparationName`,
+  - sprawdzenie istnienia preparation przez metadata,
+  - sprawdzenie, czy preparation jest gotowe do przeglądania folderów,
+  - wywołanie portu artefaktów preparation,
+  - zbudowanie DTO wyniku.
+- `Application` nie:
+  - wykonuje I/O niskopoziomowego,
+  - nie deserializuje JSON plików bezpośrednio,
+  - nie skanuje katalogów przez `Directory.*`.
+
+### Domain / Models (`Models`)
+- Dla tego endpointu nie trzeba dodawać nowego modelu domenowego w `Models`.
+- Jest to use-case aplikacyjny nad istniejącym bytem preparation.
+- Jeżeli chcemy unikać magic stringów, można dodać mały model wspólny w `Application`, a nie w `Models`, bo dotyczy kontraktu use-case'ów `folders`.
+
+### Infrastructure (`Infrastructure`)
+- `Infrastructure` implementuje odczyt manifestu `folders.json`.
+- Nowy adapter powinien:
+  - znać layout katalogów preparation,
+  - zbudować ścieżkę do manifestu,
+  - odczytać plik przez `IFileStorageGateway`,
+  - zdeserializować `string[]`,
+  - rzucić błąd techniczny przy uszkodzonym JSON.
+- `Infrastructure` nie:
+  - mapuje `404` preparation,
+  - nie decyduje o `409 not ready`,
+  - nie tworzy `ApiResponse`.
+
+## 7) Rekomendowana decyzja o portach i antyduplikacji
+
+### 7.1 Czego nie robić
+- Nie rozszerzać `IDatasetPreparationsGateway` o odczyt `board/folders.json`.
+- Nie używać `IFileStorageGateway` bezpośrednio z kontrolera.
+- Nie wrzucać logiki ścieżek do query handlera.
+
+### 7.2 Co dodać zamiast tego
+- `[NOWY]` port `IDatasetPreparationArtifactsGateway` w `Application/Abstractions`.
+- Powód:
+  - `IDatasetPreparationsGateway` powinien pozostać gatewayem metadanych,
+  - `UC-18` i `UC-19` będą jeszcze konsumować inne artefakty preparation,
+  - przyszłe `digit/folders`, `board/{sourceName}/files`, obraz planszy i `DELETE` będą mogły reuse'ować ten sam adapter.
+
+### 7.3 Minimalny zakres portu na teraz
+- Metoda generyczna pod folder manifests:
+  - `GetSourceFolderNamesAsync(string preparationName, string sourceType, CancellationToken cancellationToken = default)`
+- Dla tego endpointu `sourceType = "board"`.
+- Dla przyszłego `digit/folders` ten sam handler i ten sam port mogą pracować z `sourceType = "digit"`.
+
+## 8) Pliki per warstwa i odpowiedzialności
+
+### 8.1 API (`src/Backend/Sudoku/Sudoku`)
+- `[MODYFIKACJA]` `Controllers/DatasetsController.cs`
+  - dodać akcję `GetPreparationBoardFoldersAsync(string? preparationName, CancellationToken)`
+  - wysłać `GetDatasetPreparationFoldersQuery(preparationName, "board")`
+  - zmapować wynik do `DatasetPreparationFoldersApiResponse`
+  - złapać `ValidationException -> 400`
+  - złapać `DatasetPreparationNotFoundException -> 404`
+  - złapać `DatasetPreparationArtifactsNotReadyException -> 409`
+  - złapać `IOException | UnauthorizedAccessException | InvalidDataException | JsonException | FileStorageItemNotFoundException -> 500`
+- `[NOWY]` `Contracts/DatasetPreparationFoldersApiResponse.cs`
+  - publiczny kontrakt listy folderów dla `board` i później `digit`
+- `[REUSE]` `Contracts/ErrorApiResponse.cs`
+  - kontrakt błędu
+
+### 8.2 Application (`src/Backend/Sudoku/Application`)
+- `[NOWY]` `Abstractions/IDatasetPreparationArtifactsGateway.cs`
+  - port do odczytu artefaktów preparation
+- `[NOWY]` `Datasets/GetDatasetPreparationFoldersQuery.cs`
+  - query z `PreparationName` i `Type`
+- `[NOWY]` `Datasets/GetDatasetPreparationFoldersQueryValidator.cs`
+  - walidacja `preparationName`
+  - walidacja `Type` do dozwolonych wartości `board` / `digit`
+- `[NOWY]` `Datasets/GetDatasetPreparationFoldersQueryHandler.cs`
+  - sprawdza metadata
+  - pilnuje statusu gotowości
+  - czyta folder names przez port artefaktów
+  - buduje wynik
+- `[NOWY]` `Datasets/GetDatasetPreparationFoldersQueryResultDto.cs`
+  - wynik use-case'a
+- `[NOWY]` `Datasets/GetDatasetPreparationFoldersErrorTypes.cs`
+  - stałe `errorType`
+- `[NOWY]` `Datasets/DatasetPreparationArtifactsNotReadyException.cs`
+  - wyjątek semantyczny `409`
+- `[NOWY]` `Datasets/DatasetPreparationNameValidationRules.cs`
+  - współdzielone reguły walidacji `preparationName` dla kolejnych endpointów `UC-18`
+- `[REUSE]` `Abstractions/IDatasetPreparationsGateway.cs`
+  - sprawdzenie istnienia preparation i statusu
+- `[REUSE]` `Datasets/DatasetPreparationMetadataDto.cs`
+  - źródło statusu i wybranych sources
+- `[REUSE]` `Datasets/DatasetPreparationNotFoundException.cs`
+  - semantyka `404`
+- `[REUSE]` `Datasets/GetDatasetPreparationDetailsQueryValidator.cs`
+  - jako wzorzec; po dodaniu `DatasetPreparationNameValidationRules` można z niego skorzystać również tutaj przy późniejszym refactorze
+
+### 8.3 Domain / Models (`src/Backend/Sudoku/Models`)
+- `[REUSE]` `Models/Datasets/DatasetPreparationStatus.cs`
+  - źródło nazw statusów i `IsTerminal()`
+- `[BRAK NOWYCH PLIKÓW]`
+  - endpoint nie wnosi nowego modelu domenowego
+
+### 8.4 Infrastructure (`src/Backend/Sudoku/Infrastructure`)
+- `[NOWY]` `Storage/DatasetPreparationArtifactsGateway.cs`
+  - implementacja portu artefaktów
+  - odczyt `folders.json` przez `IFileStorageGateway`
+  - mapowanie JSON do `IReadOnlyList<string>`
+- `[MODYFIKACJA]` `DependencyInjection.cs`
+  - rejestracja `IDatasetPreparationArtifactsGateway`
+- `[REUSE]` `Storage/LocalFileStorageGateway.cs`
+  - bez zmian, jako adapter niskiego poziomu
+- `[REUSE]` `Application/Datasets/DatasetsPreparationOptions.cs`
+  - źródło `PreparationsDirectoryPath`
+
+### 8.5 Konfiguracja i workflow
+- `[REUSE]` `Sudoku/appsettings.local.json`
+  - lokalny `PreparationsDirectoryPath` jest ustawiony na sztywno
+- `[REUSE]` `Sudoku/appsettings.production.json`
+  - ma placeholder `BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH`
+- `[MODYFIKACJA WARUNKOWA]` `.github/workflows/backend-cd.yml`
+  - nie z powodu nowego endpointu,
+  - tylko po to, by domknąć już istniejący placeholder `PreparationsDirectoryPath`, jeśli nadal nie jest podstawiany
+
+### 8.6 Testy (`src/Backend/Sudoku/Application.Tests`)
+- `[NOWY]` `GetDatasetPreparationFoldersQueryHandlerTests.cs`
+  - testy query handlera
+- `[NOWY]` `GetDatasetPreparationFoldersQueryValidatorTests.cs`
+  - testy walidacji
+- `[MODYFIKACJA]` `DatasetsControllerTests.cs`
+  - testy nowej akcji HTTP
+- `[REUSE]` istniejący wzorzec test doubles ze `GetDatasetPreparationDetailsQueryHandlerTests.cs`
+  - stub gateway metadata
+  - stub sender
+
+## 9) Przepływ w obrębie backendu
+1. `FE` wywołuje `GET /api/datasets/preparations/{preparationName}/board/folders`.
+2. Middleware autoryzacji z `UC-13` weryfikuje token.
+3. `DatasetsController.GetPreparationBoardFoldersAsync(...)` binduje `preparationName`.
+4. Kontroler wysyła `GetDatasetPreparationFoldersQuery(preparationName, "board")`.
+5. `ValidationBehavior` uruchamia walidator query.
+6. `GetDatasetPreparationFoldersQueryHandler.Handle(...)` odczytuje metadata przez `IDatasetPreparationsGateway.GetByNameAsync(...)`.
+7. Jeśli metadata nie istnieją:
+  - handler rzuca `DatasetPreparationNotFoundException`.
+8. Jeśli preparation istnieje, handler sprawdza status:
+  - `completed` -> można czytać manifest,
+  - `queued` / `running` / `failed` -> `DatasetPreparationArtifactsNotReadyException`.
+9. Handler wywołuje `IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync(preparationName, "board")`.
+10. Adapter infrastruktury czyta `{PreparationsDirectoryPath}/{preparationName}/board/folders.json`.
+11. Handler buduje `GetDatasetPreparationFoldersQueryResultDto`.
+12. Kontroler mapuje wynik do `DatasetPreparationFoldersApiResponse`.
+13. API zwraca `200 OK`.
+
+## 10) Główne funkcje
+- `DatasetsController.GetPreparationBoardFoldersAsync(...)`
+- `DatasetsController.ToDatasetPreparationFoldersApiResponse(...)`
+- `GetDatasetPreparationFoldersQueryHandler.Handle(...)`
+- `GetDatasetPreparationFoldersQueryValidator.Validate(...)`
+- `DatasetPreparationNameValidationRules.AddRules(...)`
+- `GetDatasetPreparationFoldersQueryHandler.EnsurePreparationExists(...)`
+- `GetDatasetPreparationFoldersQueryHandler.EnsurePreparationCompleted(...)`
+- `GetDatasetPreparationFoldersQueryHandler.BuildResult(...)`
+- `IDatasetPreparationsGateway.GetByNameAsync(...)`
+- `IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync(...)`
+- `DatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync(...)`
+- `DatasetPreparationArtifactsGateway.BuildFoldersManifestPath(...)`
+
+## 11) Wyjątki, fallbacki i zachowanie błędowe
+
+### 11.1 Publiczne statusy HTTP
+- `200 OK`
+  - preparation istnieje,
+  - ma status `completed`,
+  - manifest jest poprawny
+- `400 Bad Request`
+  - `preparationName` pusty
+  - `preparationName` zawiera niedozwolone znaki
+- `401 Unauthorized`
+  - brak poprawnej autoryzacji admina
+- `404 Not Found`
+  - preparation o podanej nazwie nie istnieje
+- `409 Conflict`
+  - preparation istnieje, ale nie jest gotowe do przeglądania artefaktów `board`
+- `500 Internal Server Error`
+  - błąd I/O
+  - brak uprawnień do odczytu storage
+  - uszkodzony `folders.json`
+  - brak `board/folders.json` dla preparation `completed`
+  - niespójność runtime storage
+
+### 11.2 Rekomendowane `errorType`
+- `invalid_dataset_preparation_name`
+- `dataset_preparation_not_found`
+- `dataset_preparation_artifacts_not_ready`
+- `dataset_preparation_folders_read_failed`
+
+### 11.3 Fallbacki
+- Jeśli `folders.json` zawiera pustą listę:
+  - zwrócić `200 OK`
+  - `items: []`
+  - `totalCount: 0`
+- Jeśli preparation ma tylko źródła `digit`, a `board/folders.json` jest poprawnym pustym manifestem:
+  - zwrócić `200 OK`
+- Jeśli kolejność wpisów w `folders.json` jest deterministyczna:
+  - zachować ją bez zmian
+
+### 11.4 Czego nie robimy jako fallback
+- Nie odbudowujemy listy z samych nazw katalogów pod `board/`.
+- Nie próbujemy zgadnąć listy z `metadata.Sources`.
+- Nie odpytywujemy `ML`, żeby sprawdzić, czy preparation jest gotowe.
+- Nie zwracamy `200 []` dla statusu `queued`, `running` albo `failed`, bo ukrywałoby to stan workflow.
+- Nie traktujemy braku manifestu dla `completed` jako `404`, bo preparation istnieje.
+
+### 11.5 Sytuacje graniczne
+- preparation istnieje, ale ma status `running`
+  - `409`
+- preparation istnieje, ma status `failed`
+  - `409`
+- preparation istnieje, ma status `completed`, ale manifest nie istnieje
+  - `500`
+- preparation istnieje, ma status `completed`, ale JSON jest uszkodzony
+  - `500`
+
+## 12) Specyficzna logika i pseudokod
+
+### 12.1 Pseudokod handlera
+
+```text
+handleGetDatasetPreparationFolders(query):
+  validate(query.preparationName, query.type)
+
+  metadata = datasetPreparationsGateway.getByName(query.preparationName)
+  if metadata is null:
+    throw dataset_preparation_not_found
+
+  if metadata.status != "completed":
+    throw dataset_preparation_artifacts_not_ready
+
+  items = datasetPreparationArtifactsGateway.getSourceFolderNames(
+    query.preparationName,
+    query.type
+  )
+
+  return {
+    preparationName: metadata.preparationName,
+    type: query.type,
+    items: items,
+    totalCount: items.length
+  }
+```
+
+### 12.2 Pseudokod adaptera artefaktów
+
+```text
+getSourceFolderNames(preparationName, sourceType):
+  relativeDirectory = combine(preparationName, sourceType)
+  fileName = "folders.json"
+
+  stream = fileStorageGateway.openRead(preparationsRoot, relativeDirectory + "/" + fileName)
+  items = deserialize string[] from stream
+
+  if items is null:
+    throw invalid_data
+
+  return items
+```
+
+### 12.3 Pseudokod walidacji
+
+```text
+validateQuery(preparationName, type):
+  validatePreparationName(preparationName)
+
+  if type is null or whitespace:
+    invalid_dataset_preparation_type
+
+  if type not in ["board", "digit"]:
+    invalid_dataset_preparation_type
+```
+
+### 12.4 Ważna logika specyficzna
+- Status readiness ma być oceniany na podstawie metadata preparation, a nie na podstawie obecności pliku.
+- Lista folderów ma pochodzić z manifestu, a nie z `metadata.Sources`.
+- `board/folders.json` jest artefaktem runtime, ale kontraktowo należy do oficjalnego workflow `UC-18` i `UC-19`, więc brak pliku dla `completed` to błąd systemowy, nie brak zasobu.
+
+## 13) Mermaid flowchart - flow modeli
+
+```mermaid
+flowchart TD
+    A["route preparationName<br/>DatasetsController.GetPreparationBoardFoldersAsync()<br/>parametr sciezki FE"] --> B["GetDatasetPreparationFoldersQuery<br/>GetPreparationBoardFoldersAsync()<br/>query aplikacyjne z type=board"]
+    B --> C["DatasetPreparationMetadataDto<br/>IDatasetPreparationsGateway.GetByNameAsync()<br/>metadata preparation i status"]
+    C --> D["IReadOnlyList<string><br/>IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync()<br/>lista nazw z folders.json"]
+    D --> E["GetDatasetPreparationFoldersQueryResultDto<br/>GetDatasetPreparationFoldersQueryHandler.Handle()<br/>wynik use-case"]
+    E --> F["DatasetPreparationFoldersApiResponse<br/>ToDatasetPreparationFoldersApiResponse()<br/>publiczna odpowiedz FE"]
+```
+
+## 14) Mermaid flowchart - logika aplikacji z funkcjami
+
+```mermaid
+flowchart TD
+    A["DatasetsController.GetPreparationBoardFoldersAsync()<br/>odbiera GET /api/datasets/preparations/{preparationName}/board/folders"] --> B["GetDatasetPreparationFoldersQueryValidator.Validate()<br/>waliduje preparationName i type"]
+    B --> C["GetDatasetPreparationFoldersQueryHandler.Handle()<br/>koordynuje odczyt folder manifests"]
+    C --> D["IDatasetPreparationsGateway.GetByNameAsync()<br/>czyta preparation.metadata.json"]
+    D --> E["GetDatasetPreparationFoldersQueryHandler.EnsurePreparationExists()<br/>mapuje null na not found"]
+    E --> F["GetDatasetPreparationFoldersQueryHandler.EnsurePreparationCompleted()<br/>pilnuje gotowosci artefaktow"]
+    F --> G["IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync()<br/>czyta board/folders.json"]
+    G --> H["GetDatasetPreparationFoldersQueryHandler.BuildResult()<br/>ustala items i totalCount"]
+    H --> I["DatasetsController.ToDatasetPreparationFoldersApiResponse()<br/>mapuje DTO do kontraktu HTTP"]
+    I --> J["DatasetsController.GetPreparationBoardFoldersAsync()<br/>zwraca 200 OK"]
+```
+
+## 15) Logging
+
+### 15.1 `Information`
+- rozpoczęto odczyt listy folderów preparation
+- zakończono odczyt listy folderów preparation
+- w logu wystarczą:
+  - `preparationName`
+  - `type`
+  - `totalCount`
+
+### 15.2 `Warning`
+- preparation nie istnieje
+- preparation istnieje, ale nie jest gotowe do odczytu artefaktów
+- opcjonalnie:
+  - pusty manifest `board/folders.json`, jeśli zespół uzna to za sygnał diagnostyczny
+
+### 15.3 `Error`
+- błąd odczytu `board/folders.json`
+- błąd deserializacji manifestu
+- brak manifestu dla preparation `completed`
+
+### 15.4 Guardraile logowania
+- nie logować całej zawartości `folders.json`
+- nie logować pełnych ścieżek systemowych w odpowiedziach HTTP
+- nie logować każdego elementu `items` osobno przy poprawnym `GET`
+- nie spamować logów ostrzeżeniami dla każdego odpytywania preparation w statusie `running`
+- preferować pola:
+  - `preparationName`
+  - `type`
+  - `status`
+  - `errorType`
+
+## 16) Workflow GitHub i konfiguracja runtime
+
+### 16.1 Czy endpoint wymaga nowych zmian konfiguracyjnych
+- Sam endpoint nie wymaga:
+  - nowych opcji `appsettings`,
+  - nowych sekretów,
+  - nowych zmiennych workflow,
+  - nowego deployu `ML`.
+
+### 16.2 Co już musi istnieć
+- Lokalnie:
+  - `appsettings.local.json` ma ustawić `DatasetsPreparation.PreparationsDirectoryPath` na stałą ścieżkę developerską.
+- Produkcyjnie:
+  - workflow ma podstawiać `DatasetsPreparation.PreparationsDirectoryPath` do `appsettings.production.json`.
+
+### 16.3 Ważna uwaga do obecnego workflow
+- W `appsettings.production.json` istnieje placeholder:
+  - `BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH`
+- Obecny `backend-cd.yml` wygląda na niedomknięty dla tego pola:
+  - nie waliduje tej zmiennej,
+  - nie podstawia jej do sekcji `DatasetsPreparation`.
+- Dlatego w planie należy zapisać:
+  - jeśli luka nadal istnieje w momencie implementacji, trzeba ją naprawić jako techniczny prerequisite do działania wszystkich endpointów opartych o preparation storage,
+  - nie jest to nowa potrzeba stworzona przez ten endpoint, tylko domknięcie wcześniejszego kontraktu środowiskowego.
+
+### 16.4 Reguła operacyjna
+- Workflow może modyfikować `appsettings.production.json`.
+- Lokalnie ścieżki pozostają wpisane na sztywno w `appsettings.local.json`.
+- Deploy nie może nadpisywać `shared/data`, bo tam żyją manifesty runtime.
+
+## 17) Inne istotne reguły
+- Endpoint ma zachować kompatybilność z późniejszym `GET /api/datasets/preparations/{preparationName}/digit/folders`.
+- `type = "board"` jest częścią publicznego kontraktu odpowiedzi i nie może być pomijane.
+- Nie wolno zmieniać istniejących nazw klas i pól, które są już wystawione lub używane przez wcześniejsze historyjki.
+- `preparationName` pozostaje jedynym identyfikatorem preparation w route dla tego endpointu.
+- `items` mają reprezentować logiczne źródła, a nie pojedyncze foldery plansz.
+- Nie rozszerzać teraz odpowiedzi o dodatkowe pola typu `status`, `warnings` albo `sourceCount`, bo to jest rola innych endpointów.
+
+## 18) Kolejność implementacji kodu dla historyjki
+1. Dodać `DatasetPreparationNameValidationRules`.
+2. Dodać `IDatasetPreparationArtifactsGateway`.
+3. Dodać `GetDatasetPreparationFoldersQuery`.
+4. Dodać `GetDatasetPreparationFoldersQueryValidator`.
+5. Dodać `GetDatasetPreparationFoldersErrorTypes`.
+6. Dodać `DatasetPreparationArtifactsNotReadyException`.
+7. Dodać `GetDatasetPreparationFoldersQueryResultDto`.
+8. Dodać `DatasetPreparationArtifactsGateway`.
+9. Zarejestrować nowy gateway w `DependencyInjection`.
+10. Dodać `DatasetPreparationFoldersApiResponse`.
+11. Rozszerzyć `DatasetsController` o `GET /api/datasets/preparations/{preparationName}/board/folders`.
+12. Dodać mapowanie `ValidationException -> 400`.
+13. Dodać mapowanie `DatasetPreparationNotFoundException -> 404`.
+14. Dodać mapowanie `DatasetPreparationArtifactsNotReadyException -> 409`.
+15. Dodać mapowanie błędów I/O i JSON -> `500`.
+16. Dodać testy validatora.
+17. Dodać testy handlera.
+18. Rozszerzyć testy kontrolera.
+19. Jeśli nadal istnieje luka produkcyjna, domknąć wiring `BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH` w `backend-cd.yml`.
+20. Manualnie zweryfikować scenariusze `completed`, `running`, `failed`, `404`, pusty manifest i uszkodzony manifest.
+
+## 19) Guardraile implementacyjne
+- Nie czytać `board/folders.json` bezpośrednio w kontrolerze.
+- Nie skanować katalogów jako fallback.
+- Nie rozszerzać `IDatasetPreparationsGateway` o artefakty runtime.
+- Nie odpytywać `ML`.
+- Nie sortować `items` po stronie `BE`, jeśli manifest ma już kolejność deterministyczną.
+- Nie zwracać `200 []` dla preparation niegotowego.
+- Nie hardcodować ścieżek lokalnych ani produkcyjnych w kodzie.
+- Nie mapować błędów storage na `404`, jeśli preparation istnieje, ale artefakt jest uszkodzony lub zaginął.
+- Nie przenosić logiki gotowości preparation do `Infrastructure`.
+
+## 20) Zależności pomiędzy historyjkami
+- `UC-13`
+  - dostarcza autoryzację admina
+- `UC-17 POST /api/datasets/preparations`
+  - tworzy metadata preparation i inicjuje workflow, który prowadzi do pojawienia się artefaktów
+- `UC-17 GET /api/datasets/preparations`
+  - pozwala użytkownikowi wybrać preparation
+- `UC-17 GET /api/datasets/preparations/{preparationName}`
+  - pozwala sprawdzić status przed wejściem w foldery
+- `UC-18`
+  - ten endpoint jest jego pierwszym technicznym krokiem po wyborze preparation
+- `UC-19`
+  - ten sam kontrakt folderów będzie reuse'owany przy dalszym wyborze źródeł do budowy `.npz`
+
+## 21) Plan testów minimum
+
+### 21.1 Unit - validator
+- pusty `preparationName` -> `400`
+- `preparationName` z `..` -> `400`
+- `preparationName` z separatorem ścieżki -> `400`
+- `type = board` -> walidacja przechodzi
+- `type = digit` -> walidacja przechodzi
+- nieobsługiwany `type` -> `400`
+
+### 21.2 Unit - handler
+- preparation `completed` + poprawny manifest -> poprawne `items` i `totalCount`
+- preparation `completed` + pusty manifest -> `items = []`, `totalCount = 0`
+- preparation nie istnieje -> `DatasetPreparationNotFoundException`
+- preparation `queued` -> `DatasetPreparationArtifactsNotReadyException`
+- preparation `running` -> `DatasetPreparationArtifactsNotReadyException`
+- preparation `failed` -> `DatasetPreparationArtifactsNotReadyException`
+- handler zachowuje kolejność wpisów z manifestu
+
+### 21.3 API
+- poprawny odczyt -> `200 OK`
+- brak autoryzacji -> `401`
+- niepoprawny `preparationName` -> `400`
+- brak preparation -> `404`
+- preparation niegotowe -> `409`
+- `IOException` z gateway -> `500`
+- `JsonException` albo `InvalidDataException` z adaptera artefaktów -> `500`
+
+### 21.4 Manual smoke
+- `completed` z dwoma źródłami `board` -> lista dwóch wpisów
+- `completed` bez źródeł `board` -> pusta lista
+- `running` -> `409`
+- `failed` -> `409`
+- nieistniejąca nazwa -> `404`
+- uszkodzony `board/folders.json` -> `500`
+
+## 22) Podsumowanie decyzji architektonicznych
+- Endpoint ma być cienkim odczytem HTTP nad istniejącym bytem preparation i nowym, małym portem artefaktów runtime.
+- `IDatasetPreparationsGateway` zostaje gatewayem metadata i nie powinien być przeciążany logiką `folders.json`.
+- Nowy port `IDatasetPreparationArtifactsGateway` jest uzasadniony, bo daje reuse dla:
+  - `board/folders`
+  - `digit/folders`
+  - późniejszych endpointów plikowych `UC-18`
+- Readiness należy oceniać przez `metadata.Status`, a samą listę pobierać wyłącznie z `board/folders.json`.
+- Dla preparation niegotowego najlepszą semantyką publiczną jest `409 Conflict`.
+- Dla preparation `completed` z brakującym lub uszkodzonym manifestem należy zwrócić `500`, bo to błąd spójności runtime.
+- Nowe zmiany workflow nie są wymagane przez sam endpoint, ale plan musi odnotować i ewentualnie domknąć istniejący wiring `PreparationsDirectoryPath` w produkcyjnym `backend-cd.yml`.

--- a/.ai/implementation-plan/be/uc-18-be-get-api-datasets-preparations-preparation-name-board-source-name-files-board-folder-name-image.md
+++ b/.ai/implementation-plan/be/uc-18-be-get-api-datasets-preparations-preparation-name-board-source-name-files-board-folder-name-image.md
@@ -1,0 +1,727 @@
+# UC-18-BE - Plan implementacyjny dla `GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}/image`
+
+## 1) Przeznaczenie endpointa
+- Endpoint zwraca obraz preview pojedynczej planszy `board` z przygotowania datasetu.
+- W `UC-18` jest to krok wykonywany po:
+  - wyborze preparation,
+  - wyborze `board` source,
+  - pobraniu listy `boardFolderName` z `board/{sourceName}/file.json`.
+- Endpoint służy wyłącznie do podglądu artefaktu `corrected-board.png`.
+- Endpoint jest `read-only`:
+  - nie uruchamia preprocessingu,
+  - nie wywołuje `ML`,
+  - nie skanuje katalogów jako źródła prawdy,
+  - nie modyfikuje manifestów ani metadata.
+- Publiczna odpowiedź ma reuse'ować istniejący kontrakt backendu dla obrazów:
+  - `ImageApiResponse`
+  - pola: `mimeType`, `base64`
+- Nie tworzymy nowego publicznego kontraktu typu `fileName/contentType/base64Content`, bo obowiązują wcześniejsze kontrakty backendu.
+
+## 2) Zakres i główne założenia
+- Plan dotyczy wyłącznie warstwy `BE` w `src/Backend/Sudoku`.
+- Nie sugerujemy się aktualnym stanem `FE` i `ML`, poza obowiązującymi kontraktami, layoutem artefaktów i wcześniejszymi historyjkami.
+- Architektura ma pozostać zgodna z zasadami projektu:
+  - `Api` cienkie,
+  - `Application` zawiera logikę use-case'a,
+  - `Infrastructure` realizuje I/O i szczegóły storage,
+  - `Models` bez nowych bytów, jeśli nie ma realnej domenowej potrzeby.
+- Źródłem prawdy dla listy plansz jest manifest:
+  - `{PreparationsDirectoryPath}/{preparationName}/board/{sourceName}/file.json`
+- Źródłem danych obrazu jest artefakt:
+  - `{PreparationsDirectoryPath}/{preparationName}/board/{sourceName}/{boardFolderName}/corrected-board.png`
+- Nie wolno traktować samego istnienia katalogu `{boardFolderName}` jako potwierdzenia zasobu.
+- Najpierw trzeba potwierdzić, że:
+  - preparation istnieje,
+  - preparation ma status `completed`,
+  - `sourceName` istnieje w `board/folders.json`,
+  - `boardFolderName` istnieje w `board/{sourceName}/file.json`.
+
+## 3) Co już istnieje i co należy reuse'ować
+
+### 3.1 Istniejące elementy backendu
+- `Sudoku/Controllers/DatasetsController.cs`
+  - ma już:
+    - `GET /api/datasets/preparations`
+    - `GET /api/datasets/preparations/{preparationName}`
+    - `GET /api/datasets/preparations/{preparationName}/board/folders`
+    - `GET /api/datasets/preparations/{preparationName}/digit/folders`
+    - `GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files`
+  - zawiera już helper:
+    - `BuildDatasetPreparationBoardImageEndpoint(...)`
+- `Application/Abstractions/IDatasetPreparationsGateway.cs`
+  - odczyt metadata preparation.
+- `Application/Abstractions/IDatasetPreparationArtifactsGateway.cs`
+  - odczyt manifestów preparation:
+    - `GetSourceFolderNamesAsync(...)`
+    - `GetBoardFileNamesAsync(...)`
+- `Application/Datasets/GetDatasetPreparationBoardFilesQueryHandler.cs`
+  - gotowy wzorzec logiki:
+    - sprawdzenie preparation,
+    - sprawdzenie `completed`,
+    - walidacja `sourceName` przez `board/folders.json`,
+    - odczyt `board/{sourceName}/file.json`
+- `Application/Datasets/DatasetPreparationNameValidationRules.cs`
+  - wspólna walidacja `preparationName`.
+- `Application/Datasets/DatasetPreparationSourceNameValidationRules.cs`
+  - wspólna walidacja `sourceName`.
+- `Application/Datasets/DatasetPreparationNotFoundException.cs`
+  - semantyka `404`.
+- `Application/Datasets/DatasetPreparationSourceNotFoundException.cs`
+  - semantyka `404` dla `sourceName`.
+- `Application/Datasets/DatasetPreparationArtifactsNotReadyException.cs`
+  - semantyka `409`.
+- `Infrastructure/Storage/DatasetPreparationArtifactsGateway.cs`
+  - czyta już manifesty `folders.json` i `file.json`.
+- `Infrastructure/Storage/LocalFileStorageGateway.cs`
+  - ma bezpieczne `OpenReadAsync(...)`.
+- `Sudoku/Contracts/ImageApiResponse.cs`
+  - istniejący publiczny kontrakt obrazów:
+    - `mimeType`
+    - `base64`
+- `.github/workflows/backend-cd.yml`
+  - już waliduje i podstawia:
+    - `BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH`
+
+### 3.2 Wniosek architektoniczny
+- Nie tworzymy nowego gatewaya tylko do `corrected-board.png`.
+- Nie używamy `IFileStorageGateway` bezpośrednio w kontrolerze ani w handlerze.
+- Rozszerzamy istniejący `IDatasetPreparationArtifactsGateway` o generyczny odczyt artefaktu z folderu planszy.
+- Dzięki temu ten sam mechanizm będzie można reuse'ować także przy kolejnych use-case'ach operujących na artefaktach w folderze planszy.
+
+### 3.3 Czego nie należy tworzyć
+- Nie tworzyć osobnego:
+  - `IDatasetPreparationBoardImageGateway`
+  - `IDatasetPreparationBoardPreviewGateway`
+  - `DatasetPreparationBoardImageApiResponse`
+- Nie zmieniać istniejącego `ImageApiResponse`.
+- Nie przenosić logiki statusu preparation do `Infrastructure`.
+- Nie opierać się na stanie `FE` ani na bezpośrednim dostępie do `ML`.
+
+## 4) Kontrakty API FE i ML
+
+### 4.1 FE -> BE
+- Metoda i ścieżka:
+  - `GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}/image`
+- Route params:
+  - `preparationName: string`
+  - `sourceName: string`
+  - `boardFolderName: string`
+- Query string:
+  - brak
+- Body:
+  - brak
+- Autoryzacja:
+  - taka sama jak dla innych endpointów administracyjnych z `UC-13`
+
+### 4.2 BE -> FE
+- `200 OK` -> `ImageApiResponse`
+- `400 Bad Request` -> `ErrorApiResponse`
+- `401 Unauthorized` -> `ErrorApiResponse`
+- `404 Not Found` -> `ErrorApiResponse`
+- `409 Conflict` -> `ErrorApiResponse`
+- `500 Internal Server Error` -> `ErrorApiResponse`
+
+`ImageApiResponse`:
+- `mimeType: string`
+- `base64: string`
+
+Przykład:
+
+```json
+{
+  "mimeType": "image/png",
+  "base64": "iVBORw0KGgoAAAANSUhEUgAA..."
+}
+```
+
+### 4.3 BE -> ML
+- Brak nowej komunikacji.
+- Endpoint działa wyłącznie na lokalnych artefaktach runtime preparation.
+
+### 4.4 ML -> BE
+- Brak nowej komunikacji HTTP.
+- Jedyna zależność pośrednia: wcześniejszy workflow preparation musi zapisać `corrected-board.png`.
+
+### 4.5 Plikowy kontrakt wejściowy dla BE
+- Manifest źródeł:
+  - `{PreparationsDirectoryPath}/{preparationName}/board/folders.json`
+- Manifest plansz:
+  - `{PreparationsDirectoryPath}/{preparationName}/board/{sourceName}/file.json`
+- Artefakt obrazu:
+  - `{PreparationsDirectoryPath}/{preparationName}/board/{sourceName}/{boardFolderName}/corrected-board.png`
+
+Format `file.json`:
+
+```json
+[
+  "Image1",
+  "Image2",
+  "Image1079"
+]
+```
+
+### 4.6 Reguły kontraktowe
+- `boardFolderName` musi pochodzić z `file.json`, a nie z heurystyki po filesystemie.
+- `mimeType` dla tego endpointu ma być `image/png`, bo kontrakt artefaktu jest stały: `corrected-board.png`.
+- `BE` zwraca obraz inline jako base64, zgodnie z obowiązującym kontraktem `ImageApiResponse`.
+
+## 5) Model API wejściowy i wyjściowy w komunikacji z FE i ML
+
+### 5.1 FE -> BE
+- wejście:
+  - `preparationName` w route
+  - `sourceName` w route
+  - `boardFolderName` w route
+- brak body
+
+### 5.2 BE -> FE
+- `[REUSE]` `src/Backend/Sudoku/Sudoku/Contracts/ImageApiResponse.cs`
+  - `mimeType`
+  - `base64`
+- `[REUSE]` `src/Backend/Sudoku/Sudoku/Contracts/ErrorApiResponse.cs`
+  - `errorType`
+  - `message`
+
+### 5.3 BE -> ML
+- brak komunikacji
+
+### 5.4 ML -> BE
+- brak komunikacji HTTP
+
+### 5.5 Wniosek kontraktowy
+- Dla tego endpointu obowiązującym kontraktem odpowiedzi jest już istniejący `ImageApiResponse`.
+- To jest ważniejsze niż opis poglądowy w historyjce, bo użytkownik wymaga zachowania wcześniejszych kontraktów i nazw.
+
+## 6) Zachowanie per warstwa
+
+### 6.1 API
+- Nowa akcja w `DatasetsController`:
+  - `[HttpGet("preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}/image")]`
+- Kontroler:
+  - binduje `preparationName`, `sourceName`, `boardFolderName`,
+  - wysyła `GetDatasetPreparationBoardImageQuery` do `MediatR`,
+  - mapuje wynik do `ImageApiResponse`,
+  - mapuje wyjątki na `400/404/409/500`.
+- `Api` nie:
+  - czyta plików,
+  - nie buduje ścieżek filesystemu,
+  - nie sprawdza statusu preparation,
+  - nie odpytuje `ML`.
+
+### 6.2 Application
+- `Application` odpowiada za:
+  - walidację `preparationName`,
+  - walidację `sourceName`,
+  - walidację `boardFolderName`,
+  - sprawdzenie istnienia preparation,
+  - sprawdzenie statusu `completed`,
+  - sprawdzenie, czy `sourceName` istnieje w `board/folders.json`,
+  - sprawdzenie, czy `boardFolderName` istnieje w `board/{sourceName}/file.json`,
+  - zlecenie odczytu artefaktu `corrected-board.png` przez port,
+  - konwersję do `base64`,
+  - zbudowanie DTO wyniku.
+- `Application` nie:
+  - wykonuje niskopoziomowego I/O,
+  - nie używa `File.*` ani `Directory.*`,
+  - nie tworzy odpowiedzi HTTP,
+  - nie skanuje katalogów jako fallback.
+
+### 6.3 Models / Domain
+- Brak potrzeby dodawania nowego modelu domenowego.
+- Reuse:
+  - `Models/Datasets/DatasetPreparationStatus.cs`
+- Ten endpoint jest read-only use-case'em nad istniejącym preparation.
+
+### 6.4 Infrastructure
+- `Infrastructure` ma:
+  - zbudować ścieżkę do folderu planszy,
+  - otworzyć wskazany artefakt przez `IFileStorageGateway.OpenReadAsync(...)`,
+  - nie wnikać w semantykę HTTP ani workflow.
+- Najlepiej dodać generyczną metodę w gatewayu artefaktów, np.:
+  - `OpenBoardArtifactReadAsync(string preparationName, string sourceName, string boardFolderName, string artifactFileName, CancellationToken cancellationToken = default)`
+- Dzięki temu `Infrastructure` pozostaje implementacją techniczną, a `Application` decyduje, że dla tego use-case'a żądanym artefaktem jest `corrected-board.png`.
+
+## 7) Pliki per warstwa i odpowiedzialności
+
+### 7.1 API (`src/Backend/Sudoku/Sudoku`)
+- `[MODYFIKACJA]` `Controllers/DatasetsController.cs`
+  - dodać akcję `GetPreparationBoardImageAsync(string? preparationName, string? sourceName, string? boardFolderName, CancellationToken)`
+  - wysłać `GetDatasetPreparationBoardImageQuery`
+  - mapować wynik do `ImageApiResponse`
+  - mapować:
+    - `ValidationException -> 400`
+    - `DatasetPreparationNotFoundException -> 404`
+    - `DatasetPreparationSourceNotFoundException -> 404`
+    - `DatasetPreparationBoardFileNotFoundException -> 404`
+    - `DatasetPreparationArtifactsNotReadyException -> 409`
+    - `IOException | UnauthorizedAccessException | InvalidDataException | JsonException | FileStorageItemNotFoundException -> 500`
+- `[REUSE]` `Contracts/ImageApiResponse.cs`
+  - publiczny kontrakt odpowiedzi z obrazem
+- `[REUSE]` `Contracts/ErrorApiResponse.cs`
+  - wspólny kontrakt błędu
+
+### 7.2 Application (`src/Backend/Sudoku/Application`)
+- `[NOWY]` `Datasets/GetDatasetPreparationBoardImageQuery.cs`
+  - query MediatR
+- `[NOWY]` `Datasets/GetDatasetPreparationBoardImageQueryValidator.cs`
+  - walidacja `preparationName`, `sourceName`, `boardFolderName`
+- `[NOWY]` `Datasets/GetDatasetPreparationBoardImageQueryHandler.cs`
+  - logika use-case'a obrazu
+- `[NOWY]` `Datasets/GetDatasetPreparationBoardImageQueryResultDto.cs`
+  - wynik use-case'a:
+    - `mimeType`
+    - `base64`
+- `[NOWY]` `Datasets/GetDatasetPreparationBoardImageErrorTypes.cs`
+  - stałe `errorType`
+- `[NOWY]` `Datasets/DatasetPreparationBoardFolderNameValidationRules.cs`
+  - wspólna walidacja `boardFolderName`
+  - do reuse także przez późniejszy `DELETE /.../{boardFolderName}`
+- `[NOWY]` `Datasets/DatasetPreparationBoardFileNotFoundException.cs`
+  - semantyczny `404` dla `boardFolderName`, gdy wpis nie istnieje w `file.json`
+- `[NOWY]` `Datasets/DatasetPreparationBoardArtifactNames.cs`
+  - stała:
+    - `CorrectedBoardFileName = "corrected-board.png"`
+- `[MODYFIKACJA]` `Abstractions/IDatasetPreparationArtifactsGateway.cs`
+  - dodać generyczne otwieranie artefaktu z folderu planszy:
+    - `OpenBoardArtifactReadAsync(...)`
+- `[REUSE]` `Abstractions/IDatasetPreparationsGateway.cs`
+  - odczyt metadata preparation
+- `[REUSE]` `Datasets/DatasetPreparationNameValidationRules.cs`
+  - walidacja `preparationName`
+- `[REUSE]` `Datasets/DatasetPreparationSourceNameValidationRules.cs`
+  - walidacja `sourceName`
+- `[REUSE]` `Datasets/DatasetPreparationNotFoundException.cs`
+  - `404`
+- `[REUSE]` `Datasets/DatasetPreparationSourceNotFoundException.cs`
+  - `404`
+- `[REUSE]` `Datasets/DatasetPreparationArtifactsNotReadyException.cs`
+  - `409`
+- `[REUSE]` `Datasets/DatasetsPreparationOptions.cs`
+  - typed options dla storage
+- `[REUSE]` `Datasets/GetDatasetPreparationBoardFilesQueryHandler.cs`
+  - jako wzorzec logiki weryfikacji preparation i source
+
+### 7.3 Models (`src/Backend/Sudoku/Models`)
+- `[REUSE]` `Models/Datasets/DatasetPreparationStatus.cs`
+  - źródło statusów preparation
+- `[BRAK NOWYCH PLIKÓW]`
+  - endpoint nie wnosi nowego modelu domenowego
+
+### 7.4 Infrastructure (`src/Backend/Sudoku/Infrastructure`)
+- `[MODYFIKACJA]` `Storage/DatasetPreparationArtifactsGateway.cs`
+  - zaimplementować `OpenBoardArtifactReadAsync(...)`
+  - zbudować ścieżkę:
+    - `{preparationName}/board/{sourceName}/{boardFolderName}`
+  - otworzyć przekazany plik artefaktu przez `IFileStorageGateway.OpenReadAsync(...)`
+  - nie zgadywać nazw plików
+- `[REUSE]` `Storage/LocalFileStorageGateway.cs`
+  - bezpieczny odczyt plików
+- `[REUSE]` `Storage/DatasetPreparationsGateway.cs`
+  - odczyt metadata preparation
+- `[REUSE]` `DependencyInjection.cs`
+  - brak nowego serwisu do rejestracji, tylko reuse istniejącego gatewaya artefaktów po rozszerzeniu interfejsu
+
+### 7.5 Testy (`src/Backend/Sudoku/Application.Tests`)
+- `[NOWY]` `GetDatasetPreparationBoardImageQueryHandlerTests.cs`
+  - testy handlera
+- `[NOWY]` `GetDatasetPreparationBoardImageQueryValidatorTests.cs`
+  - testy walidacji
+- `[MODYFIKACJA]` `DatasetsControllerTests.cs`
+  - testy nowej akcji HTTP
+- `[REUSE]` `GetDatasetPreparationBoardFilesQueryHandlerTests.cs`
+  - wzorzec stubów metadata/artifacts i semantyki wyjątków
+
+### 7.6 Workflow i config
+- `[REUSE]` `Sudoku/appsettings.local.json`
+  - lokalna ścieżka preparation ustawiona na sztywno
+- `[REUSE]` `Sudoku/appsettings.production.json`
+  - overlay produkcyjny
+- `[REUSE]` `.github/workflows/backend-cd.yml`
+  - już podstawia `DatasetsPreparation.PreparationsDirectoryPath`
+
+## 8) Przepływ w obrębie backendu
+1. `FE` wywołuje `GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}/image`.
+2. Autoryzacja z `UC-13` przepuszcza tylko admina.
+3. `DatasetsController.GetPreparationBoardImageAsync(...)` binduje route params.
+4. Kontroler wysyła `GetDatasetPreparationBoardImageQuery(preparationName, sourceName, boardFolderName)`.
+5. `ValidationBehavior` uruchamia validator.
+6. Handler czyta metadata przez `IDatasetPreparationsGateway.GetByNameAsync(...)`.
+7. Jeśli preparation nie istnieje:
+  - `DatasetPreparationNotFoundException`
+8. Jeśli preparation nie ma statusu `completed`:
+  - `DatasetPreparationArtifactsNotReadyException`
+9. Handler czyta `board/folders.json` przez `IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync(preparationName, "board")`.
+10. Jeśli `sourceName` nie należy do listy:
+  - `DatasetPreparationSourceNotFoundException`
+11. Handler czyta `board/{sourceName}/file.json` przez `GetBoardFileNamesAsync(preparationName, sourceName)`.
+12. Jeśli `boardFolderName` nie należy do listy:
+  - `DatasetPreparationBoardFileNotFoundException`
+13. Handler otwiera `corrected-board.png` przez `OpenBoardArtifactReadAsync(...)`.
+14. Handler buforuje zawartość, konwertuje ją do base64 i buduje `GetDatasetPreparationBoardImageQueryResultDto`.
+15. Kontroler mapuje wynik do `ImageApiResponse`.
+16. API zwraca `200 OK`.
+
+## 9) Główne funkcje
+- `DatasetsController.GetPreparationBoardImageAsync(...)`
+- `DatasetsController.ToImageApiResponse(...)`
+- `GetDatasetPreparationBoardImageQueryHandler.Handle(...)`
+- `GetDatasetPreparationBoardImageQueryValidator.Validate(...)`
+- `DatasetPreparationNameValidationRules.Validate(...)`
+- `DatasetPreparationSourceNameValidationRules.Validate(...)`
+- `DatasetPreparationBoardFolderNameValidationRules.Validate(...)`
+- `GetDatasetPreparationBoardImageQueryHandler.EnsurePreparationCompleted(...)`
+- `GetDatasetPreparationBoardImageQueryHandler.EnsureBoardSourceExists(...)`
+- `GetDatasetPreparationBoardImageQueryHandler.EnsureBoardFolderExists(...)`
+- `GetDatasetPreparationBoardImageQueryHandler.ReadArtifactAsBase64Async(...)`
+- `IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync(...)`
+- `IDatasetPreparationArtifactsGateway.GetBoardFileNamesAsync(...)`
+- `IDatasetPreparationArtifactsGateway.OpenBoardArtifactReadAsync(...)`
+- `DatasetPreparationArtifactsGateway.OpenBoardArtifactReadAsync(...)`
+
+## 10) Wyjątki, fallbacki i zachowanie błędowe
+
+### 10.1 Publiczne statusy HTTP
+- `200 OK`
+  - preparation istnieje,
+  - status to `completed`,
+  - `sourceName` istnieje,
+  - `boardFolderName` istnieje w `file.json`,
+  - `corrected-board.png` jest dostępny i czytelny
+- `400 Bad Request`
+  - niepoprawny `preparationName`
+  - niepoprawny `sourceName`
+  - niepoprawny `boardFolderName`
+- `401 Unauthorized`
+  - brak poprawnej autoryzacji
+- `404 Not Found`
+  - preparation nie istnieje
+  - `sourceName` nie istnieje w `board/folders.json`
+  - `boardFolderName` nie istnieje w `board/{sourceName}/file.json`
+- `409 Conflict`
+  - preparation istnieje, ale artefakty nie są jeszcze gotowe do odczytu
+- `500 Internal Server Error`
+  - błąd I/O
+  - brak uprawnień do storage
+  - uszkodzony JSON manifestu
+  - brak `board/folders.json` lub `file.json` dla preparation `completed`
+  - `corrected-board.png` nie istnieje mimo poprawnego wpisu w `file.json`
+  - artefakt jest niespójny lub nieczytelny
+
+### 10.2 `errorType`
+- `invalid_dataset_preparation_name`
+- `invalid_dataset_preparation_source_name`
+- `invalid_dataset_preparation_board_folder_name`
+- `dataset_preparation_not_found`
+- `dataset_preparation_source_not_found`
+- `dataset_preparation_board_file_not_found`
+- `dataset_preparation_artifacts_not_ready`
+- `dataset_preparation_board_image_read_failed`
+
+### 10.3 Fallbacki dozwolone
+- Brak dodatkowych fallbacków biznesowych.
+- Jeśli obraz jest poprawny, zawsze zwracamy go inline jako `ImageApiResponse`.
+
+### 10.4 Fallbacki niedozwolone
+- Nie skanować katalogu `{boardFolderName}` w celu potwierdzenia zasobu.
+- Nie uznawać fizycznie istniejącego folderu za ważny, jeśli nie ma go w `file.json`.
+- Nie odpytywać `ML`, by ponownie wygenerować preview.
+- Nie zwracać `404`, gdy preparation istnieje, `boardFolderName` istnieje w manifeście, ale `corrected-board.png` zniknął.
+- Nie zwracać pustego obrazu, placeholdera ani `200` z pustym base64.
+
+### 10.5 Sytuacje graniczne
+- preparation istnieje, status `running`
+  - `409`
+- preparation istnieje, status `failed`
+  - `409`
+- `sourceName` istnieje w route, ale nie ma go w `board/folders.json`
+  - `404`
+- `boardFolderName` istnieje fizycznie, ale nie ma go w `file.json`
+  - `404`
+- `boardFolderName` jest w `file.json`, ale `corrected-board.png` nie istnieje
+  - `500`
+- `file.json` jest uszkodzony
+  - `500`
+
+## 11) Specyficzna logika i pseudokod
+
+### 11.1 Pseudokod handlera
+
+```text
+handle(query):
+  validate(query)
+
+  metadata = datasetPreparationsGateway.getByName(query.preparationName)
+  if metadata is null:
+    throw dataset_preparation_not_found
+
+  if metadata.status != "completed":
+    throw dataset_preparation_artifacts_not_ready
+
+  boardSources = artifactsGateway.getSourceFolderNames(query.preparationName, "board")
+  if query.sourceName not in boardSources:
+    throw dataset_preparation_source_not_found
+
+  boardFolders = artifactsGateway.getBoardFileNames(query.preparationName, query.sourceName)
+  if query.boardFolderName not in boardFolders:
+    throw dataset_preparation_board_file_not_found
+
+  stream = artifactsGateway.openBoardArtifactRead(
+    query.preparationName,
+    query.sourceName,
+    query.boardFolderName,
+    "corrected-board.png"
+  )
+
+  bytes = read_all_bytes(stream)
+
+  return {
+    mimeType: "image/png",
+    base64: convert_to_base64(bytes)
+  }
+```
+
+### 11.2 Pseudokod gatewaya artefaktów
+
+```text
+openBoardArtifactRead(preparationName, sourceName, boardFolderName, artifactFileName):
+  directoryPath = combine(
+    preparationsDirectoryPath,
+    preparationName,
+    "board",
+    sourceName,
+    boardFolderName
+  )
+
+  return fileStorageGateway.openRead(directoryPath, artifactFileName)
+```
+
+### 11.3 Pseudokod walidacji
+
+```text
+validate(query):
+  validatePreparationName(query.preparationName)
+  validateSourceName(query.sourceName)
+  validateBoardFolderName(query.boardFolderName)
+```
+
+### 11.4 Wyjątkowa logika do uwzględnienia
+- Walidacja zasobu jest dwuetapowa:
+  - najpierw logicznie przez manifest `file.json`,
+  - dopiero potem technicznie przez odczyt pliku.
+- To rozróżnienie jest kluczowe dla poprawnego mapowania:
+  - brak wpisu w manifeście -> `404`
+  - brak artefaktu dla istniejącego wpisu -> `500`
+- `corrected-board.png` jest częścią kontraktu workflow preparation, a nie dynamicznie wybieranym plikiem użytkownika.
+
+## 12) Mermaid flowchart - flow modeli
+
+```mermaid
+flowchart TD
+    A["route params<br/>DatasetsController.GetPreparationBoardImageAsync()"] --> B["GetDatasetPreparationBoardImageQuery<br/>query aplikacyjne"]
+    B --> C["DatasetPreparationMetadataDto<br/>IDatasetPreparationsGateway.GetByNameAsync()"]
+    C --> D["IReadOnlyList<string><br/>IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync()"]
+    D --> E["IReadOnlyList<string><br/>IDatasetPreparationArtifactsGateway.GetBoardFileNamesAsync()"]
+    E --> F["Stream corrected-board.png<br/>IDatasetPreparationArtifactsGateway.OpenBoardArtifactReadAsync()"]
+    F --> G["GetDatasetPreparationBoardImageQueryResultDto<br/>mimeType + base64"]
+    G --> H["ImageApiResponse<br/>publiczna odpowiedz FE"]
+```
+
+## 13) Mermaid flowchart - logika aplikacji z funkcjami
+
+```mermaid
+flowchart TD
+    A["DatasetsController.GetPreparationBoardImageAsync()"] --> B["GetDatasetPreparationBoardImageQueryValidator.Validate()"]
+    B --> C["GetDatasetPreparationBoardImageQueryHandler.Handle()"]
+    C --> D["IDatasetPreparationsGateway.GetByNameAsync()"]
+    D --> E["EnsurePreparationCompleted()"]
+    E --> F["IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync()"]
+    F --> G["EnsureBoardSourceExists()"]
+    G --> H["IDatasetPreparationArtifactsGateway.GetBoardFileNamesAsync()"]
+    H --> I["EnsureBoardFolderExists()"]
+    I --> J["IDatasetPreparationArtifactsGateway.OpenBoardArtifactReadAsync()"]
+    J --> K["ReadArtifactAsBase64Async()"]
+    K --> L["DatasetsController.ToImageApiResponse()"]
+```
+
+## 14) Logging
+
+### 14.1 `Information`
+- start:
+  - `preparationName`
+  - `sourceName`
+  - `boardFolderName`
+- success:
+  - `preparationName`
+  - `sourceName`
+  - `boardFolderName`
+  - `mimeType`
+  - opcjonalnie `imageSizeBytes`, jeśli zostanie uznane za przydatne diagnostycznie
+
+### 14.2 `Warning`
+- preparation nie istnieje
+- preparation nie jest gotowe
+- `sourceName` nie należy do preparation
+- `boardFolderName` nie należy do `file.json`
+
+### 14.3 `Error`
+- błąd odczytu `board/folders.json`
+- błąd odczytu `file.json`
+- błąd otwarcia `corrected-board.png`
+- błąd odczytu strumienia artefaktu
+
+### 14.4 Guardraile logowania
+- nie logować zawartości `base64`
+- nie logować pełnych ścieżek systemowych w odpowiedziach HTTP
+- nie logować całego `file.json`
+- nie logować każdego poprawnego odczytu z dużą liczbą dodatkowych pól
+- logi mają być lekkie i operacyjne
+
+## 15) Workflow GitHub i konfiguracja runtime
+
+### 15.1 Czy endpoint wymaga nowych zmian workflow
+- Nie.
+- Sam endpoint nie wymaga:
+  - nowych sekretów,
+  - nowych zmiennych środowiskowych,
+  - nowych plików `appsettings`,
+  - zmian po stronie `ML`.
+
+### 15.2 Co już musi istnieć
+- Lokalnie:
+  - `appsettings.local.json` ma ustawiać `DatasetsPreparation.PreparationsDirectoryPath` na stałą ścieżkę developerską.
+- Produkcyjnie:
+  - `backend-cd.yml` ma podstawiać `BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH` do `DatasetsPreparation.PreparationsDirectoryPath`.
+
+### 15.3 Stan obecny workflow
+- `backend-cd.yml` już:
+  - waliduje `BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH`
+  - wpisuje tę wartość do `appsettings.production.json`
+- W planie należy to opisać jako istniejący prerequisite, nie nową pracę.
+
+### 15.4 Reguła operacyjna
+- Workflow może modyfikować `appsettings.production.json`.
+- Lokalnie ścieżki pozostają wpisane na sztywno.
+- Deploy nie może nadpisywać `shared/data`, bo tam żyją runtime artifacts preparation.
+
+## 16) Inne istotne reguły
+- Nie zmieniać istniejących nazw klas i pól, które już są używane w backendzie.
+- Reuse'ować istniejący `ImageApiResponse`.
+- Nie zwracać pliku jako `FileStreamResult` ani surowego `image/png` response body, bo obecny backend dla obrazów używa JSON z base64.
+- Decyzja o tym, jaki artefakt ma zostać odczytany, należy do `Application`.
+- `Infrastructure` ma dostać nazwę artefaktu jako parametr i tylko go odczytać.
+- `boardFolderName` powinno dostać wspólne reguły walidacji, bo będzie reuse'owane także przez późniejsze `DELETE`.
+
+## 17) Kolejność implementacji kodu dla historyjki
+1. Dodać `DatasetPreparationBoardFolderNameValidationRules`.
+2. Dodać `DatasetPreparationBoardFileNotFoundException`.
+3. Dodać `DatasetPreparationBoardArtifactNames`.
+4. Dodać `GetDatasetPreparationBoardImageErrorTypes`.
+5. Dodać `GetDatasetPreparationBoardImageQuery`.
+6. Dodać `GetDatasetPreparationBoardImageQueryResultDto`.
+7. Dodać `GetDatasetPreparationBoardImageQueryValidator`.
+8. Rozszerzyć `IDatasetPreparationArtifactsGateway` o `OpenBoardArtifactReadAsync(...)`.
+9. Rozszerzyć `DatasetPreparationArtifactsGateway` o generyczny odczyt artefaktu z folderu planszy.
+10. Dodać `GetDatasetPreparationBoardImageQueryHandler`.
+11. Rozszerzyć `DatasetsController` o nową akcję `GET`.
+12. Dodać mapowanie DTO do `ImageApiResponse`.
+13. Dodać testy validatora.
+14. Dodać testy handlera.
+15. Rozszerzyć testy kontrolera.
+16. Wykonać smoke test dla:
+  - `completed`
+  - `running`
+  - braku preparation
+  - braku source
+  - braku boardFolderName w manifeście
+  - braku `corrected-board.png`
+
+## 18) Guardraile implementacyjne
+- Nie czytać `corrected-board.png` w kontrolerze.
+- Nie używać `IFileStorageGateway` bezpośrednio w `Application`.
+- Nie tworzyć image-specific gatewaya, jeśli wystarcza rozszerzenie istniejącego gatewaya artefaktów.
+- Nie skanować katalogów jako fallback.
+- Nie odpytywać `ML`.
+- Nie zmieniać kontraktu `ImageApiResponse`.
+- Nie mapować brakującego artefaktu dla poprawnego wpisu w manifeście na `404`.
+- Nie trzymać logiki ścieżek w kontrolerze.
+- Nie hardcodować ścieżek runtime w kodzie.
+
+## 19) Zależności pomiędzy historyjkami
+- `UC-13`
+  - dostarcza autoryzację admina
+- `UC-17 POST /api/datasets/preparations`
+  - tworzy preparation i artefakty runtime
+- `UC-17 GET /api/datasets/preparations`
+  - pozwala wybrać preparation
+- `UC-17 GET /api/datasets/preparations/{preparationName}`
+  - pozwala ocenić status preparation
+- `UC-18 GET /api/datasets/preparations/{preparationName}/board/folders`
+  - dostarcza `sourceName`
+- `UC-18 GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files`
+  - dostarcza `boardFolderName` i jest bezpośrednim poprzednikiem tego endpointu
+- `UC-18 DELETE /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}`
+  - powinien reuse'ować walidację `boardFolderName` oraz sprawdzanie istnienia wpisu w `file.json`
+- `UC-19`
+  - zależy pośrednio od zachowania spójności artefaktów preparation po `UC-18`
+
+## 20) Plan testów minimum
+
+### 20.1 Validator
+- pusty `preparationName` -> `400`
+- pusty `sourceName` -> `400`
+- pusty `boardFolderName` -> `400`
+- `preparationName` z `..` -> `400`
+- `sourceName` z separatorem ścieżki -> `400`
+- `boardFolderName` z separatorem ścieżki -> `400`
+- poprawny request -> walidacja przechodzi
+
+### 20.2 Handler
+- happy path:
+  - preparation `completed`
+  - source istnieje
+  - board folder istnieje
+  - obraz odczytany poprawnie
+- brak preparation -> `DatasetPreparationNotFoundException`
+- status `queued` / `running` / `failed` -> `DatasetPreparationArtifactsNotReadyException`
+- brak `sourceName` w `board/folders.json` -> `DatasetPreparationSourceNotFoundException`
+- brak `boardFolderName` w `file.json` -> `DatasetPreparationBoardFileNotFoundException`
+- poprawny wpis w `file.json`, ale brak artefaktu -> propagacja błędu technicznego do `500`
+- wynik zawiera:
+  - `mimeType = image/png`
+  - poprawne `base64`
+
+### 20.3 API
+- `200 OK` i poprawne mapowanie `ImageApiResponse`
+- `400` dla błędu walidacji
+- `401` bez autoryzacji
+- `404` dla braku preparation
+- `404` dla braku source
+- `404` dla braku board folderu w manifeście
+- `409` dla niegotowego preparation
+- `500` dla błędu odczytu manifestu
+- `500` dla braku `corrected-board.png`
+
+### 20.4 Manual smoke
+- poprawny preview istniejącej planszy
+- preview dla wpisu z białymi znakami lub nielegalną nazwą
+- preview dla source spoza `folders.json`
+- preview dla board spoza `file.json`
+- preview dla preparation `running`
+- preview dla brakującego `corrected-board.png`
+
+## 21) Podsumowanie decyzji architektonicznych
+- Endpoint ma być cienkim `GET` nad istniejącym workflow preparation.
+- `Application` posiada pełną logikę semantyczną:
+  - walidacje,
+  - sprawdzenie `completed`,
+  - potwierdzenie `sourceName`,
+  - potwierdzenie `boardFolderName`,
+  - konwersję do base64.
+- `Infrastructure` ma tylko odczytać wskazany artefakt z folderu planszy.
+- Najważniejsza decyzja antyduplikacyjna:
+  - rozszerzyć `IDatasetPreparationArtifactsGateway`,
+  - nie tworzyć nowego dedykowanego gatewaya obrazu.
+- Najważniejsze rozróżnienie błędów:
+  - brak wpisu w `file.json` -> `404`
+  - brak `corrected-board.png` dla istniejącego wpisu -> `500`
+- Publiczny kontrakt musi reuse'ować istniejący `ImageApiResponse`, a nie wprowadzać nowego wariantu odpowiedzi tylko dla tego endpointu.

--- a/.ai/implementation-plan/be/uc-18-be-get-api-datasets-preparations-preparation-name-board-source-name-files.md
+++ b/.ai/implementation-plan/be/uc-18-be-get-api-datasets-preparations-preparation-name-board-source-name-files.md
@@ -1,0 +1,481 @@
+# UC-18-BE - Plan implementacyjny dla `GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files?page={page}&pageSize={pageSize}`
+
+## 1) Przeznaczenie endpointa
+- Endpoint zwraca stronicowaną listę folderów plansz dla jednego źródła `board` w wybranym preparation.
+- To jest krok po `GET /api/datasets/preparations/{preparationName}/board/folders`: `FE` wybiera `sourceName`, a potem pobiera listę plansz z `board/{sourceName}/file.json`.
+- Endpoint jest `read-only`: nie wywołuje `ML`, nie uruchamia preprocessingu, nie przebudowuje manifestów i nie skanuje katalogów jako źródła prawdy.
+- Zwraca tylko dane potrzebne do listy: `boardFolderName` i `imageEndpoint`. Sam obraz pozostaje osobnym endpointem.
+
+## 2) Kluczowe założenia i zależności
+- Zakres planu obejmuje wyłącznie `BE` w `src/Backend/Sudoku`.
+- Nie sugerujemy się aktualnym stanem `FE` ani bieżącą implementacją `ML`; opieramy się na PRD, `UC-18`, obecnym backendzie i wcześniejszych kontraktach.
+- Zależności historyjek:
+  - `UC-13` daje autoryzację admina.
+  - `UC-17 POST /api/datasets/preparations` tworzy preparation i artefakty runtime.
+  - `UC-17 GET /api/datasets/preparations` oraz `GET /api/datasets/preparations/{preparationName}` dostarczają wybór i status preparation.
+  - `UC-18 GET .../board/folders` dostarcza `sourceName`.
+  - późniejsze `GET .../image` i `DELETE .../files/{boardFolderName}` będą reuse'ować ten sam obszar storage.
+- Najważniejszy wniosek: nie tworzyć nowego gatewaya tylko dla `file.json`; rozszerzyć istniejący `IDatasetPreparationArtifactsGateway`.
+
+## 3) Co już istnieje i co należy reuse'ować
+- `Sudoku/Controllers/DatasetsController.cs`
+  - istnieją już endpointy:
+    - `GET /api/datasets/preparations`
+    - `GET /api/datasets/preparations/{preparationName}`
+    - `GET /api/datasets/preparations/{preparationName}/board/folders`
+    - `GET /api/datasets/preparations/{preparationName}/digit/folders`
+- `Application/Abstractions/IDatasetPreparationsGateway.cs`
+  - odczyt metadata preparation.
+- `Application/Abstractions/IDatasetPreparationArtifactsGateway.cs`
+  - generyczny port artefaktów preparation.
+- `Application/Datasets/DatasetPreparationNameValidationRules.cs`
+  - wspólna walidacja `preparationName`.
+- `Application/Datasets/DatasetPreparationNotFoundException.cs`
+  - semantyka `404`.
+- `Application/Datasets/DatasetPreparationArtifactsNotReadyException.cs`
+  - semantyka `409`.
+- `Infrastructure/Storage/DatasetPreparationArtifactsGateway.cs`
+  - odczytuje już `board/folders.json` i `digit/folders.json`.
+- `Infrastructure/Storage/DatasetPreparationsGateway.cs`
+  - czyta `preparation.metadata.json`.
+- `Infrastructure/Storage/LocalFileStorageGateway.cs`
+  - ma bezpieczne `OpenReadAsync(...)`.
+- `.github/workflows/backend-cd.yml`
+  - już podstawia `BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH`; nie potrzeba nowej zmiany workflow.
+
+## 4) Kontrakty FE/BE/ML i plikowy input dla BE
+
+### FE -> BE
+- `GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files`
+- route:
+  - `preparationName: string`
+  - `sourceName: string`
+- query:
+  - `page: int`
+  - `pageSize: int`
+- body:
+  - brak
+
+### BE -> FE
+- `200 OK` -> `DatasetPreparationBoardFilesApiResponse`
+- `400 Bad Request` -> `ErrorApiResponse`
+- `401 Unauthorized` -> `ErrorApiResponse`
+- `404 Not Found` -> `ErrorApiResponse`
+- `409 Conflict` -> `ErrorApiResponse`
+- `500 Internal Server Error` -> `ErrorApiResponse`
+
+`DatasetPreparationBoardFilesApiResponse`:
+- `preparationName`
+- `sourceName`
+- `items: DatasetPreparationBoardFileListItemApiResponse[]`
+- `page`
+- `pageSize`
+- `totalCount`
+
+`DatasetPreparationBoardFileListItemApiResponse`:
+- `boardFolderName`
+- `imageEndpoint`
+
+Przykład:
+
+```json
+{
+  "preparationName": "preparation-001",
+  "sourceName": "v1_training",
+  "items": [
+    {
+      "boardFolderName": "Image1",
+      "imageEndpoint": "/api/datasets/preparations/preparation-001/board/v1_training/files/Image1/image"
+    }
+  ],
+  "page": 1,
+  "pageSize": 50,
+  "totalCount": 240
+}
+```
+
+### BE -> ML / ML -> BE
+- Brak nowej komunikacji. Ten endpoint działa wyłącznie na runtime artifacts zapisanych wcześniej do storage przez flow preparation.
+
+### Plikowy input dla BE
+- `board/folders.json`:
+  - służy do potwierdzenia, że `sourceName` należy do preparation.
+- `board/{sourceName}/file.json`:
+  - jest jedynym źródłem listy `boardFolderName`.
+- Format `file.json`:
+
+```json
+[
+  "Image1",
+  "Image2",
+  "Image1079"
+]
+```
+
+## 5) Zachowanie per warstwa
+
+### API
+- Nowa akcja w `DatasetsController`:
+  - `[HttpGet("preparations/{preparationName}/board/{sourceName}/files")]`
+- Kontroler:
+  - binduje `preparationName`, `sourceName`, `page`, `pageSize`,
+  - wysyła query do `MediatR`,
+  - mapuje DTO do `DatasetPreparationBoardFilesApiResponse`,
+  - buduje `imageEndpoint`.
+- API nie:
+  - czyta plików,
+  - nie robi paginacji,
+  - nie waliduje gotowości preparation,
+  - nie rozmawia z `ML`.
+
+### Application
+- `Application` odpowiada za:
+  - walidację `preparationName`,
+  - walidację `sourceName`,
+  - walidację `page` i `pageSize`,
+  - sprawdzenie istnienia preparation,
+  - sprawdzenie statusu `completed`,
+  - sprawdzenie, czy `sourceName` istnieje w `board/folders.json`,
+  - odczyt listy z `board/{sourceName}/file.json`,
+  - wyliczenie paginacji,
+  - budowę DTO wyniku.
+- `Application` nie:
+  - robi niskopoziomowego I/O,
+  - nie składa URL-i HTTP,
+  - nie skanuje katalogów.
+
+### Models / Domain
+- Brak nowego modelu domenowego.
+- Reuse:
+  - `Models/Datasets/DatasetPreparationStatus.cs`
+
+### Infrastructure
+- `Infrastructure` ma:
+  - odczytać `board/folders.json`,
+  - odczytać `board/{sourceName}/file.json`,
+  - zdeserializować `string[]`,
+  - zgłosić błąd techniczny przy uszkodzonych danych.
+- `Infrastructure` nie:
+  - decyduje o `404`,
+  - nie decyduje o `409`,
+  - nie liczy paginacji,
+  - nie składa `imageEndpoint`.
+
+## 6) Pliki per warstwa i odpowiedzialności
+
+### API
+- `[MODYFIKACJA]` `src/Backend/Sudoku/Sudoku/Controllers/DatasetsController.cs`
+  - dodać `GetPreparationBoardFilesAsync(string? preparationName, string? sourceName, int? page, int? pageSize, CancellationToken)`
+  - wysłać `GetDatasetPreparationBoardFilesQuery`
+  - mapować `ValidationException -> 400`, `DatasetPreparationNotFoundException -> 404`, `DatasetPreparationSourceNotFoundException -> 404`, `DatasetPreparationArtifactsNotReadyException -> 409`, techniczne I/O/JSON/storage -> `500`
+  - złożyć `imageEndpoint`
+- `[NOWY]` `src/Backend/Sudoku/Sudoku/Contracts/DatasetPreparationBoardFilesApiResponse.cs`
+  - response listy plansz
+- `[NOWY]` `src/Backend/Sudoku/Sudoku/Contracts/DatasetPreparationBoardFileListItemApiResponse.cs`
+  - pojedynczy wpis listy
+- `[REUSE]` `src/Backend/Sudoku/Sudoku/Contracts/ErrorApiResponse.cs`
+  - wspólny kontrakt błędów
+
+### Application
+- `[NOWY]` `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardFilesQuery.cs`
+  - query MediatR
+- `[NOWY]` `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardFilesQueryValidator.cs`
+  - walidacja `preparationName`, `sourceName`, `page`, `pageSize`
+- `[NOWY]` `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardFilesQueryHandler.cs`
+  - logika use-case'a
+- `[NOWY]` `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardFilesQueryResultDto.cs`
+  - wynik use-case'a
+- `[NOWY]` `src/Backend/Sudoku/Application/Datasets/DatasetPreparationBoardFileListItemDto.cs`
+  - wewnętrzny item listy
+- `[NOWY]` `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardFilesErrorTypes.cs`
+  - spójne `errorType`
+- `[NOWY]` `src/Backend/Sudoku/Application/Datasets/DatasetPreparationSourceNameValidationRules.cs`
+  - wspólna walidacja `sourceName`, do reuse także przez endpoint obrazu i `DELETE`
+- `[NOWY]` `src/Backend/Sudoku/Application/Datasets/DatasetPreparationSourceNotFoundException.cs`
+  - semantyczny `404` dla `sourceName`
+- `[MODYFIKACJA]` `src/Backend/Sudoku/Application/Abstractions/IDatasetPreparationArtifactsGateway.cs`
+  - dodać `GetBoardFileNamesAsync(string preparationName, string sourceName, CancellationToken cancellationToken = default)`
+- `[REUSE]` `src/Backend/Sudoku/Application/Abstractions/IDatasetPreparationsGateway.cs`
+  - metadata preparation
+- `[REUSE]` `src/Backend/Sudoku/Application/Datasets/DatasetPreparationNameValidationRules.cs`
+  - walidacja `preparationName`
+- `[REUSE]` `src/Backend/Sudoku/Application/Datasets/DatasetPreparationNotFoundException.cs`
+  - `404`
+- `[REUSE]` `src/Backend/Sudoku/Application/Datasets/DatasetPreparationArtifactsNotReadyException.cs`
+  - `409`
+- `[REUSE]` `src/Backend/Sudoku/Application/Datasets/DatasetsPreparationOptions.cs`
+  - konfiguracja storage
+
+### Models
+- `[REUSE]` `src/Backend/Sudoku/Models/Datasets/DatasetPreparationStatus.cs`
+  - statusy preparation
+- `[BRAK NOWYCH PLIKÓW]` `src/Backend/Sudoku/Models`
+  - endpoint nie wnosi nowej domeny
+
+### Infrastructure
+- `[MODYFIKACJA]` `src/Backend/Sudoku/Infrastructure/Storage/DatasetPreparationArtifactsGateway.cs`
+  - zaimplementować `GetBoardFileNamesAsync(...)`
+  - zbudować ścieżkę `board/{sourceName}`
+  - odczytać `file.json`
+  - zdeserializować `string[]`
+  - sprawdzić brak pustych wpisów
+- `[REUSE]` `src/Backend/Sudoku/Infrastructure/Storage/DatasetPreparationsGateway.cs`
+  - odczyt metadata
+- `[REUSE]` `src/Backend/Sudoku/Infrastructure/Storage/LocalFileStorageGateway.cs`
+  - bezpieczny odczyt plików
+- `[REUSE]` `src/Backend/Sudoku/Infrastructure/DependencyInjection.cs`
+  - brak nowego serwisu, tylko reuse istniejącej rejestracji gatewaya artefaktów
+
+### Testy
+- `[NOWY]` `src/Backend/Sudoku/Application.Tests/GetDatasetPreparationBoardFilesQueryHandlerTests.cs`
+  - testy handlera
+- `[NOWY]` `src/Backend/Sudoku/Application.Tests/GetDatasetPreparationBoardFilesQueryValidatorTests.cs`
+  - testy walidacji
+- `[MODYFIKACJA]` `src/Backend/Sudoku/Application.Tests/DatasetsControllerTests.cs`
+  - testy kontrolera
+- `[REUSE]` `src/Backend/Sudoku/Application.Tests/GetDatasetPreparationFoldersQueryHandlerTests.cs`
+  - wzorzec stubów metadata/artifacts
+
+### Workflow i config
+- `[REUSE]` `src/Backend/Sudoku/Sudoku/appsettings.local.json`
+  - lokalna ścieżka na sztywno
+- `[REUSE]` `src/Backend/Sudoku/Sudoku/appsettings.production.json`
+  - overlay produkcyjny
+- `[REUSE]` `.github/workflows/backend-cd.yml`
+  - już podstawia `PreparationsDirectoryPath`
+
+## 7) Przepływ w obrębie BE
+1. `FE` wywołuje `GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files?page={page}&pageSize={pageSize}`.
+2. Autoryzacja z `UC-13` przepuszcza tylko admina.
+3. `DatasetsController.GetPreparationBoardFilesAsync(...)` binduje route i query.
+4. Kontroler wysyła `GetDatasetPreparationBoardFilesQuery(preparationName, sourceName, page, pageSize)`.
+5. `ValidationBehavior` uruchamia validator.
+6. Handler czyta metadata przez `IDatasetPreparationsGateway.GetByNameAsync(...)`.
+7. Gdy preparation nie istnieje -> `DatasetPreparationNotFoundException`.
+8. Gdy status nie jest `completed` -> `DatasetPreparationArtifactsNotReadyException`.
+9. Handler czyta `board/folders.json` przez `IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync(preparationName, "board")`.
+10. Gdy `sourceName` nie należy do listy -> `DatasetPreparationSourceNotFoundException`.
+11. Handler czyta `board/{sourceName}/file.json` przez `GetBoardFileNamesAsync(...)`.
+12. Handler liczy `skip/take` na podstawie `page` i `pageSize`.
+13. Handler zwraca wynik bez URL-i HTTP, tylko z `boardFolderName`.
+14. Kontroler składa `imageEndpoint` i zwraca `200 OK`.
+
+## 8) Główne funkcje
+- `DatasetsController.GetPreparationBoardFilesAsync(...)`
+- `DatasetsController.ToDatasetPreparationBoardFilesApiResponse(...)`
+- `DatasetsController.BuildDatasetPreparationBoardImageEndpoint(...)`
+- `GetDatasetPreparationBoardFilesQueryHandler.Handle(...)`
+- `GetDatasetPreparationBoardFilesQueryValidator.Validate(...)`
+- `DatasetPreparationSourceNameValidationRules.Validate(...)`
+- `GetDatasetPreparationBoardFilesQueryHandler.EnsurePreparationCompleted(...)`
+- `GetDatasetPreparationBoardFilesQueryHandler.EnsureBoardSourceExists(...)`
+- `GetDatasetPreparationBoardFilesQueryHandler.Paginate(...)`
+- `IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync(...)`
+- `IDatasetPreparationArtifactsGateway.GetBoardFileNamesAsync(...)`
+- `DatasetPreparationArtifactsGateway.GetBoardFileNamesAsync(...)`
+
+## 9) Wyjątki, fallbacki i semantyka
+
+### Statusy HTTP
+- `200`
+  - preparation istnieje, jest `completed`, `sourceName` istnieje, `file.json` jest poprawny
+- `400`
+  - niepoprawny `preparationName`
+  - niepoprawny `sourceName`
+  - `page < 1`
+  - `pageSize < 1`
+  - `pageSize > MaxPageSize`
+- `401`
+  - brak poprawnej autoryzacji
+- `404`
+  - preparation nie istnieje
+  - `sourceName` nie ma w `board/folders.json`
+- `409`
+  - preparation istnieje, ale nie jest gotowe do odczytu artefaktów
+- `500`
+  - błąd I/O
+  - brak dostępu do storage
+  - brak `board/folders.json` dla `completed`
+  - brak `board/{sourceName}/file.json` mimo obecności wpisu w `board/folders.json`
+  - uszkodzony JSON
+  - puste wpisy w manifeście
+
+### `errorType`
+- `invalid_dataset_preparation_name`
+- `invalid_dataset_preparation_source_name`
+- `invalid_dataset_preparation_board_files_page`
+- `invalid_dataset_preparation_board_files_page_size`
+- `dataset_preparation_not_found`
+- `dataset_preparation_source_not_found`
+- `dataset_preparation_artifacts_not_ready`
+- `dataset_preparation_board_files_read_failed`
+
+### Fallbacki
+- Dozwolone:
+  - pusty `file.json` -> `200`, `items=[]`, `totalCount=0`
+  - `page` poza zakresem -> `200`, `items=[]`, `totalCount` zachowane
+- Niedozwolone:
+  - skan katalogów zamiast `file.json`
+  - zgadywanie `sourceName` z katalogów
+  - budowanie listy z `SourceReports`
+  - odpytywanie `ML`
+  - zamiana brakującego `file.json` dla istniejącego `sourceName` na `404`
+
+## 10) Pseudokod
+
+### Handler
+
+```text
+handle(query):
+  validate(query)
+
+  metadata = datasetPreparationsGateway.getByName(query.preparationName)
+  if metadata is null:
+    throw dataset_preparation_not_found
+
+  if metadata.status != "completed":
+    throw dataset_preparation_artifacts_not_ready
+
+  boardSources = artifactsGateway.getSourceFolderNames(query.preparationName, "board")
+  if query.sourceName not in boardSources:
+    throw dataset_preparation_source_not_found
+
+  allItems = artifactsGateway.getBoardFileNames(query.preparationName, query.sourceName)
+  totalCount = allItems.length
+  skip = (query.page - 1) * query.pageSize
+  pageItems = allItems.skip(skip).take(query.pageSize)
+
+  return result(preparationName, sourceName, pageItems, query.page, query.pageSize, totalCount)
+```
+
+### Gateway artefaktów
+
+```text
+getBoardFileNames(preparationName, sourceName):
+  path = combine(preparationsDirectoryPath, preparationName, "board", sourceName)
+  stream = fileStorageGateway.openRead(path, "file.json")
+  items = deserialize string[]
+
+  if items is null or contains empty values:
+    throw invalid_data
+
+  return items
+```
+
+### Walidacja
+
+```text
+validate(query):
+  validatePreparationName(query.preparationName)
+  validateSourceName(query.sourceName)
+
+  if query.page is null or query.page < 1:
+    invalid_page
+
+  if query.pageSize is null or query.pageSize < 1 or query.pageSize > 200:
+    invalid_page_size
+```
+
+## 11) Mermaid flowchart - flow modeli
+
+```mermaid
+flowchart TD
+    A["route/query params<br/>DatasetsController.GetPreparationBoardFilesAsync()"] --> B["GetDatasetPreparationBoardFilesQuery<br/>query aplikacyjne"]
+    B --> C["DatasetPreparationMetadataDto<br/>IDatasetPreparationsGateway.GetByNameAsync()"]
+    C --> D["IReadOnlyList<string><br/>IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync()"]
+    D --> E["IReadOnlyList<string><br/>IDatasetPreparationArtifactsGateway.GetBoardFileNamesAsync()"]
+    E --> F["GetDatasetPreparationBoardFilesQueryResultDto<br/>po paginacji"]
+    F --> G["DatasetPreparationBoardFilesApiResponse<br/>z imageEndpoint"]
+```
+
+## 12) Mermaid flowchart - logika aplikacji z funkcjami
+
+```mermaid
+flowchart TD
+    A["DatasetsController.GetPreparationBoardFilesAsync()"] --> B["GetDatasetPreparationBoardFilesQueryValidator.Validate()"]
+    B --> C["GetDatasetPreparationBoardFilesQueryHandler.Handle()"]
+    C --> D["IDatasetPreparationsGateway.GetByNameAsync()"]
+    D --> E["EnsurePreparationCompleted()"]
+    E --> F["IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync()"]
+    F --> G["EnsureBoardSourceExists()"]
+    G --> H["IDatasetPreparationArtifactsGateway.GetBoardFileNamesAsync()"]
+    H --> I["Paginate()"]
+    I --> J["ToDatasetPreparationBoardFilesApiResponse()"]
+```
+
+## 13) Logging
+- `Information`
+  - start: `preparationName`, `sourceName`, `page`, `pageSize`
+  - success: `preparationName`, `sourceName`, `page`, `pageSize`, `totalCount`, `returnedItemsCount`
+- `Warning`
+  - preparation nie istnieje
+  - preparation niegotowe
+  - `sourceName` nie należy do preparation
+- `Error`
+  - błąd odczytu `board/folders.json`
+  - błąd odczytu `board/{sourceName}/file.json`
+  - błąd deserializacji manifestu
+- Guardraile:
+  - nie logować całej zawartości `file.json`
+  - nie logować każdego `boardFolderName` osobno
+  - nie logować ścieżek systemowych w odpowiedziach HTTP
+  - logi mają być lekkie, bez spamowania dysku
+
+## 14) Workflow GitHub i runtime
+- Brak nowych zmian w `.github/workflows`.
+- Brak nowych opcji `appsettings`.
+- Lokalnie `PreparationsDirectoryPath` pozostaje ustawione na sztywno w `appsettings.local.json`.
+- Produkcyjnie `backend-cd.yml` już wpisuje `BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH` do `appsettings.production.json`.
+- Należy tylko pamiętać, że deploy nie może nadpisywać `shared/data`, bo tam żyją runtime artifacts preparation.
+
+## 15) Kolejność implementacji
+1. Dodać `DatasetPreparationSourceNameValidationRules`.
+2. Dodać `DatasetPreparationSourceNotFoundException`.
+3. Dodać `GetDatasetPreparationBoardFilesErrorTypes`.
+4. Dodać `GetDatasetPreparationBoardFilesQuery`, `...QueryResultDto`, `DatasetPreparationBoardFileListItemDto`.
+5. Dodać `GetDatasetPreparationBoardFilesQueryValidator`.
+6. Rozszerzyć `IDatasetPreparationArtifactsGateway` o `GetBoardFileNamesAsync(...)`.
+7. Rozszerzyć `DatasetPreparationArtifactsGateway` o odczyt `board/{sourceName}/file.json`.
+8. Dodać `GetDatasetPreparationBoardFilesQueryHandler`.
+9. Dodać `DatasetPreparationBoardFileListItemApiResponse` i `DatasetPreparationBoardFilesApiResponse`.
+10. Rozszerzyć `DatasetsController`.
+11. Dodać testy validatora, handlera i kontrolera.
+12. Wykonać smoke test dla `completed`, `running`, `failed`, braku preparation, braku `sourceName`, pustego i uszkodzonego manifestu.
+
+## 16) Guardraile implementacyjne
+- Nie czytać `file.json` w kontrolerze.
+- Nie skanować katalogów jako fallback.
+- Nie budować `imageEndpoint` w `Application`.
+- Nie przenosić paginacji do `Infrastructure`.
+- Nie rozszerzać `IDatasetPreparationsGateway` o `file.json`.
+- Nie odpytywać `ML`.
+- Nie hardcodować ścieżek runtime.
+- Nie sortować listy po stronie `BE`, jeśli `file.json` ma już ustaloną kolejność.
+- Nie mapować brakującego `file.json` dla istniejącego `sourceName` na `404`.
+
+## 17) Plan testów minimum
+- Validator:
+  - pusty lub nielegalny `preparationName`
+  - pusty lub nielegalny `sourceName`
+  - `page = null`, `0`
+  - `pageSize = null`, `0`, `>200`
+  - poprawny request
+- Handler:
+  - happy path
+  - pusty `file.json`
+  - `page` poza zakresem
+  - brak preparation
+  - status `running` / `failed`
+  - brak `sourceName` w `board/folders.json`
+- API:
+  - `200`, `400`, `401`, `404`, `409`, `500`
+- Manual smoke:
+  - duży manifest z paginacją
+  - pusty manifest
+  - uszkodzony manifest
+
+## 18) Podsumowanie decyzji architektonicznych
+- `Application` ma posiadać całą logikę: walidację, sprawdzenie statusu, sprawdzenie `sourceName` i paginację.
+- `Infrastructure` ma tylko odczytać i zdeserializować manifesty.
+- `Api` ma tylko zmapować wynik i zbudować `imageEndpoint`.
+- Najważniejsza decyzja antyduplikacyjna: rozszerzyć `IDatasetPreparationArtifactsGateway`, a nie tworzyć osobny gateway dla `board/{sourceName}/file.json`.

--- a/.ai/implementation-plan/be/uc-18-be-get-api-datasets-preparations-preparation-name-digit-folders.md
+++ b/.ai/implementation-plan/be/uc-18-be-get-api-datasets-preparations-preparation-name-digit-folders.md
@@ -1,0 +1,697 @@
+# UC-18-BE - Plan implementacyjny dla `GET /api/datasets/preparations/{preparationName}/digit/folders`
+
+## 1) Przeznaczenie endpointa
+- Endpoint `GET /api/datasets/preparations/{preparationName}/digit/folders` zwraca listę nazw źródeł typu `digit` dla wybranego preparation.
+- Jest to pomocniczy endpoint przeglądowy w `UC-18`:
+  - użytkownik wybiera preparation,
+  - `FE` pobiera listę folderów źródłowych `digit`,
+  - `FE` pokazuje tę listę jako logiczne źródła danych,
+  - endpoint nie służy do podglądu pojedynczych próbek cyfr i nie usuwa danych.
+- Endpoint jest `read-only`:
+  - nie uruchamia preprocessingu,
+  - nie wywołuje `ML`,
+  - nie przebudowuje manifestów,
+  - nie skanuje katalogów heurystycznie.
+- Publiczne API pozostaje po stronie `BE`, a źródłem danych dla odpowiedzi jest manifest:
+  - `{PreparationsDirectoryPath}/{preparationName}/digit/folders.json`
+
+## 2) Zakres i główne założenia
+- Plan dotyczy wyłącznie części `BE` w `src/Backend/Sudoku`.
+- Nie sugerujemy się aktualnym stanem `FE` i nie projektujemy niczego pod obecną implementację `ML`, poza obowiązującym kontraktem workflow oraz artefaktami już ustalonymi dla `UC-17` i `UC-18`.
+- Trzymamy architekturę:
+  - `Api` cienkie,
+  - `Application` zawiera logikę use-case,
+  - `Infrastructure` realizuje I/O i szczegóły storage,
+  - `Models` pozostaje warstwą modeli domenowych i statusów.
+- Nie zmieniamy istniejących nazw klas i pól, które już zostały dodane przez wcześniejsze historyjki.
+- Plan ma kontynuować istniejący kontrakt backendu, a nie tworzyć równoległego wariantu tylko dla `digit`.
+
+## 3) Kontekst historyjki i zależności
+
+### 3.1 Miejsce w workflow
+- `UC-17` tworzy preparation i jego metadata.
+- `UC-18` pozwala przeglądać przygotowane artefakty i czyścić dane.
+- Dla `digit` w `UC-18` zakres jest węższy niż dla `board`:
+  - pokazujemy listę logicznych folderów źródłowych,
+  - nie budujemy osobnego ekranu podglądu plików,
+  - nie usuwamy pojedynczych elementów `digit`.
+
+### 3.2 Historyjki, od których ten endpoint zależy
+- `UC-13`
+  - autoryzacja administratora dla endpointów administracyjnych.
+- `UC-17 - GET /api/datasets/preparations`
+  - wybór preparation przez użytkownika.
+- `UC-17 - GET /api/datasets/preparations/{preparationName}`
+  - odczyt statusu preparation.
+- `UC-17 - POST /api/datasets/preparations`
+  - powstanie metadata i artefaktów runtime.
+- `UC-18 - GET /api/datasets/preparations/{preparationName}/board/folders`
+  - już wdrożony wzorzec techniczny dla analogicznego use-case'a.
+- `UC-19`
+  - później będzie reuse'ować listę źródeł `digit` przy dalszych operacjach na przygotowaniach.
+
+### 3.3 Ważny wniosek projektowy
+- Dla `digit/folders` nie projektujemy nowego stosu aplikacyjnego.
+- Obecny backend ma już generyczne wsparcie dla typu `board` i `digit` w warstwie `Application` oraz `Infrastructure`.
+- Brakująca część to głównie ekspozycja nowej trasy HTTP w `Api` oraz domknięcie testów kontrolera dla wariantu `digit`.
+
+## 4) Co już istnieje i czego należy użyć
+
+### 4.1 Istniejące elementy do bezpośredniego reuse
+- `Sudoku/Controllers/DatasetsController.cs`
+  - ma już akcję dla `GET /api/datasets/preparations/{preparationName}/board/folders`,
+  - należy wykorzystać ją jako referencyjny wzorzec dla `digit/folders`.
+- `Application/Datasets/GetDatasetPreparationFoldersQuery.cs`
+  - wspólny query model dla `board` i `digit`.
+- `Application/Datasets/GetDatasetPreparationFoldersQueryValidator.cs`
+  - już waliduje `type` do wartości `board` albo `digit`.
+- `Application/Datasets/GetDatasetPreparationFoldersQueryHandler.cs`
+  - już obsługuje oba typy.
+- `Application/Datasets/GetDatasetPreparationFoldersQueryResultDto.cs`
+  - wspólny wynik use-case'a.
+- `Application/Datasets/GetDatasetPreparationFoldersErrorTypes.cs`
+  - wspólne typy błędów dla `folders`.
+- `Application/Datasets/DatasetPreparationArtifactsNotReadyException.cs`
+  - semantyka `409`.
+- `Application/Datasets/DatasetPreparationNotFoundException.cs`
+  - semantyka `404`.
+- `Application/Datasets/DatasetPreparationNameValidationRules.cs`
+  - wspólna walidacja `preparationName`.
+- `Application/Abstractions/IDatasetPreparationsGateway.cs`
+  - odczyt metadata preparation.
+- `Application/Abstractions/IDatasetPreparationArtifactsGateway.cs`
+  - port do odczytu manifestów artefaktów preparation.
+- `Infrastructure/Storage/DatasetPreparationsGateway.cs`
+  - odczyt `preparation.metadata.json`.
+- `Infrastructure/Storage/DatasetPreparationArtifactsGateway.cs`
+  - odczyt `board/folders.json` i `digit/folders.json`.
+- `Sudoku/Contracts/DatasetPreparationFoldersApiResponse.cs`
+  - wspólny kontrakt publicznej odpowiedzi.
+- `Sudoku/Contracts/ErrorApiResponse.cs`
+  - wspólny kontrakt błędu.
+- `Models/Datasets/DatasetPreparationStatus.cs`
+  - źródło nazw statusów preparation.
+
+### 4.2 Ważny stan obecny
+- W warstwie `Application` i `Infrastructure` logika dla `digit` już istnieje.
+- `DatasetPreparationArtifactsGateway` mapuje:
+  - `board -> board`
+  - `digit -> digit`
+- `GetDatasetPreparationFoldersQueryValidator` akceptuje `digit`.
+- To oznacza, że ten plan nie powinien proponować nowych query, handlerów, gatewayów ani DTO tylko dlatego, że endpoint dotyczy `digit`.
+
+### 4.3 Czego nie należy tworzyć
+- Nie tworzyć osobnego:
+  - `GetDatasetPreparationDigitFoldersQuery`
+  - `GetDatasetPreparationDigitFoldersQueryHandler`
+  - `GetDatasetPreparationDigitFoldersApiResponse`
+  - `IDatasetPreparationDigitArtifactsGateway`
+- Nie rozszerzać `IDatasetPreparationsGateway` o manifesty `folders.json`.
+- Nie budować nowej komunikacji `BE -> ML`.
+
+## 5) Kontrakty API i modele komunikacji
+
+### 5.1 FE -> BE
+- Metoda i ścieżka:
+  - `GET /api/datasets/preparations/{preparationName}/digit/folders`
+- Route params:
+  - `preparationName: string`
+- Query string:
+  - brak
+- Request body:
+  - brak
+- Autoryzacja:
+  - taka sama jak dla innych endpointów administracyjnych z `UC-13`
+
+### 5.2 BE -> FE
+- `200 OK` -> `DatasetPreparationFoldersApiResponse`
+- `400 Bad Request` -> `ErrorApiResponse`
+- `401 Unauthorized` -> `ErrorApiResponse`
+- `404 Not Found` -> `ErrorApiResponse`
+- `409 Conflict` -> `ErrorApiResponse`
+- `500 Internal Server Error` -> `ErrorApiResponse`
+
+### 5.3 Model odpowiedzi HTTP
+`DatasetPreparationFoldersApiResponse`
+- `preparationName: string`
+- `type: string`
+- `items: string[]`
+- `totalCount: number`
+
+Przykład `200 OK`:
+
+```json
+{
+  "preparationName": "preparation-001",
+  "type": "digit",
+  "items": [
+    "mnist_train",
+    "mnist_test"
+  ],
+  "totalCount": 2
+}
+```
+
+### 5.4 FE/ML input-output model
+- `FE -> BE`
+  - wejście: `preparationName` w route
+  - wyjście: `DatasetPreparationFoldersApiResponse` albo `ErrorApiResponse`
+- `BE -> ML`
+  - brak komunikacji
+- `ML -> BE`
+  - brak komunikacji HTTP dla tego endpointu
+
+### 5.5 Plikowy kontrakt wejściowy dla BE
+- `BE` czyta manifest:
+  - `{DatasetsPreparation.PreparationsDirectoryPath}/{preparationName}/digit/folders.json`
+- Format pliku:
+
+```json
+[
+  "mnist_train",
+  "mnist_test"
+]
+```
+
+### 5.6 Reguły kontraktowe
+- `type` w odpowiedzi musi mieć wartość `"digit"`.
+- `items` muszą zachować kolejność z `folders.json`.
+- `BE` nie sortuje, nie filtruje i nie rekonstruuje listy na podstawie skanu filesystemu.
+- Pusta lista w manifeście jest poprawnym przypadkiem biznesowym.
+
+## 6) Zachowanie per warstwa
+
+### 6.1 API
+- `DatasetsController` dostaje nową akcję:
+  - `[HttpGet("preparations/{preparationName}/digit/folders")]`
+- Akcja:
+  - binduje `preparationName`,
+  - ustawia `const string type = "digit"`,
+  - wysyła `GetDatasetPreparationFoldersQuery(preparationName, type)`,
+  - mapuje wynik do `DatasetPreparationFoldersApiResponse`,
+  - mapuje wyjątki na odpowiednie statusy HTTP.
+- `Api` nie:
+  - czyta plików,
+  - nie deserializuje JSON,
+  - nie decyduje o gotowości preparation,
+  - nie skanuje katalogów,
+  - nie odpytuje `ML`.
+
+### 6.2 Application
+- `GetDatasetPreparationFoldersQueryHandler`:
+  - waliduje, że query dotarło po `ValidationBehavior`,
+  - odczytuje metadata preparation,
+  - rzuca `404`, jeśli preparation nie istnieje,
+  - sprawdza, czy status preparation to `completed`,
+  - rzuca `409`, jeśli preparation nie jest gotowe,
+  - zleca odczyt manifestu gatewayowi artefaktów,
+  - buduje wynik DTO.
+- `Application` jest właścicielem logiki:
+  - czy preparation można już czytać,
+  - jaki wyjątek semantyczny zwrócić,
+  - jaki ma być wynik use-case'a.
+- `Application` nie wykonuje:
+  - niskopoziomowego I/O,
+  - operacji `File.*`, `Directory.*`,
+  - deserializacji plików JSON bezpośrednio.
+
+### 6.3 Domain / Models
+- Dla tego endpointu nie ma potrzeby dodawania nowego modelu domenowego.
+- Reuse'owany jest status z:
+  - `Models/Datasets/DatasetPreparationStatus.cs`
+- `digit/folders` nie wprowadza nowego bytu domenowego, tylko read-only use-case nad istniejącym preparation.
+
+### 6.4 Infrastructure
+- `DatasetPreparationArtifactsGateway`:
+  - buduje ścieżkę do `digit/folders.json`,
+  - czyta plik przez `IFileStorageGateway`,
+  - deserializuje `string[]`,
+  - pilnuje, aby wynik nie był `null`,
+  - pilnuje, aby lista nie zawierała pustych wpisów.
+- `Infrastructure` nie:
+  - mapuje odpowiedzi HTTP,
+  - nie decyduje o `404` preparation,
+  - nie rozstrzyga biznesowo, czy preparation jest gotowe.
+
+## 7) Pliki per warstwa i odpowiedzialności
+
+### 7.1 API - pliki i odpowiedzialności
+
+#### `src/Backend/Sudoku/Sudoku/Controllers/DatasetsController.cs`
+- status: `[MODYFIKACJA WYMAGANA]`
+- odpowiedzialność:
+  - dodać akcję `GetPreparationDigitFoldersAsync`
+  - wysłać `GetDatasetPreparationFoldersQuery(preparationName, "digit")`
+  - reuse'ować:
+    - `ToDatasetPreparationFoldersApiResponse(...)`
+    - `MapDatasetPreparationFoldersValidationError(...)`
+  - mapować:
+    - `ValidationException -> 400`
+    - `DatasetPreparationNotFoundException -> 404`
+    - `DatasetPreparationArtifactsNotReadyException -> 409`
+    - `IOException | UnauthorizedAccessException | InvalidDataException | JsonException | FileStorageItemNotFoundException -> 500`
+
+#### `src/Backend/Sudoku/Sudoku/Contracts/DatasetPreparationFoldersApiResponse.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - wspólny response model dla `board/folders` i `digit/folders`
+
+#### `src/Backend/Sudoku/Sudoku/Contracts/ErrorApiResponse.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - wspólny kontrakt błędów HTTP
+
+### 7.2 Application - pliki i odpowiedzialności
+
+#### `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationFoldersQuery.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - wspólny query model z polami `PreparationName` i `Type`
+
+#### `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationFoldersQueryValidator.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - walidacja `preparationName`
+  - walidacja `type` do `board` albo `digit`
+
+#### `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationFoldersQueryHandler.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - logika read-only dla obu typów
+  - sprawdzenie istnienia preparation
+  - sprawdzenie statusu `completed`
+  - pobranie folderów z portu artefaktów
+
+#### `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationFoldersQueryResultDto.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - DTO wyniku use-case'a
+
+#### `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationFoldersErrorTypes.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - spójne `errorType` dla wariantu `board` i `digit`
+
+#### `src/Backend/Sudoku/Application/Datasets/DatasetPreparationArtifactsNotReadyException.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - semantyka `409`, gdy status preparation nie pozwala czytać artefaktów
+
+#### `src/Backend/Sudoku/Application/Datasets/DatasetPreparationNotFoundException.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - semantyka `404`
+
+#### `src/Backend/Sudoku/Application/Datasets/DatasetPreparationNameValidationRules.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - wspólna walidacja nazwy preparation
+
+#### `src/Backend/Sudoku/Application/Abstractions/IDatasetPreparationsGateway.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - odczyt metadata preparation
+
+#### `src/Backend/Sudoku/Application/Abstractions/IDatasetPreparationArtifactsGateway.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - port do odczytu artefaktów preparation
+  - metoda:
+    - `GetSourceFolderNamesAsync(string preparationName, string sourceType, CancellationToken cancellationToken = default)`
+
+#### `src/Backend/Sudoku/Application/Datasets/DatasetsPreparationOptions.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - typed options dla ścieżek i ustawień workflow
+
+### 7.3 Models - pliki i odpowiedzialności
+
+#### `src/Backend/Sudoku/Models/Datasets/DatasetPreparationStatus.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - stałe statusów preparation
+  - kontrola semantyki `completed` versus stany niegotowe
+
+### 7.4 Infrastructure - pliki i odpowiedzialności
+
+#### `src/Backend/Sudoku/Infrastructure/Storage/DatasetPreparationArtifactsGateway.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - odczyt manifestu `digit/folders.json`
+  - mapowanie `sourceType` na katalog
+  - deserializacja `string[]`
+  - wykrywanie pustych wpisów
+
+#### `src/Backend/Sudoku/Infrastructure/Storage/DatasetPreparationsGateway.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - odczyt `preparation.metadata.json`
+  - źródło danych do sprawdzenia istnienia i statusu preparation
+
+#### `src/Backend/Sudoku/Infrastructure/Storage/LocalFileStorageGateway.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - niskopoziomowy dostęp do plików
+  - bezpieczeństwo ścieżek
+  - mapowanie błędów plikowych do wyjątków storage
+
+#### `src/Backend/Sudoku/Infrastructure/DependencyInjection.cs`
+- status: `[REUSE - BEZ ZMIAN]`
+- odpowiedzialność:
+  - rejestracja gatewayów
+  - tu nic nowego nie trzeba dopinać, bo `IDatasetPreparationArtifactsGateway` już jest zarejestrowany
+
+### 7.5 Testy - pliki i odpowiedzialności
+
+#### `src/Backend/Sudoku/Application.Tests/DatasetsControllerTests.cs`
+- status: `[MODYFIKACJA WYMAGANA]`
+- odpowiedzialność:
+  - dodać testy nowej akcji HTTP dla `digit/folders`
+
+#### `src/Backend/Sudoku/Application.Tests/GetDatasetPreparationFoldersQueryValidatorTests.cs`
+- status: `[REUSE - OPCJONALNIE BEZ ZMIAN]`
+- odpowiedzialność:
+  - już pokrywa akceptację typu `digit`
+
+#### `src/Backend/Sudoku/Application.Tests/GetDatasetPreparationFoldersQueryHandlerTests.cs`
+- status: `[REUSE - OPCJONALNIE MAŁE UZUPEŁNIENIE]`
+- odpowiedzialność:
+  - obecnie potwierdza flow dla `board`
+  - można dodać jeden test dowodzący, że handler przekazuje `type = "digit"` do gatewaya artefaktów, ale nie jest to konieczne do uruchomienia endpointa
+
+## 8) Minimalny zakres zmian implementacyjnych
+
+### 8.1 Zmiany obowiązkowe
+1. Dodać akcję `GetPreparationDigitFoldersAsync(...)` w `DatasetsController`.
+2. Dodać testy kontrolera dla tej akcji.
+
+### 8.2 Zmiany opcjonalne, ale zalecane
+1. Dodać pojedynczy test handlera z `type = "digit"`.
+2. Dodać logi analogiczne do `board/folders`, żeby operacyjnie obie trasy zachowywały się spójnie.
+
+### 8.3 Czego nie ruszać
+- Nie zmieniać query, handlera, validatora, DTO i gatewaya tylko po to, żeby endpoint nazywał się `digit`.
+- Nie zmieniać kontraktu `DatasetPreparationFoldersApiResponse`.
+- Nie zmieniać workflow CI/CD, jeśli nowe zmiany nie wnoszą nowych ustawień.
+
+## 9) Przepływ w obrębie backendu
+1. `FE` wywołuje `GET /api/datasets/preparations/{preparationName}/digit/folders`.
+2. Warstwa autoryzacji z `UC-13` przepuszcza tylko poprawnie uwierzytelnionego admina.
+3. `DatasetsController.GetPreparationDigitFoldersAsync(...)` binduje `preparationName`.
+4. Kontroler tworzy `GetDatasetPreparationFoldersQuery(preparationName, "digit")`.
+5. `ValidationBehavior` uruchamia `GetDatasetPreparationFoldersQueryValidator`.
+6. `GetDatasetPreparationFoldersQueryHandler.Handle(...)` pobiera metadata przez `IDatasetPreparationsGateway.GetByNameAsync(...)`.
+7. Jeśli metadata nie istnieją:
+  - handler rzuca `DatasetPreparationNotFoundException`.
+8. Jeśli preparation istnieje, ale status nie jest `completed`:
+  - handler rzuca `DatasetPreparationArtifactsNotReadyException`.
+9. Jeśli preparation jest gotowe:
+  - handler wywołuje `IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync(preparationName, "digit")`.
+10. `DatasetPreparationArtifactsGateway` czyta:
+  - `{PreparationsDirectoryPath}/{preparationName}/digit/folders.json`
+11. Handler buduje `GetDatasetPreparationFoldersQueryResultDto`.
+12. Kontroler mapuje wynik do `DatasetPreparationFoldersApiResponse`.
+13. API zwraca `200 OK`.
+
+## 10) Główne funkcje
+- `[NOWA]` `DatasetsController.GetPreparationDigitFoldersAsync(...)`
+- `[REUSE]` `DatasetsController.ToDatasetPreparationFoldersApiResponse(...)`
+- `[REUSE]` `DatasetsController.MapDatasetPreparationFoldersValidationError(...)`
+- `[REUSE]` `GetDatasetPreparationFoldersQueryHandler.Handle(...)`
+- `[REUSE]` `GetDatasetPreparationFoldersQueryValidator.Validate(...)`
+- `[REUSE]` `IDatasetPreparationsGateway.GetByNameAsync(...)`
+- `[REUSE]` `IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync(...)`
+- `[REUSE]` `DatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync(...)`
+- `[REUSE]` `DatasetPreparationArtifactsGateway.BuildSourceDirectoryPath(...)`
+- `[REUSE]` `DatasetPreparationArtifactsGateway.MapSourceTypeDirectoryName(...)`
+
+## 11) Wyjątki, fallbacki i zachowanie błędowe
+
+### 11.1 Publiczne statusy HTTP
+- `200 OK`
+  - preparation istnieje,
+  - status to `completed`,
+  - manifest `digit/folders.json` jest poprawny
+- `400 Bad Request`
+  - `preparationName` jest puste
+  - `preparationName` zawiera niedozwolone znaki
+- `401 Unauthorized`
+  - brak poprawnej autoryzacji admina
+- `404 Not Found`
+  - preparation nie istnieje
+- `409 Conflict`
+  - preparation istnieje, ale nie jest gotowe do odczytu artefaktów
+- `500 Internal Server Error`
+  - błąd I/O
+  - brak dostępu do storage
+  - brak manifestu dla `completed`
+  - uszkodzony JSON
+  - manifest zawiera puste wpisy
+
+### 11.2 `errorType`
+- `invalid_dataset_preparation_name`
+- `dataset_preparation_not_found`
+- `dataset_preparation_artifacts_not_ready`
+- `dataset_preparation_folders_read_failed`
+
+### 11.3 Fallbacki dozwolone
+- Jeśli `folders.json` zawiera pustą listę:
+  - zwrócić `200 OK`
+  - `items: []`
+  - `totalCount: 0`
+
+### 11.4 Fallbacki niedozwolone
+- Nie skanować katalogu `digit/` jako zastępstwa za brak manifestu.
+- Nie zgadywać listy na podstawie `metadata.Sources`.
+- Nie odpytywać `ML`, czy preparation jest gotowe.
+- Nie zwracać `200 []`, gdy status to `queued`, `running` albo `failed`.
+- Nie zamieniać błędu uszkodzonego/brakującego manifestu na `404`, jeśli samo preparation istnieje.
+
+### 11.5 Sytuacje graniczne
+- preparation istnieje, status `running`
+  - `409`
+- preparation istnieje, status `failed`
+  - `409`
+- preparation istnieje, status `completed`, ale `digit/folders.json` nie istnieje
+  - `500`
+- preparation istnieje, status `completed`, ale JSON jest uszkodzony
+  - `500`
+- preparation istnieje, status `completed`, a lista `digit` jest pusta
+  - `200`
+
+## 12) Specyficzna logika i pseudokod
+
+### 12.1 Pseudokod akcji kontrolera
+
+```text
+getPreparationDigitFolders(preparationName):
+  type = "digit"
+
+  log information start(preparationName, type)
+
+  try:
+    result = sender.send(GetDatasetPreparationFoldersQuery(preparationName, type))
+    response = mapToApiResponse(result)
+    log information success(preparationName, type, totalCount)
+    return 200 response
+  catch validation:
+    return 400 error
+  catch preparation_not_found:
+    return 404 error
+  catch artifacts_not_ready:
+    return 409 error
+  catch io/json/storage:
+    return 500 error
+```
+
+### 12.2 Pseudokod handlera
+
+```text
+handleGetDatasetPreparationFolders(query):
+  validate(query.preparationName, query.type)
+
+  metadata = datasetPreparationsGateway.getByName(query.preparationName)
+  if metadata is null:
+    throw dataset_preparation_not_found
+
+  if metadata.status != "completed":
+    throw dataset_preparation_artifacts_not_ready
+
+  items = datasetPreparationArtifactsGateway.getSourceFolderNames(
+    query.preparationName,
+    query.type
+  )
+
+  return {
+    preparationName: metadata.preparationName,
+    type: query.type,
+    items: items,
+    totalCount: items.length
+  }
+```
+
+### 12.3 Pseudokod gatewaya artefaktów
+
+```text
+getSourceFolderNames(preparationName, sourceType):
+  directoryPath = combine(preparationsDirectoryPath, preparationName, mapSourceTypeDirectoryName(sourceType))
+  stream = fileStorageGateway.openRead(directoryPath, "folders.json")
+  items = deserialize string[] from stream
+
+  if items is null:
+    throw invalid_data
+
+  if any item is null/empty/whitespace:
+    throw invalid_data
+
+  return items
+```
+
+### 12.4 Wyjątkowa logika do uwzględnienia
+- Readiness opieramy na `metadata.Status`, a nie na samym istnieniu pliku.
+- Lista `digit` pochodzi wyłącznie z `digit/folders.json`.
+- `digit/folders` nie powinno stać się boczną drogą do skanowania filesystemu.
+- To, że w `UC-18` dla `digit` nie ma osobnego podglądu plików, nie zmienia faktu, że endpoint musi być spójny kontraktowo i operacyjnie z `board/folders`.
+
+## 13) Mermaid flowchart - flow modeli
+
+```mermaid
+flowchart TD
+    A["route preparationName<br/>DatasetsController.GetPreparationDigitFoldersAsync()<br/>parametr sciezki FE"] --> B["GetDatasetPreparationFoldersQuery<br/>GetPreparationDigitFoldersAsync()<br/>query aplikacyjne z type=digit"]
+    B --> C["DatasetPreparationMetadataDto<br/>IDatasetPreparationsGateway.GetByNameAsync()<br/>metadata preparation i status"]
+    C --> D["IReadOnlyList<string><br/>IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync()<br/>lista nazw z digit/folders.json"]
+    D --> E["GetDatasetPreparationFoldersQueryResultDto<br/>GetDatasetPreparationFoldersQueryHandler.Handle()<br/>wynik use-case"]
+    E --> F["DatasetPreparationFoldersApiResponse<br/>ToDatasetPreparationFoldersApiResponse()<br/>publiczna odpowiedz FE"]
+```
+
+## 14) Mermaid flowchart - logika aplikacji z funkcjami
+
+```mermaid
+flowchart TD
+    A["DatasetsController.GetPreparationDigitFoldersAsync()<br/>odbiera GET /api/datasets/preparations/{preparationName}/digit/folders"] --> B["GetDatasetPreparationFoldersQueryValidator.Validate()<br/>waliduje preparationName i type"]
+    B --> C["GetDatasetPreparationFoldersQueryHandler.Handle()<br/>koordynuje odczyt manifestu digit"]
+    C --> D["IDatasetPreparationsGateway.GetByNameAsync()<br/>czyta preparation.metadata.json"]
+    D --> E["GetDatasetPreparationFoldersQueryHandler.Handle()<br/>mapuje null na not found"]
+    E --> F["GetDatasetPreparationFoldersQueryHandler.EnsurePreparationCompleted()<br/>pilnuje gotowosci artefaktow"]
+    F --> G["IDatasetPreparationArtifactsGateway.GetSourceFolderNamesAsync()<br/>czyta digit/folders.json"]
+    G --> H["GetDatasetPreparationFoldersQueryHandler.Handle()<br/>buduje items i totalCount"]
+    H --> I["DatasetsController.ToDatasetPreparationFoldersApiResponse()<br/>mapuje DTO do kontraktu HTTP"]
+    I --> J["DatasetsController.GetPreparationDigitFoldersAsync()<br/>zwraca 200 OK"]
+```
+
+## 15) Logging
+
+### 15.1 Information
+- log start:
+  - `preparationName`
+  - `type`
+- log success:
+  - `preparationName`
+  - `type`
+  - `totalCount`
+
+### 15.2 Warning
+- preparation nie istnieje
+- preparation istnieje, ale nie jest gotowe do odczytu artefaktów
+
+### 15.3 Error
+- błąd odczytu `digit/folders.json`
+- błąd deserializacji manifestu
+- brak manifestu dla preparation `completed`
+
+### 15.4 Guardraile logowania
+- nie logować całej zawartości `items`
+- nie logować pełnych ścieżek systemowych w odpowiedziach HTTP
+- nie logować każdego wpisu z listy osobno
+- zachować lekki poziom logów analogiczny do `board/folders`
+
+## 16) Workflow GitHub i konfiguracja runtime
+
+### 16.1 Czy endpoint wymaga nowych ustawień
+- Nie.
+- Endpoint nie potrzebuje:
+  - nowych sekretów,
+  - nowych zmiennych środowiskowych,
+  - nowych opcji `appsettings`,
+  - nowego workflow deployowego.
+
+### 16.2 Co już musi istnieć
+- Lokalnie:
+  - `appsettings.local.json` powinien mieć na sztywno ustawione `DatasetsPreparation.PreparationsDirectoryPath`.
+- Produkcyjnie:
+  - `backend-cd.yml` powinien podstawiać `BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH` do `DatasetsPreparation.PreparationsDirectoryPath`.
+
+### 16.3 Stan obecny workflow
+- `backend-cd.yml` już:
+  - waliduje `BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH`
+  - wpisuje tę wartość do `appsettings.production.json`
+- W tym use-case nie trzeba dopisywać nowych kroków workflow.
+- W planie implementacji warto jedynie odnotować, że ten endpoint zależy operacyjnie od poprawnie ustawionej ścieżki preparation storage.
+
+### 16.4 Reguła operacyjna
+- Workflow może modyfikować `appsettings.production.json`.
+- Lokalnie ścieżki pozostają wpisane na sztywno.
+- Deploy nie może nadpisywać katalogu `shared/data`, bo tam znajdują się artefakty runtime preparation.
+
+## 17) Inne istotne reguły
+- Endpoint ma pozostać kompatybilny z istniejącym kontraktem `DatasetPreparationFoldersApiResponse`.
+- `type = "digit"` jest częścią publicznego kontraktu odpowiedzi i nie może zostać pominięte.
+- Nie dokładamy nowych pól typu `status`, `warnings`, `sourceCount`.
+- `items` reprezentują logiczne źródła `digit`, a nie listę plików lub pojedynczych próbek.
+- Zachowanie powinno być symetryczne operacyjnie względem `board/folders`, ale bez dokładania logiki preview.
+
+## 18) Kolejność implementacji kodu dla historyjki
+1. Dodać akcję `GetPreparationDigitFoldersAsync(...)` do `DatasetsController`.
+2. Ustawić trasę:
+   - `preparations/{preparationName}/digit/folders`
+3. Wysłać z kontrolera:
+   - `new GetDatasetPreparationFoldersQuery(preparationName, "digit")`
+4. Reuse'ować istniejące mapowanie błędów i odpowiedzi.
+5. Dodać test `200 OK` dla nowej akcji w `DatasetsControllerTests`.
+6. Dodać test `400` dla walidacji.
+7. Dodać test `404` dla braku preparation.
+8. Dodać test `409` dla niegotowych artefaktów.
+9. Dodać test `500` dla błędu odczytu manifestu.
+10. Opcjonalnie dodać jeden test handlera potwierdzający przepływ z `type = "digit"`.
+11. Wykonać manualny smoke test dla preparation `completed`, `running`, `failed`, nieistniejącego preparation oraz pustego manifestu.
+
+## 19) Guardraile implementacyjne
+- Nie tworzyć nowego query/handlera tylko dla `digit`.
+- Nie przenosić logiki gotowości preparation do `Infrastructure`.
+- Nie skanować katalogów jako fallback.
+- Nie odpytywać `ML`.
+- Nie sortować `items` po stronie `BE`.
+- Nie zmieniać istniejących nazw kontraktów i pól.
+- Nie mapować brakującego manifestu dla `completed` na `404`.
+- Nie hardcodować ścieżek runtime w kodzie.
+
+## 20) Plan testów minimum
+
+### 20.1 API
+- `GetPreparationDigitFoldersAsync_ReturnsOkAndMapsResponse`
+- `GetPreparationDigitFoldersAsync_ReturnsBadRequest_WhenValidationFails`
+- `GetPreparationDigitFoldersAsync_ReturnsNotFound_WhenPreparationDoesNotExist`
+- `GetPreparationDigitFoldersAsync_ReturnsConflict_WhenArtifactsAreNotReady`
+- `GetPreparationDigitFoldersAsync_ReturnsInternalServerError_WhenReadFails`
+
+### 20.2 Application
+- brak obowiązkowych nowych testów logiki, bo stos `folders` już obsługuje `digit`
+- opcjonalnie:
+  - test, że handler przekazuje `type = "digit"` do gatewaya artefaktów
+
+### 20.3 Manual smoke
+- `completed` z dwoma źródłami `digit` -> lista dwóch wpisów
+- `completed` z pustym manifestem -> `200`, `items=[]`
+- `running` -> `409`
+- `failed` -> `409`
+- nieistniejąca nazwa -> `404`
+- uszkodzony `digit/folders.json` -> `500`
+
+## 21) Podsumowanie decyzji architektonicznych
+- Endpoint `digit/folders` jest cienkim rozszerzeniem istniejącego stosu `folders`.
+- Ciężar implementacyjny leży w `Api`, nie w nowej logice `Application` czy `Infrastructure`.
+- `Application` i `Infrastructure` są już zaprojektowane generycznie i należy je reuse'ować bez duplikacji.
+- Źródłem prawdy dla listy `digit` jest wyłącznie `digit/folders.json`.
+- Dla preparation niegotowego semantyką publiczną pozostaje `409 Conflict`.
+- Dla preparation `completed` z brakującym lub uszkodzonym manifestem należy zwrócić `500`.
+- Workflow GitHub nie wymaga nowej zmiany, bo potrzebne podstawienie `PreparationsDirectoryPath` jest już uwzględnione.

--- a/.ai/implementation-plan/be/uc-18-be-get-api-datasets-preparations-preparation-name.md
+++ b/.ai/implementation-plan/be/uc-18-be-get-api-datasets-preparations-preparation-name.md
@@ -1,0 +1,670 @@
+# UC-18-BE - Plan implementacyjny dla `GET /api/datasets/preparations/{preparationName}`
+
+## 1) Przeznaczenie endpointa
+- Endpoint `GET /api/datasets/preparations/{preparationName}` zwraca szczegóły jednego preparation datasetu.
+- W kontekście `UC-18` jego rola jest pomocnicza, ale istotna:
+  - pozwala `FE` wejść w szczegóły preparation po wyborze z listy,
+  - pozwala sprawdzić status preparation przed wejściem w `board/folders`, `digit/folders`, listę plansz, podgląd obrazu i usuwanie,
+  - dostarcza spójne źródło danych o `sources` i `warnings`.
+- Endpoint jest `read-only`:
+  - nie uruchamia preprocessingu,
+  - nie odpytuje `ML`,
+  - nie czyta artefaktów `board/folders.json`, `digit/folders.json`, `file.json`,
+  - nie wykonuje cleanupu ani retry workflow.
+- Dla `UC-18` nie projektujemy tutaj nowego rozwiązania od zera, tylko reuse endpointa bazowego z `UC-17` zgodnie z obecnymi kontraktami.
+
+## 2) Zakres i główne założenia
+- Plan dotyczy wyłącznie części `BE` w `src/Backend/Sudoku`.
+- Nie sugerujemy się stanem `FE` ani bieżącą implementacją `ML`, poza wcześniej uzgodnionymi kontraktami i artefaktami workflow.
+- `Backend` pozostaje `source of truth` dla publicznej odpowiedzi HTTP.
+- Dane dla tego endpointa pochodzą wyłącznie z rekordu metadata preparation utrzymywanego przez `BE`.
+- Należy trzymać się istniejących nazw klas, pól i kontraktów, jeśli zostały już wprowadzone w poprzednich historyjkach.
+- Wniosek dla `UC-18`: ten endpoint nie powinien dostać nowego adaptera storage ani nowego kontraktu API tylko dlatego, że jest konsumowany przez kolejną historyjkę.
+
+## 3) Stan obecny i decyzja dla UC-18
+
+### 3.1 Co już istnieje
+- Endpoint jest już obecny w backendzie.
+- Istnieją już:
+  - akcja kontrolera,
+  - query, validator, handler i DTO,
+  - kontrakt `DatasetPreparationApiResponse`,
+  - gateway odczytu metadata,
+  - testy kontrolera, handlera i validatora,
+  - logowanie start/sukces/błędy,
+  - produkcyjne podstawienie `PreparationsDirectoryPath` w workflow.
+
+### 3.2 Decyzja implementacyjna
+- Dla `UC-18` ten endpoint należy traktować jako `[REUSE - JUŻ GOTOWY]`.
+- Plan dla tej historyjki powinien opisać:
+  - jak z niego korzystać dalej w `UC-18`,
+  - czego nie zmieniać,
+  - jakie pliki są źródłem prawdy,
+  - jakie ewentualne luki wolno domknąć tylko wtedy, gdy rzeczywiście wystąpią podczas wdrażania.
+
+### 3.3 Czego nie robić
+- Nie tworzyć nowego `GetDatasetPreparationForUc18Query`.
+- Nie tworzyć osobnego `Infrastructure` do odczytu detalu preparation.
+- Nie dociągać danych z `board/` i `digit/` do tej odpowiedzi.
+- Nie rozszerzać publicznego kontraktu o pola techniczne typu:
+  - `failureErrorType`,
+  - `failureMessage`,
+  - ścieżki systemowe,
+  - statusy wyliczone heurystycznie z plików.
+
+## 4) Kontrakty API i model komunikacji FE/ML
+
+### 4.1 FE -> BE
+- Metoda i ścieżka:
+  - `GET /api/datasets/preparations/{preparationName}`
+- Route param:
+  - `preparationName: string`
+- Request body:
+  - brak
+- Query string:
+  - brak
+- Autoryzacja:
+  - taka sama jak dla innych endpointów administracyjnych z `UC-13`
+
+### 4.2 BE -> FE
+- `200 OK` -> `DatasetPreparationApiResponse`
+- `400 Bad Request` -> `ErrorApiResponse`
+- `401 Unauthorized` -> `ErrorApiResponse`
+- `404 Not Found` -> `ErrorApiResponse`
+- `500 Internal Server Error` -> `ErrorApiResponse`
+
+### 4.3 Model odpowiedzi HTTP
+`DatasetPreparationApiResponse`
+- `preparationName: string`
+- `createdAtUtc: string`
+- `status: string`
+- `sources: DatasetPreparationSourceApiResponse[]`
+- `warnings: string[]`
+
+`DatasetPreparationSourceApiResponse`
+- `name: string`
+- `type: string`
+- `preparedItemsCount: number`
+
+Przykład `200 OK`:
+
+```json
+{
+  "preparationName": "preparation-001",
+  "createdAtUtc": "2026-06-19T18:42:11Z",
+  "status": "completed",
+  "sources": [
+    {
+      "name": "v1_training",
+      "type": "board",
+      "preparedItemsCount": 24
+    },
+    {
+      "name": "mnist_train",
+      "type": "digit",
+      "preparedItemsCount": 110
+    }
+  ],
+  "warnings": [
+    "preparation_cleanup_partial"
+  ]
+}
+```
+
+### 4.4 BE -> ML
+- brak komunikacji dla tego endpointa
+
+### 4.5 ML -> BE
+- brak komunikacji HTTP dla tego endpointa
+- jedyną pośrednią zależnością jest wcześniejsze zapisanie poprawnych metadata przez wcześniejszy workflow preparation
+
+### 4.6 Plikowy kontrakt wejściowy dla BE
+- Jedynym źródłem danych jest:
+  - `{DatasetsPreparation.PreparationsDirectoryPath}/{preparationName}/preparation.metadata.json`
+- Ten endpoint nie powinien czytać:
+  - `board/folders.json`,
+  - `digit/folders.json`,
+  - `board/{sourceName}/file.json`,
+  - obrazów,
+  - innych artefaktów runtime.
+
+## 5) Zachowanie per warstwa
+
+### 5.1 API (`Sudoku`)
+- `DatasetsController`:
+  - binduje `preparationName`,
+  - wysyła `GetDatasetPreparationDetailsQuery`,
+  - mapuje wynik do `DatasetPreparationApiResponse`,
+  - mapuje wyjątki na `400/404/500`.
+- `Api` nie:
+  - czyta storage,
+  - nie deserializuje JSON,
+  - nie interpretuje plików `board` i `digit`,
+  - nie wywołuje `ML`.
+
+### 5.2 Application (`Application`)
+- `Application` odpowiada za:
+  - walidację `preparationName`,
+  - odczyt metadata przez port,
+  - zamianę braku preparation na `404`,
+  - mapowanie `Sources` + `SourceReports` do publicznego modelu źródeł,
+  - normalizację `warnings`.
+- `Application` nie:
+  - wykonuje niskopoziomowego I/O,
+  - nie zna szczegółów JSON parsera,
+  - nie skanuje katalogów,
+  - nie miesza logiki statusu z obecnością artefaktów runtime.
+
+### 5.3 Domain / Models (`Models`)
+- Warstwa `Models` dostarcza statusy preparation.
+- Dla tego endpointa nie ma potrzeby dodawania nowego modelu domenowego.
+- To jest odczyt rekordu systemowego i logika aplikacyjna, nie nowy byt domenowy.
+
+### 5.4 Infrastructure (`Infrastructure`)
+- `Infrastructure` odpowiada za:
+  - dostęp do pliku `preparation.metadata.json`,
+  - deserializację JSON do `DatasetPreparationMetadataDto`,
+  - zgłoszenie błędu technicznego przy niespójnych lub uszkodzonych danych.
+- `Infrastructure` nie:
+  - decyduje o `404`,
+  - nie mapuje odpowiedzi HTTP,
+  - nie buduje `ApiResponse`,
+  - nie zgaduje stanu workflow na podstawie katalogów.
+
+## 6) Pliki per warstwa i odpowiedzialności
+
+### 6.1 API - pliki i odpowiedzialności
+
+#### `src/Backend/Sudoku/Sudoku/Controllers/DatasetsController.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - akcja `GetPreparationByNameAsync(...)`
+  - log start/sukces/błędy
+  - wysyłka `GetDatasetPreparationDetailsQuery`
+  - mapowanie do `DatasetPreparationApiResponse`
+  - mapowanie `ValidationException -> 400`
+  - mapowanie `DatasetPreparationNotFoundException -> 404`
+  - mapowanie `IOException | UnauthorizedAccessException | InvalidDataException | JsonException -> 500`
+
+#### `src/Backend/Sudoku/Sudoku/Contracts/DatasetPreparationApiResponse.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - publiczny model odpowiedzi dla detalu preparation
+
+#### `src/Backend/Sudoku/Sudoku/Contracts/DatasetPreparationSourceApiResponse.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - publiczny model pojedynczego źródła preparation
+
+#### `src/Backend/Sudoku/Sudoku/Contracts/ErrorApiResponse.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - wspólny kontrakt błędów HTTP
+
+### 6.2 Application - pliki i odpowiedzialności
+
+#### `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationDetailsQuery.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - query MediatR z polem `PreparationName`
+
+#### `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationDetailsQueryValidator.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - walidacja parametru `preparationName`
+  - reuse wspólnych reguł nazwy preparation
+
+#### `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationDetailsQueryHandler.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - odczyt metadata po nazwie
+  - mapowanie braku preparation na wyjątek semantyczny
+  - mapowanie `Sources` i `SourceReports`
+  - normalizacja `warnings`
+
+#### `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationDetailsQueryResultDto.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - wynik use-case dla warstwy API
+
+#### `src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationDetailsErrorTypes.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - `invalid_dataset_preparation_name`
+  - `dataset_preparation_not_found`
+  - `dataset_preparation_read_failed`
+
+#### `src/Backend/Sudoku/Application/Datasets/DatasetPreparationNotFoundException.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - semantyczny wyjątek `404`
+
+#### `src/Backend/Sudoku/Application/Datasets/DatasetPreparationNameValidationRules.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - wspólna walidacja `preparationName`
+  - guardrail anty-path-traversal i anty-invalid-filename
+
+#### `src/Backend/Sudoku/Application/Datasets/DatasetPreparationMetadataDto.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - wewnętrzny rekord metadata preparation
+  - źródło `status`, `sources`, `warnings`, `sourceReports`
+
+#### `src/Backend/Sudoku/Application/Datasets/DatasetPreparationSourceReportDto.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - wewnętrzny raport per źródło
+  - źródło `preparedItemsCount` do publicznej odpowiedzi
+
+#### `src/Backend/Sudoku/Application/Datasets/CreateDatasetPreparationSourceDto.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - źródła wybrane przy tworzeniu preparation
+  - baza do deterministycznej kolejności publicznego `sources`
+
+#### `src/Backend/Sudoku/Application/Abstractions/IDatasetPreparationsGateway.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - port odczytu metadata preparation
+
+### 6.3 Models - pliki i odpowiedzialności
+
+#### `src/Backend/Sudoku/Models/Datasets/DatasetPreparationStatus.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - kanoniczne nazwy statusów:
+    - `queued`
+    - `running`
+    - `completed`
+    - `failed`
+  - pomocnicza semantyka terminalności
+
+### 6.4 Infrastructure - pliki i odpowiedzialności
+
+#### `src/Backend/Sudoku/Infrastructure/Storage/DatasetPreparationsGateway.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - odczyt `preparation.metadata.json`
+  - deserializacja do `DatasetPreparationMetadataDto`
+  - zwrot `null`, gdy plik metadata nie istnieje
+  - techniczne wykrycie niespójności nazwy w pliku
+
+#### `src/Backend/Sudoku/Infrastructure/Storage/LocalFileStorageGateway.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - generyczny, bezpieczny dostęp do plików
+  - ochrona ścieżek i podstawowe operacje I/O
+
+#### `src/Backend/Sudoku/Infrastructure/DependencyInjection.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - rejestracja `IDatasetPreparationsGateway`
+  - brak potrzeby dopinania nowej usługi dla tego endpointa
+
+### 6.5 Testy - pliki i odpowiedzialności
+
+#### `src/Backend/Sudoku/Application.Tests/GetDatasetPreparationDetailsQueryValidatorTests.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - testy walidacji `preparationName`
+
+#### `src/Backend/Sudoku/Application.Tests/GetDatasetPreparationDetailsQueryHandlerTests.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - testy mapowania metadata do wyniku
+  - testy braków `SourceReports`
+  - testy `warnings`
+  - test `404`
+
+#### `src/Backend/Sudoku/Application.Tests/DatasetsControllerTests.cs`
+- status: `[REUSE - JUŻ ISTNIEJE]`
+- odpowiedzialność:
+  - testy `200`, `400`, `404`, `500` dla `GetPreparationByNameAsync(...)`
+
+### 6.6 Konfiguracja i workflow
+
+#### `src/Backend/Sudoku/Sudoku/appsettings.local.json`
+- status: `[REUSE]`
+- odpowiedzialność:
+  - lokalne ustawienie `DatasetsPreparation.PreparationsDirectoryPath` na sztywno
+
+#### `src/Backend/Sudoku/Sudoku/appsettings.production.json`
+- status: `[REUSE]`
+- odpowiedzialność:
+  - produkcyjny overlay z placeholderem dla `PreparationsDirectoryPath`
+
+#### `.github/workflows/backend-cd.yml`
+- status: `[REUSE - JUŻ DOMKNIĘTE]`
+- odpowiedzialność:
+  - walidacja `BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH`
+  - podstawienie `DatasetsPreparation.PreparationsDirectoryPath` do `appsettings.production.json`
+
+## 7) Weryfikacja antyduplikacyjna dla Infrastructure
+- Najpierw należy sprawdzić, czy istnieje już usługa realizująca odczyt metadata preparation.
+- W tym repo już istnieje:
+  - `IDatasetPreparationsGateway`
+  - `DatasetPreparationsGateway`
+- Wniosek:
+  - nie tworzyć nowego `PreparationDetailsGateway`,
+  - nie tworzyć osobnego readera tylko dla `UC-18`,
+  - nie używać `IDatasetPreparationArtifactsGateway`, bo ten endpoint nie czyta artefaktów runtime.
+- To jest dokładnie przypadek, w którym nowa usługa w `Infrastructure` byłaby duplikacją i naruszałaby podział odpowiedzialności.
+
+## 8) Przepływ w obrębie backendu
+1. `FE` wywołuje `GET /api/datasets/preparations/{preparationName}`.
+2. Warstwa autoryzacji z `UC-13` przepuszcza tylko poprawnie uwierzytelnionego admina.
+3. `DatasetsController.GetPreparationByNameAsync(...)` binduje `preparationName`.
+4. Kontroler wysyła `GetDatasetPreparationDetailsQuery(preparationName)`.
+5. `ValidationBehavior` uruchamia `GetDatasetPreparationDetailsQueryValidator`.
+6. `GetDatasetPreparationDetailsQueryHandler.Handle(...)` wywołuje `IDatasetPreparationsGateway.GetByNameAsync(preparationName)`.
+7. Jeśli metadata nie istnieją:
+  - handler rzuca `DatasetPreparationNotFoundException`.
+8. Jeśli metadata istnieją:
+  - handler mapuje wynik na `GetDatasetPreparationDetailsQueryResultDto`,
+  - kolejność `sources` bierze z `Sources`,
+  - `preparedItemsCount` dobiera z `SourceReports`,
+  - `warnings` normalizuje do pustej listy, jeśli są `null`.
+9. Kontroler mapuje DTO do `DatasetPreparationApiResponse`.
+10. API zwraca `200 OK`.
+
+## 9) Główne funkcje
+- `DatasetsController.GetPreparationByNameAsync(...)`
+- `DatasetsController.ToDatasetPreparationApiResponse(...)`
+- `GetDatasetPreparationDetailsQueryValidator.Validate(...)`
+- `DatasetPreparationNameValidationRules.Validate(...)`
+- `GetDatasetPreparationDetailsQueryHandler.Handle(...)`
+- `GetDatasetPreparationDetailsQueryHandler.MapToResultDto(...)`
+- `GetDatasetPreparationDetailsQueryHandler.MapSourceReports(...)`
+- `GetDatasetPreparationDetailsQueryHandler.NormalizeWarnings(...)`
+- `IDatasetPreparationsGateway.GetByNameAsync(...)`
+- `DatasetPreparationsGateway.GetByNameAsync(...)`
+
+## 10) Wyjątki, fallbacki i zachowanie błędowe
+
+### 10.1 Publiczne statusy HTTP
+- `200 OK`
+  - preparation istnieje
+  - metadata są poprawne
+  - status może być `queued`, `running`, `completed` albo `failed`
+- `400 Bad Request`
+  - pusty `preparationName`
+  - niedozwolone znaki w `preparationName`
+- `401 Unauthorized`
+  - brak poprawnej autoryzacji
+- `404 Not Found`
+  - preparation nie istnieje
+- `500 Internal Server Error`
+  - błąd I/O
+  - uszkodzony JSON metadata
+  - niespójność nazwy preparation w pliku metadata
+  - brak dostępu do storage
+
+### 10.2 Dozwolone fallbacki
+- Jeśli status to `queued`:
+  - zwracamy `200`
+  - bez zgadywania dalszego postępu
+- Jeśli status to `running`:
+  - zwracamy `200`
+  - `preparedItemsCount` może być `0` dla części źródeł
+- Jeśli status to `failed`:
+  - zwracamy `200`
+  - nie ukrywamy preparation z listy
+- Jeśli `warnings` są `null`:
+  - zwracamy `warnings: []`
+- Jeśli dla części `Sources` nie ma pasującego `SourceReport`:
+  - zwracamy dane źródła,
+  - `preparedItemsCount = 0`,
+  - zachowujemy kolejność z `Sources`
+
+### 10.3 Fallbacki niedozwolone
+- Nie odczytywać `board/folders.json` ani `digit/folders.json`, aby "uzupełnić" odpowiedź.
+- Nie liczyć `preparedItemsCount` przez skan katalogów.
+- Nie zmieniać `status` na podstawie artefaktów runtime.
+- Nie odpytywać `ML`, by potwierdzić realny stan preparation.
+- Nie eksponować pól technicznych metadata, jeśli nie są częścią publicznego kontraktu.
+
+### 10.4 Rekomendowane `errorType`
+- `invalid_dataset_preparation_name`
+- `dataset_preparation_not_found`
+- `dataset_preparation_read_failed`
+
+### 10.5 Sytuacje graniczne
+- istnieje katalog preparation, ale brak `preparation.metadata.json`
+  - publicznie traktować jako `404`
+- metadata istnieją, ale `PreparationName` w pliku różni się od route
+  - `500`
+- `SourceReports` są w innej kolejności niż `Sources`
+  - odpowiedź nadal ma zachować kolejność `Sources`
+- preparation ma status `failed` i warnings
+  - poprawny `200`, bez zmiany kontraktu
+
+## 11) Specyficzna logika i pseudokod
+
+### 11.1 Pseudokod handlera
+
+```text
+handleGetDatasetPreparationDetails(query):
+  validate(query.preparationName)
+
+  metadata = datasetPreparationsGateway.getByName(query.preparationName)
+  if metadata is null:
+    throw dataset_preparation_not_found
+
+  sources = mapSources(metadata.sources, metadata.sourceReports)
+  warnings = normalizeWarnings(metadata.warnings)
+
+  return {
+    preparationName: metadata.preparationName,
+    createdAtUtc: metadata.createdAtUtc,
+    status: metadata.status,
+    sources: sources,
+    warnings: warnings
+  }
+```
+
+### 11.2 Pseudokod mapowania źródeł
+
+```text
+mapSources(selectedSources, sourceReports):
+  reportsByKey = sourceReports grouped by (name + "::" + type)
+
+  return selectedSources.map(source => {
+    key = source.name + "::" + source.type
+    report = reportsByKey[key]
+
+    if report is null:
+      return {
+        name: source.name,
+        type: source.type,
+        preparedItemsCount: 0
+      }
+
+    return {
+      name: source.name,
+      type: source.type,
+      preparedItemsCount: report.preparedItemsCount
+    }
+  })
+```
+
+### 11.3 Pseudokod walidacji
+
+```text
+validatePreparationName(preparationName):
+  if preparationName is null or whitespace:
+    invalid_dataset_preparation_name
+
+  trimmed = trim(preparationName)
+
+  if trimmed.length > 160:
+    invalid_dataset_preparation_name
+
+  if trimmed contains ".." or "/" or "\" or ":":
+    invalid_dataset_preparation_name
+
+  if trimmed contains control chars or invalid filename chars:
+    invalid_dataset_preparation_name
+```
+
+### 11.4 Wyjątkowa logika do uwzględnienia
+- Publiczne `sources` powinny być budowane na bazie `Sources`, a nie na bazie `SourceReports`.
+- Dzięki temu nie tracimy źródeł w odpowiedzi, gdy raporty cząstkowe jeszcze nie istnieją albo są niepełne.
+- To jest ważne szczególnie dla `UC-18`, bo użytkownik ma móc ocenić stan preparation jeszcze przed wejściem w szczegóły artefaktów.
+
+## 12) Mermaid flowchart - flow modeli
+
+```mermaid
+flowchart TD
+    A["route preparationName<br/>DatasetsController.GetPreparationByNameAsync()<br/>parametr wejściowy FE"] --> B["GetDatasetPreparationDetailsQuery<br/>GetPreparationByNameAsync()<br/>query aplikacyjne"]
+    B --> C["DatasetPreparationMetadataDto<br/>IDatasetPreparationsGateway.GetByNameAsync()<br/>trwałe metadata preparation"]
+    C --> D["GetDatasetPreparationDetailsQueryResultDto<br/>GetDatasetPreparationDetailsQueryHandler.Handle()<br/>wynik use-case"]
+    D --> E["DatasetPreparationApiResponse<br/>ToDatasetPreparationApiResponse()<br/>publiczna odpowiedź FE"]
+```
+
+## 13) Mermaid flowchart - logika aplikacji z funkcjami
+
+```mermaid
+flowchart TD
+    A["DatasetsController.GetPreparationByNameAsync()<br/>odbiera GET /api/datasets/preparations/{preparationName}"] --> B["GetDatasetPreparationDetailsQueryValidator.Validate()<br/>waliduje preparationName"]
+    B --> C["GetDatasetPreparationDetailsQueryHandler.Handle()<br/>koordynuje odczyt detalu preparation"]
+    C --> D["IDatasetPreparationsGateway.GetByNameAsync()<br/>czyta preparation.metadata.json"]
+    D --> E["GetDatasetPreparationDetailsQueryHandler.Handle()<br/>mapuje null na not found"]
+    E --> F["GetDatasetPreparationDetailsQueryHandler.MapSourceReports()<br/>buduje publiczne sources"]
+    F --> G["GetDatasetPreparationDetailsQueryHandler.NormalizeWarnings()<br/>normalizuje warnings"]
+    G --> H["DatasetsController.ToDatasetPreparationApiResponse()<br/>mapuje DTO do kontraktu HTTP"]
+    H --> I["DatasetsController.GetPreparationByNameAsync()<br/>zwraca 200 OK"]
+```
+
+## 14) Logging
+
+### 14.1 `Information`
+- start odczytu:
+  - `preparationName`
+- sukces odczytu:
+  - `preparationName`
+  - `status`
+
+### 14.2 `Warning`
+- preparation nie istnieje
+- opcjonalnie:
+  - preparation ma status `failed`, jeśli zespół chce lekki sygnał operacyjny
+
+### 14.3 `Error`
+- błąd odczytu metadata
+- błąd deserializacji metadata
+- niespójność nazwy preparation w pliku metadata
+
+### 14.4 Guardraile logowania
+- nie logować całego `preparation.metadata.json`
+- nie logować pełnych ścieżek systemowych w odpowiedzi HTTP
+- nie logować całych tablic `warnings` i `sources` przy każdym poprawnym `GET`
+- logi mają być lekkie i użyteczne diagnostycznie
+
+## 15) Workflow GitHub i konfiguracja runtime
+
+### 15.1 Czy potrzebne są nowe zmiany
+- Nie.
+- Ten endpoint nie wymaga:
+  - nowych sekretów,
+  - nowych zmiennych workflow,
+  - nowych opcji `appsettings`,
+  - nowego deployu `ML`.
+
+### 15.2 Co już musi istnieć
+- Lokalnie:
+  - `appsettings.local.json` ma mieć ustawiony na sztywno `DatasetsPreparation.PreparationsDirectoryPath`
+- Produkcyjnie:
+  - `backend-cd.yml` ma walidować `BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH`
+  - workflow ma wpisać tę wartość do `appsettings.production.json`
+
+### 15.3 Reguła operacyjna
+- Workflow może modyfikować `appsettings.production.json`.
+- Lokalnie ścieżki pozostają ustawione na sztywno.
+- Deploy nie może nadpisywać runtime state w `shared/data`, bo tam żyją preparation i ich artefakty.
+
+## 16) Inne istotne reguły
+- `preparationName` pozostaje jedynym identyfikatorem preparation w route.
+- Nie wolno zmieniać nazw pól publicznego kontraktu:
+  - `preparationName`
+  - `createdAtUtc`
+  - `status`
+  - `sources`
+  - `warnings`
+- Nie ujawniać technicznych pól metadata bez osobnej decyzji kontraktowej.
+- Endpoint ma działać poprawnie dla wszystkich statusów preparation, nie tylko dla `completed`.
+- Ten endpoint ma opisywać preparation, a nie gotowość konkretnych artefaktów `UC-18`.
+
+## 17) Kolejność implementacji kodu dla historyjki
+1. Zweryfikować, że `UC-17` endpoint istnieje i jest zgodny z kontraktem wymaganym przez `UC-18`.
+2. Zweryfikować, że źródłem danych jest wyłącznie `preparation.metadata.json`.
+3. Zweryfikować, że kontroler nie czyta artefaktów runtime `board` i `digit`.
+4. Zweryfikować, że `GetDatasetPreparationDetailsQueryValidator` reuse'uje `DatasetPreparationNameValidationRules`.
+5. Zweryfikować, że handler mapuje `Sources` i `SourceReports` deterministycznie.
+6. Zweryfikować, że `warnings` są normalizowane do `[]`.
+7. Zweryfikować mapowanie wyjątków na `400/404/500`.
+8. Zweryfikować testy validatora, handlera i kontrolera.
+9. Jeśli którykolwiek z powyższych punktów ma lukę, uzupełnić ją bez zmiany kontraktu publicznego.
+10. Wykonać manualny smoke dla statusów `queued`, `running`, `completed`, `failed` oraz scenariusza `404`.
+
+## 18) Guardraile implementacyjne
+- Nie tworzyć nowego adaptera `Infrastructure`.
+- Nie używać `IDatasetPreparationArtifactsGateway` w tym endpointcie.
+- Nie odpytywać `ML`.
+- Nie skanować katalogów jako fallback.
+- Nie liczyć `preparedItemsCount` z filesystemu.
+- Nie rozszerzać publicznego kontraktu bez osobnej decyzji.
+- Nie hardcodować ścieżek lokalnych ani produkcyjnych w kodzie.
+- Nie przenosić logiki aplikacyjnej do `Infrastructure`.
+- Nie zmieniać istniejących nazw klas i pól, które są już używane przez wcześniejsze historyjki.
+
+## 19) Zależności pomiędzy historyjkami
+- `UC-13`
+  - dostarcza autoryzację admina
+- `UC-17 POST /api/datasets/preparations`
+  - tworzy rekord preparation i metadata, które ten endpoint odczytuje
+- `UC-17 GET /api/datasets/preparations`
+  - daje listę, z której użytkownik wybiera `preparationName`
+- `UC-18`
+  - konsumuje ten endpoint jako ekran szczegółów i oceny stanu preparation przed dalszym przeglądaniem
+- `UC-19`
+  - reuse'uje ten sam detail endpoint do oceny gotowości preparation przed budową finalnego `.npz`
+
+## 20) Plan testów minimum
+
+### 20.1 Validator
+- pusty `preparationName` -> `400`
+- `preparationName` z niedozwolonymi znakami -> `400`
+- poprawny `preparationName` -> walidacja przechodzi
+
+### 20.2 Handler
+- metadata istnieją -> poprawne mapowanie odpowiedzi
+- brak `SourceReport` dla jednego ze źródeł -> `preparedItemsCount = 0`
+- `warnings = null` -> `warnings = []`
+- brak preparation -> `DatasetPreparationNotFoundException`
+
+### 20.3 API
+- `200 OK`
+- `400 Bad Request`
+- `401 Unauthorized`
+- `404 Not Found`
+- `500 Internal Server Error`
+
+### 20.4 Manual smoke
+- preparation `queued`
+- preparation `running`
+- preparation `completed`
+- preparation `failed`
+- nieistniejąca nazwa
+- uszkodzony `preparation.metadata.json`
+
+## 21) Podsumowanie decyzji architektonicznych
+- Dla `UC-18` endpoint `GET /api/datasets/preparations/{preparationName}` jest elementem reuse z `UC-17`, a nie nową pionową implementacją.
+- `Application` ma zachować pełną logikę use-case:
+  - walidację,
+  - mapowanie `null -> 404`,
+  - składanie publicznych `sources`,
+  - normalizację `warnings`.
+- `Infrastructure` ma pozostać wyłącznie implementacją odczytu metadata.
+- Nie trzeba dodawać nowych usług, nowych opcji konfiguracyjnych ani zmian workflow.
+- Jeśli w implementacji `UC-18` pojawi się potrzeba modyfikacji tego endpointa, powinny to być tylko korekty zgodności lub testów, bez łamania wcześniejszych kontraktów.

--- a/.ai/implementation-plan/fe/uc-18-fe-delete-api-datasets-preparations-{preparationName}-board-{sourceName}-files-{boardFolderName}.md
+++ b/.ai/implementation-plan/fe/uc-18-fe-delete-api-datasets-preparations-{preparationName}-board-{sourceName}-files-{boardFolderName}.md
@@ -1,0 +1,680 @@
+# UC-18-FE - Plan implementacyjny dla `DELETE /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}`
+
+## 1) Przeznaczenie endpointa
+- Endpoint usuwa jeden logiczny element `board` z istniejacego `preparation`.
+- Z perspektywy `FE` ten endpoint:
+  - nie wybiera `preparation`,
+  - nie wybiera `sourceName`,
+  - nie pobiera listy plansz,
+  - nie pobiera obrazu preview,
+  - wykonuje mutacje danych i wymaga pozniejszego odswiezenia listy z `Backendu`.
+- Gdy operator usuwa `boardFolderName`, `Backend` pozostaje jedynym zrodlem prawdy dla:
+  - tego, czy wskazany rekord nadal istnieje,
+  - tego, czy usuniecie sie powiodlo,
+  - liczby pozostalych rekordow,
+  - finalnego ksztaltu listy po usunieciu,
+  - ewentualnej korekty paginacji po zmianie `totalCount`.
+- `FE` ma jedynie:
+  - wystawic akcje usuniecia,
+  - pokazac bezpieczne potwierdzenie,
+  - zablokowac konfliktowe akcje w trakcie mutacji,
+  - odswiezyc liste przy uzyciu juz istniejacego mechanizmu `GET /board/{sourceName}/files`.
+
+## 2) Zakres planu
+- Plan dotyczy tylko `FE`.
+- Plan nie projektuje implementacji `BE` ani `ML`; opiera sie tylko na:
+  - publicznym kontrakcie endpointa,
+  - wymaganiach `UC-18`,
+  - aktualnym stanie `src/Frontend`,
+  - juz wdrozonych czesciach `UC-17` i `UC-18`.
+- Nie nalezy sugerowac sie biezaca implementacja `BE` i `ML` poza kontraktem HTTP i opisem historyjki.
+- Plan musi pozostac warstwowy i zgodny z praktycznym ukladem:
+  - `src/features/*`
+  - `src/api/*`
+  - `src/types/*`
+  - `src/app/*`
+
+## 3) Miejsce endpointa w workflow `UC-18`
+1. Operator wybiera `preparationName`.
+2. `FE` pobiera `board/folders`.
+3. Operator wybiera `sourceName`.
+4. `FE` pobiera `board/{sourceName}/files?page={page}&pageSize={pageSize}`.
+5. `FE` renderuje liste plansz i preview obrazow.
+6. Operator inicjuje usuniecie jednej planszy `boardFolderName`.
+7. `FE` wysyla `DELETE /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}`.
+8. Po sukcesie `FE` nie zgaduje nowej listy lokalnie, tylko odswieza biezaca strone przez istniejacy hook `useUc18BoardFiles()`.
+9. Jesli po usunieciu biezaca strona przestala istniec, obecny fallback `useUc18BoardFiles()` ma przeladowac ostatnia dostepna strone.
+
+## 4) Co juz istnieje i czego nalezy uzyc
+- Istnieje shell `UC-18`:
+  - `src/Frontend/src/features/uc18/api/Uc18BoardFoldersSection.tsx`
+- Istnieje panel listy plansz:
+  - `src/Frontend/src/features/uc18/api/Uc18BoardFilesPanel.tsx`
+- Istnieje hook listowania plansz i paginacji:
+  - `src/Frontend/src/features/uc18/application/useUc18BoardFiles.ts`
+  - `src/Frontend/src/features/uc18/application/uc18BoardFilesReducer.ts`
+  - `src/Frontend/src/features/uc18/application/uc18BoardFilesTypes.ts`
+- Istnieje model domenowy planszy:
+  - `src/Frontend/src/features/uc18/domain/uc18BoardFile.ts`
+  - `src/Frontend/src/features/uc18/domain/resolveUc18BoardFilesPageAfterLoad.ts`
+- Istnieje preview obrazu per karta:
+  - `src/Frontend/src/features/uc18/api/Uc18BoardImagePreview.tsx`
+  - `src/Frontend/src/features/uc18/application/useUc18BoardImage.ts`
+- Istnieje wspolny klient HTTP dla preparation:
+  - `src/Frontend/src/api/datasetPreparations.ts`
+- Istnieje wspolny helper transportowy:
+  - `src/Frontend/src/api/shared/fetchJson.ts`
+- Istnieja aktualne kontrakty `UC-18`:
+  - `src/Frontend/src/types/api.ts`
+
+Wniosek:
+- nie tworzyc nowego pliku API obok `datasetPreparations.ts`,
+- nie dublowac logiki odswiezania listy z `useUc18BoardFiles()`,
+- nie implementowac optymistycznej rekonstrukcji paginowanej listy po stronie klienta,
+- reuse'owac istniejace `page`, `pageSize`, `totalCount` i fallback strony po odswiezeniu.
+
+## 5) Strategia generycznosci i reuse
+- Najpierw trzeba sprawdzic, czy usluga juz istnieje.
+- Wlasciwe miejsce rozszerzenia juz istnieje:
+  - `src/Frontend/src/api/datasetPreparations.ts`
+- Nowa funkcja nie musi byc globalnie generyczna dla wszystkich mutacji datasetowych, ale powinna byc napisana tak, by dalo sie ja reuse'owac przy:
+  - recznym ponowieniu delete,
+  - przyszlym batchowym czyszczeniu kart w tym samym feature,
+  - ewentualnych testach integracyjnych hooka mutacji.
+- Reuse ma byc pragmatyczny:
+  - wspolny klient HTTP i `fetchJson()` tak,
+  - reuse `Uc18BoardFile` jako targetu delete tak,
+  - reuse `useUc18BoardFiles().loadBoardFiles()` do finalnego reconcile tak,
+  - tworzenie nowego globalnego store dla mutacji nie.
+- Najwazniejsza decyzja architektoniczna:
+  - po sukcesie delete nie mutowac lokalnej paginowanej listy "na slepo",
+  - tylko przeladowac biezacy widok z `Backendu`.
+
+## 6) Model API w komunikacji z BE
+
+### 6.1 Request `FE -> BE`
+- Metoda i sciezka:
+  - `DELETE /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}`
+- Path params:
+  - `preparationName: string`
+  - `sourceName: string`
+  - `boardFolderName: string`
+- Query params:
+  - brak
+- Body:
+  - brak
+- Naglowki:
+  - `Accept: application/json`
+  - `Authorization: Bearer <token>` gdy sesja administracyjna jest aktywna
+
+### 6.2 Model wejscia po stronie FE
+- `FE` nie wysyla JSON body.
+- Warstwa `ViewController` potrzebuje:
+  - `Uc18BoardFile`
+  - aktualne `page`
+  - aktualne `pageSize`
+  - `preparationName` i `sourceName` aktywnego scope'u
+- Delete powinien byc uruchamiany tylko dla planszy widocznej na aktualnej liscie.
+
+### 6.3 Model wyjsciowy sukcesu
+- Oczekiwany status:
+  - `200 OK`
+- Nalezy dodac do `src/Frontend/src/types/api.ts`:
+  - `DeleteDatasetPreparationBoardFileApiResponse`
+    - `preparationName: string`
+    - `sourceName: string`
+    - `boardFolderName: string`
+    - `deleted: boolean`
+    - `remainingItemsCount: number`
+
+Przyklad:
+
+```json
+{
+  "preparationName": "preparation-001",
+  "sourceName": "v1_training",
+  "boardFolderName": "Image1079",
+  "deleted": true,
+  "remainingItemsCount": 241
+}
+```
+
+### 6.4 Model bledu
+- Reuse:
+  - `ErrorApiResponse`
+    - `errorType: string`
+    - `message: string`
+
+### 6.5 Reguly kontraktowe
+- Nie zmieniac nazw juz istniejacych kontraktow i nowych nazw wynikajacych z historyjki:
+  - `DeleteDatasetPreparationBoardFileApiResponse`
+  - `ErrorApiResponse`
+- Dane JSON pozostaja w `camelCase`.
+- `deleted` nie jest sygnalem do lokalnego zgadywania nowej strony; to tylko potwierdzenie mutacji.
+- `remainingItemsCount` jest metadana diagnostyczno-UI, ale nadal nie daje prawa do samodzielnego przebudowania paginowanej listy po stronie `FE`.
+- Odpowiedz `200` z `deleted = false` nalezy traktowac jako niespojny kontrakt dla tego use-case'u, a nie jako cichy sukces.
+
+## 7) Zachowanie z kazdej warstwy MVVC
+
+### Model
+- Obejmuje:
+  - kontrakt `DeleteDatasetPreparationBoardFileApiResponse`,
+  - istniejacy model `Uc18BoardFile`,
+  - ewentualna lekka strukture lokalnego sukcesu delete do UI,
+  - czyste reguly zgodnosci scope'u delete z aktywna lista.
+- Nie zna Reacta, `fetch` ani statusow HTTP.
+
+### View
+- Obejmuje:
+  - przycisk usuniecia na karcie planszy,
+  - lokalny stan potwierdzenia akcji,
+  - informacje "trwa usuwanie",
+  - komunikat sukcesu / bledu mutacji,
+  - zablokowanie konfliktowych akcji podczas delete.
+- Nie wykonuje `fetch`.
+- Nie buduje URL-i endpointow.
+
+### ViewController
+- Obejmuje:
+  - `useUc18DeleteBoardFile()`,
+  - uruchomienie requestu `DELETE`,
+  - ochrone przed wieloma rownoleglymi delete'ami,
+  - `AbortController`,
+  - reakcje na `401`, `404`, `409`, `422`, `5xx`,
+  - odswiezenie listy przez reuse `loadBoardFiles()`,
+  - lekkie logowanie diagnostyczne.
+
+### Infrastructure
+- Obejmuje:
+  - guard odpowiedzi delete,
+  - klient `deleteDatasetPreparationBoardFile(...)`,
+  - URL-encode `preparationName`, `sourceName`, `boardFolderName`,
+  - mapowanie bledow transportowych na `DatasetPreparationsApiError`.
+
+## 8) Pliki per warstwa i odpowiedzialnosci
+
+### 8.1 View
+- `[UPDATE]` `src/Frontend/src/features/uc18/api/Uc18BoardFilesPanel.tsx`
+  - osadza akcje usuniecia per karta,
+  - pokazuje komunikat mutacji,
+  - blokuje paginacje i reczne odswiezanie listy w trakcie delete,
+  - nie przejmuje logiki `fetch`.
+- `[ADD]` `src/Frontend/src/features/uc18/api/Uc18BoardFileDeleteAction.tsx`
+  - czysto prezentacyjny komponent akcji delete,
+  - pokazuje dwuetapowe potwierdzenie inline albo kontrolowany stan potwierdzenia,
+  - przyjmuje `isDeleting`, `isDisabled`, `error`, `onConfirm`, `onCancel`.
+- `[REUSE]` `src/Frontend/src/features/uc18/api/Uc18BoardImagePreview.tsx`
+  - pozostaje osobnym preview i nie powinien przejmowac stanu delete.
+- `[REUSE / CONTEXT]` `src/Frontend/src/features/uc18/api/Uc18BoardFoldersSection.tsx`
+  - dalej spina shell calego `UC-18`, ale nie powinien zawierac logiki delete.
+- `[UPDATE]` `src/Frontend/src/styles/datasets.css`
+  - style przycisku delete,
+  - style lekkiego ostrzezenia przed usunieciem,
+  - style komunikatu sukcesu i bledu mutacji,
+  - style stanu "karta zablokowana podczas usuwania".
+
+### 8.2 ViewController
+- `[ADD]` `src/Frontend/src/features/uc18/application/useUc18DeleteBoardFile.ts`
+  - glowny hook mutacji delete,
+  - pilnuje jednego aktywnego delete na panel,
+  - po sukcesie wywoluje odswiezenie przez `loadBoardFiles(...)`.
+- `[ADD]` `src/Frontend/src/features/uc18/application/uc18DeleteBoardFileReducer.ts`
+  - reduktor stanu mutacji delete.
+- `[ADD]` `src/Frontend/src/features/uc18/application/uc18DeleteBoardFileTypes.ts`
+  - typy stanu, akcji, payloadow i kontraktu hooka.
+- `[REUSE]` `src/Frontend/src/features/uc18/application/useUc18BoardFiles.ts`
+  - pozostaje jedynym miejscem pobrania i reconcile paginowanej listy po mutacji,
+  - nie duplikowac w nim klienta `DELETE`.
+- `[REUSE]` `src/Frontend/src/features/uc18/application/uc18BoardFilesTypes.ts`
+  - dostarcza `page`, `pageSize`, `sourceName`, `preparationName`.
+
+### 8.3 Model
+- `[UPDATE]` `src/Frontend/src/types/api.ts`
+  - dodac `DeleteDatasetPreparationBoardFileApiResponse`.
+- `[REUSE]` `src/Frontend/src/features/uc18/domain/uc18BoardFile.ts`
+  - istniejacy model planszy jest targetem delete,
+  - istniejacy `key` moze sluzyc do identyfikacji pending akcji.
+- `[REUSE]` `src/Frontend/src/features/uc18/domain/resolveUc18BoardFilesPageAfterLoad.ts`
+  - po sukcesie delete nadal odpowiada za fallback strony juz na etapie reloadu listy.
+- `[ADD]` `src/Frontend/src/features/uc18/domain/isUc18BoardFileWithinScope.ts`
+  - czysta funkcja sprawdzajaca, czy klikniety `boardFile` nalezy do aktualnego `preparationName + sourceName`;
+  - chroni przed uruchomieniem delete na karcie z nieaktualnego scope'u po szybkiej zmianie widoku.
+
+### 8.4 Infrastructure
+- `[UPDATE]` `src/Frontend/src/api/datasetPreparations.ts`
+  - dodac guard `isDeleteDatasetPreparationBoardFileApiResponse()`,
+  - dodac klient `deleteDatasetPreparationBoardFile(apiBaseUrl, params, accessToken, signal)`.
+- `[REUSE]` `src/Frontend/src/api/shared/fetchJson.ts`
+  - wspolny mechanizm `fetch + parse + validate + errorFactory`.
+
+### 8.5 Pliki kontekstowe, ktorych nie nalezy tutaj rozwijac
+- `[REUSE / UPSTREAM]` `src/Frontend/src/features/uc17/application/useUc17DatasetPreparations.ts`
+  - dostarcza wybor `preparationName`.
+- `[REUSE / UPSTREAM]` `src/Frontend/src/features/uc18/application/useUc18BoardFolders.ts`
+  - dostarcza wybor `sourceName`.
+- `[LEGACY / NIE ROZWIJAC]` `src/Frontend/src/components/Uc12DatasetPreparationSection.tsx`
+  - stary workflow `UC-12`, bez znaczenia dla nowego delete w `UC-18`.
+
+## 9) Glowne funkcje
+- `deleteDatasetPreparationBoardFile()`
+- `isDeleteDatasetPreparationBoardFileApiResponse()`
+- `useUc18DeleteBoardFile()`
+- `deleteBoardFile()`
+- `retryDeleteBoardFile()`
+- `clearDeleteFeedback()`
+- `uc18DeleteBoardFileReducer()`
+- `isUc18BoardFileWithinScope()`
+- `loadBoardFiles()`
+- `resolveUc18BoardFilesPageAfterLoad()`
+- `Uc18BoardFileDeleteAction()`
+
+## 10) Zachowanie aplikacyjne
+- Delete ma byc dostepny tylko wtedy, gdy:
+  - istnieje aktywne `preparationName`,
+  - istnieje aktywne `sourceName`,
+  - rekord planszy jest aktualnie widoczny na liscie,
+  - lista nie jest w trakcie przeladowania dla innego scope'u.
+- Preferowane UX:
+  - pierwszy klik pokazuje lekkie potwierdzenie inline,
+  - drugi klik wykonuje `DELETE`,
+  - anulowanie cofa widok do stanu neutralnego.
+- W trakcie delete:
+  - zablokowac przycisk odswiezenia listy,
+  - zablokowac paginacje,
+  - zablokowac inne przyciski delete w tym panelu,
+  - jasno oznaczyc, ktora plansza jest usuwana.
+- Po sukcesie:
+  - pokazac lekki komunikat sukcesu z `boardFolderName`,
+  - odswiezyc liste przez `loadBoardFiles(preparationName, sourceName, page, pageSize)`,
+  - pozwolic istniejacemu hookowi listy rozwiazac ewentualny fallback strony.
+- `FE` nie powinien:
+  - lokalnie usuwac rekordu i uznawac sprawy za zakonczona bez reloadu,
+  - zgadywac nowego `totalCount`,
+  - przesuwac elementow miedzy stronami po stronie klienta,
+  - komunikowac sie z `ML`.
+
+## 11) Szczegolowa strategia mutacji
+- Delete jest mutacja zmieniajaca globalna liste w danym `source`.
+- Dlatego bezpieczniejsza od optymistycznej mutacji listy jest strategia:
+  1. oznacz rekord jako `deleting`,
+  2. wykonaj request `DELETE`,
+  3. jesli sukces -> odswiez biezaca strone listy,
+  4. jesli po odswiezeniu strona jest nieaktualna -> reuse fallbacku z `useUc18BoardFiles()`.
+- Ta strategia:
+  - respektuje `Backend` jako source of truth,
+  - minimalizuje ryzyko rozjazdu kolejnosci i paginacji,
+  - nie duplikuje logiki listowania w hooku mutacji.
+
+## 12) Wyjatki, fallbacki i zachowanie bledowe
+
+### 12.1 Brak wejscia
+- Gdy `preparationName`, `sourceName` albo `boardFolderName` sa puste:
+  - nie wysylac requestu,
+  - pokazac lokalny blad techniczny,
+  - nie uruchamiac retry automatycznego.
+
+### 12.2 `401 Unauthorized`
+- Wywolac `onUnauthorized`.
+- Zatrzymac mutacje.
+- Pozostawic liste w ostatnim poprawnym stanie.
+- Pokazac komunikat o wygaslej sesji.
+
+### 12.3 `404 Not Found`
+- Traktowac jako stale view:
+  - plansza mogla juz zostac usunieta,
+  - preparation moglo zniknac,
+  - source moglo przestac istniec.
+- Zachowanie FE:
+  - pokazac lekki blad mutacji,
+  - jednorazowo odswiezyc aktualna liste, aby usunac ewentualnego "ducha",
+  - nie wchodzic w petle retry.
+
+### 12.4 `409 Conflict` lub `422 Unprocessable Entity`
+- Traktowac jako blad biznesowy / workflow.
+- Nie wykonywac automatycznego reloadu.
+- Zachowac liste w ostatnim poprawnym stanie.
+- Pokazac czytelny komunikat z `message`.
+
+### 12.5 `5xx`, `502`, `503`, `504`
+- Pokazac blad mutacji.
+- Nie usuwac lokalnie rekordu.
+- Nie wykonywac automatycznego retry.
+- Pozostawic operatorowi jawne ponowienie akcji.
+
+### 12.6 Niepoprawny ksztalt JSON przy `200`
+- Traktowac jako blad techniczny.
+- `console.error`.
+- Nie zakladac sukcesu tylko dlatego, ze status byl `200`.
+- Nie odswiezac listy "w ciemno", jesli nie ma poprawnego potwierdzenia kontraktu.
+
+### 12.7 Dopuszczalne fallbacki
+- Jednorazowy reload aktualnej listy po sukcesie delete.
+- Jednorazowy reload aktualnej listy po `404`, aby zsynchronizowac UI.
+- Zachowanie ostatniej poprawnej listy przy bledzie mutacji.
+- Uzycie istniejacego fallbacku strony po reloadzie listy.
+
+### 12.8 Niedopuszczalne fallbacki
+- Ciche uznanie `404` za sukces bez poinformowania operatora.
+- Lokalna rekonstrukcja brakujacych rekordow / stron po `remainingItemsCount`.
+- Automatyczne wielokrotne delete lub auto-retry w petli.
+- Rownolegle delete wielu kart na tej samej liscie w pierwszej wersji.
+
+## 13) Zachowanie UI
+- Stan neutralny:
+  - przycisk `Usun plansze` dostepny per karta.
+- Stan potwierdzenia:
+  - karta pokazuje lekkie ostrzezenie, ze usuwany jest caly logiczny folder planszy.
+- Stan `deleting`:
+  - karta pokazuje "Usuwanie...",
+  - przyciski paginacji i `Odswiez liste plansz` sa zablokowane,
+  - inne delete sa zablokowane.
+- Stan sukcesu:
+  - panel pokazuje krotki komunikat, np. "Usunieto Image1079. Odswiezono liste."
+- Stan bledu:
+  - komunikat nie powinien zaslaniac calego widoku,
+  - powinien byc osadzony przy panelu listy albo przy konkretnej karcie,
+  - przy `401` zawiera wskazanie ponownego logowania.
+
+## 14) Zachowanie Model
+- `Uc18BoardFile` pozostaje podstawowym targetem delete.
+- Nowy kontrakt `DeleteDatasetPreparationBoardFileApiResponse` opisuje tylko wynik mutacji, nie nowa liste.
+- `isUc18BoardFileWithinScope()` powinno:
+  - porownac `preparationName`,
+  - porownac `sourceName`,
+  - upewnic sie, ze kliknieta karta nalezy do aktualnego panelu.
+- `remainingItemsCount` sluzy do:
+  - lekkiego komunikatu sukcesu,
+  - logowania,
+  - ewentualnej diagnostyki,
+  - ale nie do recznego liczenia nowej paginacji w `View`.
+
+## 15) Zachowanie Infrastructure
+- Klient delete powinien:
+  - `encodeURIComponent` dla wszystkich trzech path params,
+  - uzyc `fetchJson()`,
+  - oczekiwac `200`,
+  - walidowac shape odpowiedzi.
+- Guard odpowiedzi ma sprawdzac:
+  - `preparationName` jako `string`,
+  - `sourceName` jako `string`,
+  - `boardFolderName` jako `string`,
+  - `deleted` jako `boolean`,
+  - `remainingItemsCount` jako `number`.
+- Odpowiedz `200` z `deleted !== true` nalezy traktowac jako blad kontraktu w hooku mutacji.
+
+## 16) Specyficzna logika i pseudokod
+
+### 16.1 Klient infrastrukturalny `DELETE`
+
+```text
+deleteDatasetPreparationBoardFile(apiBaseUrl, params, accessToken, signal):
+  encodedPreparationName = encodeURIComponent(params.preparationName)
+  encodedSourceName = encodeURIComponent(params.sourceName)
+  encodedBoardFolderName = encodeURIComponent(params.boardFolderName)
+
+  return fetchJson({
+    url: `${apiBaseUrl}/datasets/preparations/${encodedPreparationName}/board/${encodedSourceName}/files/${encodedBoardFolderName}`,
+    method: DELETE,
+    expectedStatus: 200,
+    validateResponse: isDeleteDatasetPreparationBoardFileApiResponse
+  })
+```
+
+### 16.2 Ochrona scope'u mutacji
+
+```text
+isUc18BoardFileWithinScope(boardFile, preparationName, sourceName):
+  return (
+    boardFile.preparationName == preparationName &&
+    boardFile.sourceName == sourceName
+  )
+```
+
+### 16.3 Hook mutacji delete
+
+```text
+deleteBoardFile(boardFile):
+  if preparationName or sourceName missing:
+    set error("Brak aktywnego scope'u delete.")
+    return false
+
+  if !isUc18BoardFileWithinScope(boardFile, preparationName, sourceName):
+    set error("Klikniety rekord nie nalezy do aktualnej listy.")
+    return false
+
+  abort previous delete
+  dispatch(deleteStarted(boardFile.key, boardFile.boardFolderName))
+
+  response = await deleteDatasetPreparationBoardFile(...)
+
+  if response.deleted != true:
+    throw contract error
+
+  dispatch(deleteSucceeded(response))
+  await loadBoardFiles(preparationName, sourceName, page, pageSize)
+  return true
+```
+
+### 16.4 Fallback po `404`
+
+```text
+catch error:
+  if error.status == 404:
+    dispatch(deleteFailed(...))
+    await loadBoardFiles(preparationName, sourceName, page, pageSize)
+    return false
+```
+
+## 17) Logging i diagnostyka
+- Logi maja pomagac, ale nie moga spamowac przy wielu kartach na stronie.
+
+### `console.info`
+- start delete:
+  - `preparationName`
+  - `sourceName`
+  - `boardFolderName`
+  - `page`
+  - `pageSize`
+- sukces delete:
+  - `boardFolderName`
+  - `remainingItemsCount`
+- start odswiezenia listy po sukcesie delete
+
+### `console.warn`
+- `401`
+- `404`
+- odrzucenie delete przez walidacje scope'u
+- `409`
+- `422`
+
+### `console.error`
+- `5xx`
+- niepoprawny ksztalt `DeleteDatasetPreparationBoardFileApiResponse`
+- inne nieoczekiwane wyjatki techniczne
+
+### Guardraile logowania
+- nie logowac tokena,
+- nie logowac pelnej odpowiedzi backendu,
+- nie logowac calej listy plansz,
+- logowac tylko lekkie metadane:
+  - `preparationName`
+  - `sourceName`
+  - `boardFolderName`
+  - `page`
+  - `pageSize`
+  - `httpStatus`
+  - `errorType`
+  - `remainingItemsCount`
+
+## 18) Mermaid - flow modeli
+
+```mermaid
+flowchart TD
+  A["Uc18BoardFile\n(domain/uc18BoardFile.ts)"] --> B["isUc18BoardFileWithinScope()\n(domain/isUc18BoardFileWithinScope.ts)"]
+  B --> C["deleteDatasetPreparationBoardFile()\n(api/datasetPreparations.ts)"]
+  C --> D["isDeleteDatasetPreparationBoardFileApiResponse()\n(api/datasetPreparations.ts)"]
+  D --> E["DeleteDatasetPreparationBoardFileApiResponse\n(types/api.ts)"]
+  E --> F["useUc18DeleteBoardFile()\n(application/useUc18DeleteBoardFile.ts)"]
+  F --> G["loadBoardFiles()\n(application/useUc18BoardFiles.ts)"]
+  G --> H["resolveUc18BoardFilesPageAfterLoad()\n(domain/resolveUc18BoardFilesPageAfterLoad.ts)"]
+```
+
+## 19) Mermaid - flow logiki aplikacji
+
+```mermaid
+flowchart TD
+  A["Uc18BoardFilesPanel()\nrender kart i akcji"] --> B["Uc18BoardFileDeleteAction()\npotwierdzenie delete"]
+  B --> C["deleteBoardFile()\napplication/useUc18DeleteBoardFile.ts"]
+  C --> D["isUc18BoardFileWithinScope()\nwalidacja scope'u"]
+  D --> E["deleteDatasetPreparationBoardFile()\nDELETE endpoint"]
+  E --> F["uc18DeleteBoardFileReducer()\ndeleteSucceeded/deleteFailed"]
+  F --> G["loadBoardFiles()\nodswiezenie biezacej strony"]
+  G --> H["resolveUc18BoardFilesPageAfterLoad()\nfallback ostatniej strony"]
+  H --> I["Uc18BoardFilesPanel()\nrender zsynchronizowanej listy"]
+```
+
+## 20) Opis przeplywu w obrebie BE potrzebny frontendowi
+- To nie jest plan implementacji `BE`.
+- Z perspektywy `FE` wymagany jest tylko taki kontraktowy przeplyw:
+  1. `FE` wysyla `DELETE` z `preparationName`, `sourceName`, `boardFolderName`.
+  2. `BE` autoryzuje request.
+  3. `BE` weryfikuje, czy wskazany rekord istnieje i nalezy do danego `source`.
+  4. `BE` usuwa logiczny folder planszy.
+  5. `BE` aktualizuje liste zrodlowa tak, aby po dalszym `GET /files` nie bylo martwego wpisu.
+  6. `BE` zwraca `deleted = true` i `remainingItemsCount`.
+  7. `FE` nie zaklada nic wiecej o strukturze plikow i nie odtwarza tej logiki lokalnie.
+
+## 21) Workflow GitHub i runtime
+- Dla tego endpointa nie widze potrzeby zmiany workflow `FE`.
+- Aktualny workflow:
+  - `.github/workflows/frontend-cd.yml`
+  - buduje `src/Frontend`
+  - ustawia `VITE_API_BASE_URL="${FE_VITE_API_BASE_URL:-/api}"`
+  - pakuje statyczny build
+- Ten endpoint korzysta z tego samego `apiBaseUrl`, wiec:
+  - nie trzeba dodawac nowej zmiennej CI/CD,
+  - nie trzeba zmieniac layoutu artefaktu,
+  - nie trzeba zmieniac deployu FE.
+- Lokalnie:
+  - `FE` dalej korzysta z przypisania "na sztywno" przez obecny mechanizm `VITE_API_BASE_URL`,
+  - plan FE nie dotyka `appsettings`.
+- Produkcyjnie:
+  - workflow backendowy moze podmieniac produkcyjne `appsettings`,
+  - ale FE ma zalezec tylko od publicznego `/api`, a nie od wiedzy o `appsettings`.
+- Guardraile:
+  - nie hardcodowac produkcyjnych hostow w kodzie,
+  - nie dodawac nowego env-a tylko dla delete,
+  - nie traktowac workflow jako miejsca sterowania logika usuwania.
+
+## 22) Kolejnosc implementacji kodu
+1. Rozszerzyc `src/Frontend/src/types/api.ts` o `DeleteDatasetPreparationBoardFileApiResponse`.
+2. Rozszerzyc `src/Frontend/src/api/datasetPreparations.ts` o:
+   - `isDeleteDatasetPreparationBoardFileApiResponse()`
+   - `deleteDatasetPreparationBoardFile(...)`
+3. Dodac helper domenowy `isUc18BoardFileWithinScope.ts`.
+4. Dodac `uc18DeleteBoardFileTypes.ts` i `uc18DeleteBoardFileReducer.ts`.
+5. Dodac hook `useUc18DeleteBoardFile.ts`.
+6. Dodac komponent `Uc18BoardFileDeleteAction.tsx`.
+7. Zintegrowac delete z `Uc18BoardFilesPanel.tsx`.
+8. Dopracowac style w `datasets.css`.
+9. Zweryfikowac recznie:
+   - sukces delete,
+   - delete ostatniego rekordu na stronie,
+   - `401`,
+   - `404`,
+   - `409/422`,
+   - `5xx`.
+
+## 23) Guardraile implementacyjne
+- Nie tworzyc nowego klienta API poza `datasetPreparations.ts`.
+- Nie robic optymistycznego przestawiania elementow miedzy stronami.
+- Nie duplikowac logiki paginacji juz obecnej w `useUc18BoardFiles()`.
+- Nie odswiezac calego workflow `UC-18` po sukcesie delete, jesli wystarczy reload listy plansz.
+- Nie pozwalac na kilka rownoleglych delete'ow w pierwszej iteracji.
+- Nie mieszac stanu delete ze stanem preview obrazu.
+- Nie przenosic logiki `fetch` do `View`.
+- Nie tworzyc obejsc `FE -> ML`.
+- Nie logowac ciezkich payloadow i nie spamowac konsoli sukcesem kazdej re-renderowanej karty.
+
+## 24) Zaleznosci pomiedzy historyjkami
+
+### Wejsciowe
+- `UC-13`
+  - dostarcza sesje administracyjna i token.
+- `UC-17 GET /api/datasets/preparations`
+  - pozwala wybrac `preparation`.
+- `UC-17 GET /api/datasets/preparations/{preparationName}`
+  - daje kontekst szczegolow preparation.
+- `UC-18 GET /api/datasets/preparations/{preparationName}/board/folders`
+  - pozwala wybrac `sourceName`.
+- `UC-18 GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files`
+  - dostarcza liste kart i paginacje, na ktorej pracuje delete.
+- `UC-18 GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}/image`
+  - dostarcza preview tej samej karty, ale nie bierze udzialu w mutacji delete.
+
+### Wyjsciowe
+- `UC-18 GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files`
+  - po delete musi zwracac juz zsynchronizowana liste bez "ducha".
+- `UC-19`
+  - korzysta z oczyszczonego preparation po review i usunieciach.
+
+## 25) Inne istotne reguly
+- `View` ma pozostac cienki:
+  - renderuje,
+  - pyta o potwierdzenie,
+  - deleguje akcje.
+- `ViewController` ma byc jedynym miejscem:
+  - mutacji delete,
+  - odswiezenia po sukcesie,
+  - mapowania bledow technicznych.
+- `Infrastructure` ma znac tylko publiczny kontrakt HTTP.
+- `Backend` pozostaje zrodlem prawdy dla:
+  - kolejnosci rekordow,
+  - paginacji,
+  - remaining count,
+  - finalnej listy po usunieciu.
+- Jesli przyszla historyjka doda batch delete, nalezy najpierw reuse'owac ten hook i dopiero potem ocenic, czy potrzebny jest nowy kontrakt mutacji zbiorczej.
+
+## 26) Plan weryfikacji minimum
+- `npm run check`
+- `npm run build`
+- scenariusz happy path:
+  - karta jest widoczna,
+  - operator potwierdza delete,
+  - backend zwraca `200`,
+  - lista odswieza sie bez usunietej planszy.
+- scenariusz usuniecia ostatniej planszy na stronie:
+  - delete sukces,
+  - reload listy,
+  - fallback na ostatnia dostepna strone dziala poprawnie.
+- scenariusz `401`:
+  - `onUnauthorized` zostaje wywolane,
+  - lista pozostaje w ostatnim poprawnym stanie.
+- scenariusz `404`:
+  - UI pokazuje blad stalego widoku,
+  - lista wykonuje jeden reconcile reload.
+- scenariusz `409/422`:
+  - UI pokazuje blad biznesowy,
+  - nic nie jest usuwane lokalnie.
+- scenariusz niepoprawnego kontraktu `200`:
+  - odpowiedz jest traktowana jako blad techniczny.
+
+## 27) Podsumowanie decyzji
+- Delete dla `UC-18` powinien zostac zaimplementowany jako osobna mutacja w `ViewController`, a nie jako rozszerzenie logiki listowania.
+- Najwazniejsze reuse:
+  - `datasetPreparations.ts`
+  - `fetchJson()`
+  - `Uc18BoardFile`
+  - `useUc18BoardFiles().loadBoardFiles()`
+  - `resolveUc18BoardFilesPageAfterLoad()`
+- Najwazniejsze granice odpowiedzialnosci:
+  - `Infrastructure` wykonuje `DELETE` i waliduje kontrakt,
+  - `ViewController` steruje mutacja oraz reloadem,
+  - `Model` pilnuje scope'u i typow,
+  - `View` renderuje akcje i komunikaty.
+- Najwazniejsze guardraile:
+  - brak nowego klienta API,
+  - brak optymistycznej przebudowy paginacji,
+  - brak wielu rownoleglych delete'ow w pierwszej iteracji,
+  - brak zaleznosci od `ML`,
+  - brak zmian w workflow FE.

--- a/.ai/implementation-plan/fe/uc-18-fe-get-api-datasets-preparations-{preparationName}-board-folders.md
+++ b/.ai/implementation-plan/fe/uc-18-fe-get-api-datasets-preparations-{preparationName}-board-folders.md
@@ -1,0 +1,676 @@
+# UC-18-FE - Plan implementacyjny dla `GET /api/datasets/preparations/{preparationName}/board/folders`
+
+## 1) Przeznaczenie endpointa
+- Endpoint `GET /api/datasets/preparations/{preparationName}/board/folders` zwraca liste logicznych zrodel typu `board` dla wybranego preparation.
+- Z perspektywy `FE` ten endpoint:
+  - zasila pierwszy ekran przegladania w `UC-18`,
+  - pokazuje tylko nazwy folderow zrodlowych `board`,
+  - nie laduje jeszcze listy plansz,
+  - nie laduje obrazow `corrected-board.png`,
+  - nie usuwa zadnych danych,
+  - nie odczytuje bezposrednio struktury katalogow runtime.
+- Wynik endpointa jest wejsciem do kolejnego kroku:
+  - wyboru `sourceName`,
+  - a potem dopiero `GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files`.
+- `Backend` pozostaje jedynym zrodlem prawdy dla:
+  - istnienia preparation,
+  - listy zrodel `board`,
+  - kolejnosci elementow zwracanych z `folders.json`,
+  - lacznej liczby rekordow.
+
+## 2) Zakres planu
+- Plan dotyczy wyłącznie `FE`.
+- Plan nie projektuje implementacji `BE` ani `ML`; opiera sie tylko na:
+  - kontrakcie publicznym,
+  - wymaganiach `UC-18`,
+  - kodzie obecnym w `src/Frontend`.
+- Nie nalezy sugerowac sie biezaca implementacja `BE` i `ML` poza publicznym API i ustalonym kontraktem historyjki.
+- Plan uwzglednia warstwowosc MVVC i obecny kierunek `feature-based`.
+- Plan obejmuje tez minimalny kontekst upstream / downstream, bo ten endpoint nie dziala w izolacji:
+  - upstream: wybor `preparationName`,
+  - downstream: wybor `sourceName` do dalszego listowania plansz.
+
+## 3) Miejsce endpointa w docelowym workflow
+1. Uzytkownik ma juz istniejace preparation utworzone w `UC-17`.
+2. `FE` zna `preparationName` wybrane przez uzytkownika.
+3. `FE` wywoluje `GET /api/datasets/preparations/{preparationName}/board/folders`.
+4. `BE` zwraca liste nazw folderow zrodlowych typu `board`.
+5. `FE` renderuje tylko te nazwy i licznik.
+6. Uzytkownik wybiera jedno `sourceName`.
+7. Dopiero wtedy `FE` moze przejsc do `GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files`.
+
+## 4) Główne zalozenia architektoniczne
+- Globalna architektura FE jest nadal formalnie `TBD`, ale aktualny kod jest praktycznie `feature-based` i warstwowy:
+  - `src/app/*`
+  - `src/features/*`
+  - `src/api/*`
+  - `src/types/*`
+- Dla tego endpointa nalezy utrzymac podzial:
+  - `Model`: kontrakt transportowy, lokalny model folderu i czyste reguly reconcile,
+  - `View`: panel listy folderow, stany `loading/error/empty/success`,
+  - `ViewController`: pobranie danych, abort, retry, reset aktywnego wyboru,
+  - `Infrastructure`: klient HTTP, walidacja JSON, mapowanie bledow transportowych.
+- `FE` nie moze:
+  - skanowac katalogow,
+  - zgadywac nazw folderow,
+  - budowac listy `board` z innych endpointow,
+  - komunikowac sie bezposrednio z `ML`.
+- Jesli trzeba tworzyc nowa usluge, najpierw nalezy sprawdzic, czy istnieje juz odpowiedni modul.
+- W tym repo istnieje juz odpowiedni modul infrastrukturalny:
+  - `src/Frontend/src/api/datasetPreparations.ts`
+- Wniosek:
+  - nie tworzyc nowego pliku `datasetPreparationBoardFolders.ts`,
+  - tylko rozszerzyc `datasetPreparations.ts` o generyczny klient folders.
+
+## 5) Regula generycznosci dla tej historyjki
+- Chociaz ten dokument dotyczy endpointa `board/folders`, implementacja warstwy `Infrastructure` nie powinna byc hardcoded tylko pod `board`.
+- Nalezy dodac generyczna funkcje:
+  - `getDatasetPreparationFolders(apiBaseUrl, preparationName, folderType, accessToken, signal)`
+- Dzieki temu ten sam klient bedzie mogl zostac reuse'owany dla:
+  - `GET /api/datasets/preparations/{preparationName}/board/folders`
+  - `GET /api/datasets/preparations/{preparationName}/digit/folders`
+- Warstwa `ViewController` dla tego dokumentu pozostaje endpoint-specific:
+  - `loadBoardFolders(preparationName)`
+- Warstwa `Model` moze miec lokalne zawężenie domenowe:
+  - wspiera `board | digit`,
+  - ale dla tego konkretnego use-case'u oczekuje finalnie `board`.
+
+## 6) Model API w komunikacji z BE
+
+### 6.1 Request `FE -> BE`
+- Metoda i sciezka:
+  - `GET /api/datasets/preparations/{preparationName}/board/folders`
+- Path params:
+  - `preparationName: string`
+- Query params:
+  - brak
+- Body:
+  - brak
+- Naglowki:
+  - `Accept: application/json`
+  - `Authorization: Bearer <token>` gdy aktywna jest sesja administratora
+
+### 6.2 Model wejsciowy
+- Brak payloadu JSON.
+- Jedynym wymaganym wejsciem jest poprawny `preparationName`.
+
+### 6.3 Model wyjsciowy sukcesu
+- Oczekiwany status HTTP:
+  - `200 OK`
+- Nowy / rozszerzany kontrakt transportowy w `src/Frontend/src/types/api.ts`:
+  - `DatasetPreparationFoldersApiResponse`
+    - `preparationName: string`
+    - `type: string`
+    - `items: string[]`
+    - `totalCount: number`
+
+Przyklad:
+
+```json
+{
+  "preparationName": "preparation-001",
+  "type": "board",
+  "items": [
+    "v1_training",
+    "v2_training"
+  ],
+  "totalCount": 2
+}
+```
+
+### 6.4 Model bledu
+- `ErrorApiResponse`
+  - `errorType: string`
+  - `message: string`
+
+### 6.5 Reguly kontraktowe
+- Nie zmieniac nazw:
+  - `DatasetPreparationFoldersApiResponse`
+  - `ErrorApiResponse`
+- Dane transportowe zostaja w `camelCase`.
+- `type` w `src/types/api.ts` pozostaje `string`, zgodnie z dotychczasowym stylem kontraktow FE.
+- Zawężenie do `board | digit` ma byc lokalne i domenowe, nie transportowe.
+- Dla wywolania `/board/folders` odpowiedz z `type != "board"` nalezy traktowac jako blad kontraktu, a nie jako czesciowy sukces.
+
+## 7) Zachowanie z kazdej warstwy MVVC
+
+### Model
+- Obejmuje:
+  - kontrakt `DatasetPreparationFoldersApiResponse`,
+  - lokalny typ `Uc18PreparationFolderType`,
+  - lokalny model folderu do renderowania,
+  - logike utrzymania aktywnego `sourceName` po odswiezeniu.
+- Nie zna Reacta, `fetch` ani statusow HTTP.
+
+### View
+- Obejmuje:
+  - panel wyboru zrodel `board`,
+  - licznik rekordow,
+  - przycisk `Odswiez liste zrodel`,
+  - stany `loading/error/empty/success`,
+  - akcje wyboru konkretnego `sourceName`.
+- Nie tworzy URL-i endpointow.
+- Nie zawiera walidacji transportu.
+
+### ViewController
+- Obejmuje:
+  - `loadBoardFolders(preparationName)`,
+  - `retryLoadBoardFolders()`,
+  - `selectBoardSource(sourceName)`,
+  - `AbortController`,
+  - reakcje na `401`,
+  - reset wyboru, gdy `sourceName` zniknie po odswiezeniu,
+  - lekkie logowanie diagnostyczne.
+
+### Infrastructure
+- Obejmuje:
+  - `getDatasetPreparationFolders()`,
+  - guard odpowiedzi JSON,
+  - `buildAuthHeaders()`,
+  - `fetchJson()`,
+  - mapowanie bledow HTTP na `DatasetPreparationsApiError`.
+
+## 8) Co juz istnieje i nalezy reuse'owac
+- Istnieje wspolny klient preparation:
+  - `src/Frontend/src/api/datasetPreparations.ts`
+- Istnieje wspolny helper HTTP:
+  - `src/Frontend/src/api/shared/fetchJson.ts`
+- Istnieja juz kontrakty preparation:
+  - `src/Frontend/src/types/api.ts`
+- Istnieje juz wzorzec hookow z:
+  - `AbortController`,
+  - loadable state,
+  - lekkim logowaniem,
+  - obsluga `401`,
+  - zachowaniem poprzednich danych podczas `loading`.
+- Ten wzorzec widac szczegolnie w:
+  - `src/Frontend/src/features/uc17/application/useUc17RawCandidates.ts`
+  - `src/Frontend/src/features/uc17/application/useUc17DatasetPreparations.ts`
+
+Wniosek:
+- reuse'owac `datasetPreparations.ts`,
+- reuse'owac `fetchJson()`,
+- reuse'owac schemat logowania i abortow,
+- nie importowac slepo hooka `useUc17DatasetPreparations()` do `UC-18`, bo to zly poziom odpowiedzialnosci i zla nazwa use-case'u.
+
+## 9) Pliki per warstwa i odpowiedzialnosci
+
+### 9.1 View
+- `[ADD]` `src/Frontend/src/features/uc18/api/index.ts`
+  - publiczny entry point feature'a `UC-18`.
+- `[ADD]` `src/Frontend/src/features/uc18/api/Uc18BoardFoldersSection.tsx`
+  - glowny widok endpointa `board/folders`;
+  - renderuje stany `loading/error/empty/success`;
+  - pokazuje liste nazw folderow i aktywny wybor.
+- `[ADD]` `src/Frontend/src/features/uc18/api/Uc18PreparationFoldersList.tsx`
+  - czysto prezentacyjna lista `sourceName`;
+  - nie zawiera `fetch`;
+  - nie zna `apiBaseUrl`.
+- `[REUSE / INTEGRACJA UC-18]` `src/Frontend/src/app/views/DatasetsView.tsx`
+  - osadza nowy krok `UC-18` w workflow datasetowym;
+  - przekazuje `apiBaseUrl`, `accessToken`, `onUnauthorized`.
+- `[REUSE / INTEGRACJA UC-18]` `src/Frontend/src/app/state.ts`
+  - rozszerza `DatasetsStep` o `uc18`.
+- `[REUSE]` `src/Frontend/src/styles/datasets.css`
+  - style panelu `UC-18`, listy folderow, aktywnego rekordu i bannerow.
+
+### 9.2 ViewController
+- `[ADD]` `src/Frontend/src/features/uc18/application/useUc18BoardFolders.ts`
+  - glowny hook use-case'u dla tego endpointa;
+  - pobiera foldery `board`,
+  - utrzymuje stan, retry, abort i aktywne `sourceName`.
+- `[ADD]` `src/Frontend/src/features/uc18/application/uc18BoardFoldersReducer.ts`
+  - reduktor czystego stanu widoku.
+- `[ADD]` `src/Frontend/src/features/uc18/application/uc18BoardFoldersTypes.ts`
+  - typy stanu, akcji i interfejs publiczny hooka.
+- `[CONTEXT ONLY]` `src/Frontend/src/features/uc17/application/useUc17DatasetPreparations.ts`
+  - wzorzec loadable-state i `401`;
+  - nie powinien byc miejscem implementacji endpointa `UC-18`.
+
+### 9.3 Model
+- `[REUSE + EXTEND]` `src/Frontend/src/types/api.ts`
+  - dodac `DatasetPreparationFoldersApiResponse`.
+- `[ADD]` `src/Frontend/src/features/uc18/domain/uc18PreparationFolder.ts`
+  - lokalny model domenowy folderu;
+  - lokalny typ `Uc18PreparationFolderType = "board" | "digit"`.
+- `[ADD]` `src/Frontend/src/features/uc18/domain/mapDatasetPreparationFoldersToDomain.ts`
+  - mapuje transport do modelu lokalnego;
+  - odrzuca niespojny `type`.
+- `[ADD]` `src/Frontend/src/features/uc18/domain/reconcileSelectedPreparationFolder.ts`
+  - utrzymuje aktywny `sourceName` tylko, gdy nadal istnieje po odswiezeniu.
+- `[ADD]` `src/Frontend/src/features/uc18/domain/toUc18PreparationFolderKey.ts`
+  - buduje stabilny klucz np. `board:v1_training`.
+
+### 9.4 Infrastructure
+- `[REUSE + EXTEND]` `src/Frontend/src/api/datasetPreparations.ts`
+  - dodac:
+    - guard `isDatasetPreparationFoldersApiResponse()`,
+    - generyczna funkcje `getDatasetPreparationFolders(...)`.
+- `[REUSE]` `src/Frontend/src/api/shared/fetchJson.ts`
+  - wspolny mechanizm `fetch + parse + validate + errorFactory`.
+
+### 9.5 Pliki kontekstowe, ktorych nie rozwijac w tym endpointcie
+- `[REUSE / UPSTREAM]` `src/Frontend/src/api/datasetPreparations.ts`
+  - istnieje juz jako klient create/list/details dla preparation;
+  - nowa funkcja folders powinna tam dopasowac sie do istniejacego modulu.
+- `[CONTEXT ONLY]` `src/Frontend/src/features/uc17/api/Uc17RawCandidatesSection.tsx`
+  - pokazuje istniejące preparation w `UC-17`;
+  - nie powinien zostac przepelniony logika `UC-18`.
+- `[LEGACY / NIE ROZWIJAC]` `src/Frontend/src/components/Uc12DatasetPreparationSection.tsx`
+  - dotyczy starego workflow `UC-12`;
+  - nie jest wzorcem dla nowego flow `UC-17 -> UC-18 -> UC-19`.
+
+## 10) Co nalezy dodac lub dopracowac
+- Dodac brakujacy kontrakt transportowy `DatasetPreparationFoldersApiResponse`.
+- Rozszerzyc `datasetPreparations.ts` o generyczny klient folders zamiast tworzyc nowy plik API.
+- Dodac nowy feature `src/features/uc18/*` zamiast dopisywac cala logike do `uc17`.
+- Utrzymac osobny reducer i hook dla `UC-18`, bo stan tego ekranu jest inny niz:
+  - create preparation,
+  - list details,
+  - raw candidates.
+- Nie sortowac i nie deduplikowac listy folderow po stronie `FE`, o ile historia nie wymaga inaczej.
+- Zachowac kolejnosc zwrocona przez `BE`, bo powinna odpowiadac `folders.json`.
+
+## 11) Glowne funkcje
+- `getDatasetPreparationFolders()`
+- `isDatasetPreparationFoldersApiResponse()`
+- `useUc18BoardFolders()`
+- `loadBoardFolders()`
+- `retryLoadBoardFolders()`
+- `selectBoardSource()`
+- `uc18BoardFoldersReducer()`
+- `mapDatasetPreparationFoldersToDomain()`
+- `reconcileSelectedPreparationFolder()`
+- `toUc18PreparationFolderKey()`
+- `Uc18BoardFoldersSection()`
+- `Uc18PreparationFoldersList()`
+- `fetchJson()`
+
+## 12) Zachowanie View
+- Po otrzymaniu poprawnego `preparationName` widok uruchamia pobranie listy folderow `board`.
+- Widok pokazuje:
+  - nazwe wybranego preparation,
+  - licznik `totalCount`,
+  - liste `sourceName`,
+  - stan aktywnego wyboru,
+  - przycisk odswiezenia.
+- Widok nie powinien:
+  - pokazywac miniaturek plansz,
+  - pobierac `board/{sourceName}/files`,
+  - pobierac `image`,
+  - wykonywac delete.
+- Po kliknieciu konkretnego `sourceName` widok tylko aktualizuje lokalny wybor i przygotowuje dane dla kolejnego endpointa.
+
+## 13) Zachowanie ViewController
+- Hook powinien pobierac dane automatycznie po zmianie `preparationName`.
+- Jesli uzytkownik zmieni `preparationName` w trakcie requestu:
+  - poprzedni request trzeba anulowac,
+  - nowy request staje sie jedynym aktywnym.
+- W stanie `loading` nalezy zachowac poprzednia liste tylko dla tego samego `preparationName`.
+- Po sukcesie:
+  - zapisac nowa liste,
+  - wyczyscic blad,
+  - zrobic reconcile aktywnego `sourceName`.
+- Jesli aktywny `sourceName` zniknal po odswiezeniu:
+  - wyczyscic go,
+  - zalogowac lekkie `warn`.
+- Przy `401`:
+  - wywolac `onUnauthorized`.
+
+## 14) Zachowanie Model
+- Lokalny model domenowy nie powinien byc zwykla lista `string[]`, jesli od razu wiadomo, ze kolejny krok potrzebuje stabilnych kluczy i typu.
+- Preferowany lokalny model:
+  - `preparationName: string`
+  - `type: "board" | "digit"`
+  - `folderName: string`
+  - `key: string`
+- Mapowanie powinno:
+  - zachowac kolejnosc z `items`,
+  - odrzucic nieobslugiwany `type`,
+  - nie zmieniac nazw folderow,
+  - nie obcinac wartosci,
+  - nie normalizowac wielkosci liter.
+
+## 15) Zachowanie Infrastructure
+- Klient powinien URL-encode'owac `preparationName`.
+- Funkcja ma byc generyczna po `folderType`, ale dla tego endpointa wywolywana z `"board"`.
+- Oczekiwany status:
+  - `200`
+- Guard odpowiedzi ma sprawdzac:
+  - `preparationName` jako `string`,
+  - `type` jako `string`,
+  - `items` jako `string[]`,
+  - `totalCount` jako `number`.
+- Bledny ksztalt JSON jest bledem technicznym, a nie pustym stanem.
+
+## 16) Specyficzna logika i pseudokod
+
+### 16.1 Generyczny klient folders
+
+```text
+getDatasetPreparationFolders(apiBaseUrl, preparationName, folderType, accessToken, signal):
+  encodedPreparationName = encodeURIComponent(preparationName)
+
+  return fetchJson({
+    url: `${apiBaseUrl}/datasets/preparations/${encodedPreparationName}/${folderType}/folders`,
+    method: GET,
+    expectedStatus: 200,
+    validateResponse: isDatasetPreparationFoldersApiResponse
+  })
+```
+
+### 16.2 Mapowanie odpowiedzi do modelu domenowego
+
+```text
+mapDatasetPreparationFoldersToDomain(response, expectedType):
+  if response.type != expectedType:
+    throw contract error
+
+  return response.items.map(folderName => ({
+    preparationName: response.preparationName,
+    type: expectedType,
+    folderName,
+    key: `${expectedType}:${folderName}`
+  }))
+```
+
+### 16.3 Reconcile aktywnego zrodla po odswiezeniu
+
+```text
+reconcileSelectedPreparationFolder(previousSelectedSourceName, folders):
+  if previousSelectedSourceName is null:
+    return { selectedSourceName: null, wasRemoved: false }
+
+  stillExists = folders.some(folder => folder.folderName == previousSelectedSourceName)
+
+  if stillExists:
+    return { selectedSourceName: previousSelectedSourceName, wasRemoved: false }
+
+  return { selectedSourceName: null, wasRemoved: true }
+```
+
+### 16.4 Orkiestracja hooka
+
+```text
+loadBoardFolders(preparationName):
+  if preparationName.trim() is empty:
+    set state.error = "Wybierz poprawne preparation."
+    do not call backend
+    return
+
+  abort previous request
+  set state = loading
+
+  response = getDatasetPreparationFolders(apiBaseUrl, preparationName, "board", accessToken, signal)
+  mappedFolders = mapDatasetPreparationFoldersToDomain(response, "board")
+  reconciled = reconcileSelectedPreparationFolder(previousSelectedSourceName, mappedFolders)
+
+  if reconciled.wasRemoved:
+    log warn
+
+  set state = success(mappedFolders, reconciled.selectedSourceName)
+```
+
+## 17) Wyjatki, fallbacki i zachowanie bledowe
+
+### 17.1 Statusy HTTP
+- `200 OK`
+  - lista poprawna;
+  - moze byc pusta.
+- `401 Unauthorized`
+  - sesja administratora wygasla albo token jest niepoprawny;
+  - `FE` wywoluje `onUnauthorized`.
+- `403 Forbidden`
+  - uzytkownik nie ma dostepu do kroku administracyjnego;
+  - `FE` pokazuje blad bez retry automatycznego.
+- `404 Not Found`
+  - preparation nie istnieje albo nie jest juz dostepne;
+  - `FE` traktuje to jako stale / nieaktualne wejscie.
+- `500 Internal Server Error`
+  - blad backendu.
+- `502`, `503`, `504`
+  - blad infrastrukturalny na sciezce przegladarka -> nginx -> backend.
+
+### 17.2 Bledy kontraktu
+- Jesli odpowiedz `200` ma zly ksztalt:
+  - traktowac to jako blad techniczny,
+  - nie zamieniac tego na pusta liste,
+  - nie zgadywac brakujacych pol.
+- Jesli endpoint `/board/folders` zwroci `type = "digit"` albo inny typ:
+  - traktowac to jako blad kontraktowy,
+  - nie renderowac listy.
+
+### 17.3 Fallbacki dopuszczalne
+- Zachowanie poprzedniej listy podczas kolejnego `loading` dla tego samego `preparationName`.
+- Zachowanie poprzedniej listy przy chwilowym `500`, `502`, `503`, `504`, jesli nie zmienil sie `preparationName`.
+- Wyczyszczenie tylko aktywnego `sourceName`, jesli zniknal po odswiezeniu.
+
+### 17.4 Fallbacki niedopuszczalne
+- Zgadywanie listy folderow na podstawie `sources` z `GET /api/datasets/preparations/{preparationName}`.
+- Samodzielne budowanie listy po nazwach katalogow po stronie FE.
+- Sortowanie listy alfabetycznie "dla wygody", jesli backend zwrocil inna kolejnosc.
+- Bezposrednie przejscie `FE -> ML`.
+- Automatyczne pobieranie `board/{sourceName}/files` dla wszystkich pozycji po sukcesie `board/folders`.
+
+### 17.5 Zachowanie UI
+- `idle`
+  - stan przed pierwszym pobraniem lub przy braku `preparationName`.
+- `loading`
+  - blokuje przycisk odswiezenia;
+  - moze zachowac poprzednia liste.
+- `error`
+  - pokazuje banner z bledem;
+  - przy `401` dopisuje komunikat o ponownym logowaniu;
+  - przy `404` powinien zasugerowac ponowny wybor preparation.
+- `success + empty`
+  - pokazuje informacje, ze preparation nie ma jeszcze zadnych zrodel `board`.
+- `success + data`
+  - lista jest interaktywna i pozwala wybrac jedno `sourceName`.
+
+## 18) Zachowanie wyjatkowe i fallbacki domenowe
+- Jesli `preparationName` jest pusty lub sklada sie z bialych znakow:
+  - nie wysylac requestu;
+  - pokazac stan oczekiwania na wybor preparation.
+- Jesli uzytkownik szybko zmienia selection preparation:
+  - anulowac poprzednie requesty;
+  - nie dopuscic do nadpisania swiezszego stanu przez starsza odpowiedz.
+- Jesli backend zwroci pusta liste:
+  - traktowac to jako poprawny wynik;
+  - nie pokazywac tego jako blad.
+- Jesli preparation zostalo usuniete pomiedzy odczytami:
+  - `404` nie powinno zostawic aktywnego `sourceName`;
+  - nalezy wyczyscic lokalny wybor zrodla dla tego ekranu.
+
+## 19) Logging i diagnostyka FE
+- Logi maja pomagac w diagnozie, ale nie moga spamowac ani logowac duzych payloadow.
+
+### `console.info`
+- start ladowania folderow `board`,
+- reczne odswiezenie listy,
+- sukces pobrania listy wraz z `totalCount`.
+
+### `console.warn`
+- `401` i wyczyszczenie sesji,
+- usuniecie aktywnego `sourceName` po odswiezeniu,
+- `404` dla nieaktualnego `preparationName`.
+
+### `console.error`
+- `5xx`,
+- blad walidacji ksztaltu odpowiedzi,
+- niespojny `type` odpowiedzi,
+- nieprzetwarzalna odpowiedz backendu.
+
+### Guardraile logowania
+- nie logowac tokena,
+- nie logowac pelnego response backendu,
+- nie logowac calej listy `items`,
+- logowac tylko lekkie metadane:
+  - `preparationName`,
+  - `type`,
+  - `httpStatus`,
+  - `errorType`,
+  - `totalCount`,
+  - `removedSelection`.
+
+## 20) Mermaid flowchart - flow modeli
+
+```mermaid
+flowchart TD
+    A["getDatasetPreparationFolders()<br/>pobiera DatasetPreparationFoldersApiResponse"] --> B["isDatasetPreparationFoldersApiResponse()<br/>walidacja kontraktu HTTP"]
+    B --> C["mapDatasetPreparationFoldersToDomain()<br/>mapuje items do Uc18PreparationFolder[]"]
+    C --> D["Uc18PreparationFolder[]<br/>preparationName + type + folderName + key"]
+    D --> E["reconcileSelectedPreparationFolder()<br/>utrzymuje selectedSourceName"]
+    E --> F["useUc18BoardFolders()<br/>zapisuje stan sukcesu"]
+```
+
+## 21) Mermaid flowchart - logika aplikacji z funkcjami
+
+```mermaid
+flowchart TD
+    A["DatasetsView()<br/>osadza krok UC-18"] --> B["Uc18BoardFoldersSection()<br/>render sekcji board/folders"]
+    B --> C["useUc18BoardFolders()<br/>hook use-case'u"]
+    C --> D["loadBoardFolders()<br/>start pobrania"]
+    D --> E["getDatasetPreparationFolders()<br/>GET /api/datasets/preparations/{preparationName}/board/folders"]
+    E --> F["fetchJson()<br/>status + parse JSON + validate"]
+    F --> G["mapDatasetPreparationFoldersToDomain()<br/>mapowanie do modelu FE"]
+    G --> H["reconcileSelectedPreparationFolder()<br/>utrzymanie aktywnego sourceName"]
+    H --> I["uc18BoardFoldersReducer()<br/>loadSucceeded"]
+    I --> J["Uc18PreparationFoldersList()<br/>render listy folderow"]
+    J --> K["selectBoardSource()<br/>wybor sourceName dla nastepnego endpointa"]
+```
+
+## 22) Opis przeplywu w obrebie BE potrzebny frontendowi
+Ta sekcja opisuje tylko kontraktowe minimum potrzebne `FE`.
+
+1. `FE` wysyla `GET /api/datasets/preparations/{preparationName}/board/folders`.
+2. `BE` weryfikuje autoryzacje.
+3. `BE` rozpoznaje preparation na podstawie `preparationName`.
+4. `BE` odczytuje logiczna liste zrodel `board` dla tego preparation.
+5. `BE` zwraca:
+   - `preparationName`,
+   - `type = "board"`,
+   - `items`,
+   - `totalCount`.
+6. `BE` nie wywoluje `ML` dla tego endpointa.
+7. `FE` nie zaklada nic o fizycznym layoutcie katalogow poza semantyka kontraktu.
+
+## 23) Workflow GitHub i runtime
+- Ten endpoint nie wymaga nowej zmiennej srodowiskowej po stronie FE.
+- Obowiazujacy workflow FE w `.github/workflows/frontend-cd.yml` juz:
+  - buduje `src/Frontend`,
+  - ustawia `VITE_API_BASE_URL="${FE_VITE_API_BASE_URL:-/api}"`,
+  - pakuje `dist`,
+  - publikuje statyczny build.
+- Lokalnie:
+  - `FE` powinien dzialac na stalym `/api` lub lokalnym `VITE_API_BASE_URL`,
+  - nie dotykamy z poziomu FE zadnych `appsettings`.
+- Produkcyjnie:
+  - workflow backendowy moze podmieniac produkcyjne `appsettings`,
+  - ten plan FE nie moze od tego zalezec inaczej niz przez publiczny adres `/api`.
+- Guardrail:
+  - nie hardcodowac produkcyjnych URL-i w komponentach,
+  - nie dodawac nowego env-a, jesli istniejący `VITE_API_BASE_URL` wystarcza,
+  - nie traktowac workflow jako zrodla prawdy dla listy folderow.
+
+## 24) Kolejnosc implementacji kodu dla historyjki
+1. Zweryfikowac obecne kontrakty w `src/Frontend/src/types/api.ts`.
+2. Dodac `DatasetPreparationFoldersApiResponse` bez zmiany istniejacych nazw typow.
+3. Rozszerzyc `src/Frontend/src/api/datasetPreparations.ts` o:
+   - guard odpowiedzi,
+   - generyczne `getDatasetPreparationFolders(...)`.
+4. Dodac model domenowy `UC-18` i czyste helpery mapowania / reconcile.
+5. Dodac typy stanu i reducer `UC-18`.
+6. Dodac hook `useUc18BoardFolders()`.
+7. Dodac widoki `Uc18BoardFoldersSection.tsx` i `Uc18PreparationFoldersList.tsx`.
+8. Zintegrowac nowy krok z `DatasetsView.tsx` i `app/state.ts`, jesli shell `UC-18` jest wdrazany w tej samej iteracji.
+9. Dopracowac lekkie logowanie diagnostyczne.
+10. Uruchomic kontrole jakosci FE.
+
+## 25) Guardraile implementacyjne
+- Nie tworzyc nowego klienta HTTP poza `datasetPreparations.ts`.
+- Nie duplikowac `buildAuthHeaders()`.
+- Nie przenosic `fetch` do komponentow React.
+- Nie importowac logiki `UC-18` do legacy `UC-12`.
+- Nie traktowac `items: []` jako bledu.
+- Nie zgadywac `sourceName` z innych danych.
+- Nie sortowac odpowiedzi po stronie FE bez twardego wymagania.
+- Nie pobierac wszystkich kolejnych endpointow hurtowo po sukcesie `board/folders`.
+- Nie dodawac ciezkiego logowania ani `console.log` na kazdy klik elementu listy.
+
+## 26) Zaleznosci pomiedzy historyjkami
+
+### Wejsciowe
+- `UC-13`
+  - dostarcza sesje administracyjna i token.
+- `UC-17 POST /api/datasets/preparations`
+  - tworzy preparation, na ktorym pracuje `UC-18`.
+- `UC-17 GET /api/datasets/preparations`
+  - daje liste preparation do wyboru.
+- `UC-17 GET /api/datasets/preparations/{preparationName}`
+  - daje kontekst statusu i szczegolow preparation, jesli ekran `UC-18` chce go wyswietlic obok.
+
+### Rownolegle / sasiednie
+- `UC-18 GET /api/datasets/preparations/{preparationName}/digit/folders`
+  - powinien reuse'owac ten sam klient infrastrukturalny i ten sam model typu folderow.
+
+### Wyjsciowe
+- `UC-18 GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files`
+  - konsumuje wybrane `sourceName`.
+- `UC-18 GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}/image`
+  - bedzie downstream po wyborze planszy.
+- `UC-18 DELETE /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}`
+  - zalezy od poprawnego wejscia w source i liste plansz.
+- `UC-19`
+  - korzysta z oczyszczonego preparation.
+
+## 27) Inne istotne reguly
+- Trzymac sie istniejacych kontraktow i nazw typow z poprzednich historyjek.
+- Jesli nowa abstrakcja nie daje realnego reuse, nie tworzyc jej na zapas.
+- Generycznosc powinna dotyczyc przede wszystkim:
+  - klienta folders w `datasetPreparations.ts`,
+  - lokalnego typu `board | digit`,
+  - helpera reconcile.
+- `createdAtUtc`, statusy preparation i inne detale preparation nie sa odpowiedzialnoscia tego endpointa.
+- `FE` ma renderowac tylko publiczna semantyke API, nie layout runtime.
+- `FE` ma pozostac cienki:
+  - backend zwraca liste,
+  - frontend ja prezentuje,
+  - frontend nie rekonstruuje logiki plikowej.
+
+## 28) Plan weryfikacji minimum
+- `npm run check`
+- `npm run build`
+- scenariusz happy path:
+  - poprawny `preparationName`,
+  - backend zwraca `type = "board"`,
+  - lista folderow renderuje sie poprawnie,
+  - wybor `sourceName` dziala.
+- scenariusz pustej listy:
+  - `200 OK`,
+  - UI pokazuje pusty stan bez bledu.
+- scenariusz `401`:
+  - `onUnauthorized` zostaje wywolane.
+- scenariusz `404`:
+  - UI pokazuje blad stalego / niedostepnego preparation,
+  - aktywne `sourceName` zostaje wyczyszczone.
+- scenariusz niepoprawnego `type` w response:
+  - odpowiedz jest traktowana jako blad kontraktowy.
+- scenariusz odswiezenia:
+  - jezeli wybrane `sourceName` zniknie z listy, zostaje wyczyszczone.
+
+## 29) Podsumowanie decyzji
+- Dla `GET /api/datasets/preparations/{preparationName}/board/folders` nalezy dodac nowy feature `UC-18` po stronie `View`, `ViewController` i `Model`, ale warstwe `Infrastructure` trzeba rozszerzyc w istniejacym `datasetPreparations.ts`.
+- Najwazniejsze granice odpowiedzialnosci:
+  - `Infrastructure` pobiera i waliduje kontrakt,
+  - `ViewController` steruje requestem i stanem,
+  - `Model` mapuje dane i utrzymuje selection,
+  - `View` tylko renderuje i deleguje akcje.
+- Najwazniejsze guardraile:
+  - brak duplikacji klienta API,
+  - brak mieszania z `UC-12`,
+  - brak zgadywania danych po stronie FE,
+  - brak eager-loadu plansz i obrazow,
+  - brak ciezkiego logowania.
+- Najwazniejsza decyzja pod reuse:
+  - klient folders ma byc od razu generyczny dla `board` i `digit`,
+  - ale hook i widok w tym dokumencie pozostaja konkretne dla `board/folders`.

--- a/.ai/implementation-plan/fe/uc-18-fe-get-api-datasets-preparations-{preparationName}-board-{sourceName}-files-{boardFolderName}-image.md
+++ b/.ai/implementation-plan/fe/uc-18-fe-get-api-datasets-preparations-{preparationName}-board-{sourceName}-files-{boardFolderName}-image.md
@@ -1,0 +1,575 @@
+# UC-18-FE - Plan implementacyjny dla `GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}/image`
+
+## 1) Przeznaczenie endpointa
+- Endpoint zwraca obraz preview pojedynczej logicznej planszy `board` dla juz wybranego:
+  - `preparationName`,
+  - `sourceName`,
+  - `boardFolderName`.
+- Z perspektywy `FE` endpoint:
+  - uzupelnia placeholder preview w juz istniejacym kroku listy plansz,
+  - dostarcza wizualizacje `corrected-board.png`,
+  - nie sluzy do pobrania listy plansz,
+  - nie sluzy do wyboru `preparation` ani `source`,
+  - nie wykonuje usuwania danych,
+  - nie daje prawa do zgadywania URL-a lub struktury plikow po stronie klienta.
+- `Backend` pozostaje jedynym zrodlem prawdy dla:
+  - istnienia wskazanego `boardFolderName`,
+  - tego, jaki obraz nalezy zwrocic jako preview,
+  - finalnego kontraktu `ImageApiResponse`,
+  - dostarczonego wczesniej `imageEndpoint`.
+
+## 2) Zakres planu
+- Plan dotyczy tylko `FE`.
+- Plan nie projektuje implementacji `BE` ani `ML`; opiera sie tylko na:
+  - publicznym kontrakcie HTTP,
+  - wymaganiach `UC-18`,
+  - aktualnym stanie `src/Frontend`,
+  - juz wdrozonych historyjkach `UC-17` i czesci `UC-18`.
+- Nie nalezy sugerowac sie biezaca implementacja `BE` i `ML` poza ustalonym kontraktem publicznym.
+- Plan musi pozostac warstwowy i zgodny z praktycznym ukladem:
+  - `src/features/*`
+  - `src/api/*`
+  - `src/shared/*`
+  - `src/types/*`
+  - `src/app/*`
+
+## 3) Miejsce endpointa w workflow `UC-18`
+1. Uzytkownik wybiera `preparationName`.
+2. `FE` pobiera `board/folders`.
+3. Uzytkownik wybiera `sourceName`.
+4. `FE` pobiera `board/{sourceName}/files?page={page}&pageSize={pageSize}`.
+5. `BE` zwraca dla kazdej planszy:
+   - `boardFolderName`
+   - `imageEndpoint`
+6. `FE` renderuje liste plansz dla aktualnej strony.
+7. Dla kazdej aktualnie renderowanej planszy `FE` pobiera obraz przez `imageEndpoint`.
+8. Kazda karta planszy pokazuje:
+   - nazwe folderu,
+   - stan ladowania preview,
+   - obraz albo lokalny blad tylko dla tej jednej planszy.
+9. Ewentualny blad jednego preview nie moze unieruchomic calej listy `board/files`.
+
+## 4) Co juz istnieje i czego nalezy uzyc
+- Istnieje shell `UC-18` i lista plansz:
+  - `src/Frontend/src/features/uc18/api/Uc18BoardFoldersSection.tsx`
+  - `src/Frontend/src/features/uc18/api/Uc18BoardFilesPanel.tsx`
+- Istnieje pobieranie listy plansz:
+  - `src/Frontend/src/features/uc18/application/useUc18BoardFiles.ts`
+  - `src/Frontend/src/features/uc18/application/uc18BoardFilesReducer.ts`
+  - `src/Frontend/src/features/uc18/application/uc18BoardFilesTypes.ts`
+- Istnieje model listy plansz z `imageEndpoint`:
+  - `src/Frontend/src/features/uc18/domain/uc18BoardFile.ts`
+  - `src/Frontend/src/features/uc18/domain/mapDatasetPreparationBoardFilesToDomain.ts`
+- Istnieje klient preparation:
+  - `src/Frontend/src/api/datasetPreparations.ts`
+- Istnieje wspolny helper HTTP:
+  - `src/Frontend/src/api/shared/fetchJson.ts`
+- Istnieje repozytoryjny kontrakt obrazu:
+  - `src/Frontend/src/types/api.ts`
+  - `ImageApiResponse`
+- Istnieje helper zamiany kontraktu obrazu na `img src`:
+  - `src/Frontend/src/shared/images/toImageDataUrl.ts`
+- Istnieja juz co najmniej dwa lokalne guardy `ImageApiResponse` w innych modulach API:
+  - `src/Frontend/src/api/examples.ts`
+  - `src/Frontend/src/api/sudokuOverlayCells.ts`
+
+Wniosek:
+- nie tworzyc nowego rownoleglego formatu obrazu,
+- nie tworzyc nowego top-level kroku `UC-18`,
+- nie budowac URL-a obrazka z `preparationName/sourceName/boardFolderName` w `View`,
+- wykorzystac upstream `imageEndpoint` z listy plansz,
+- rozwazyc wydzielenie wspolnego guarda `isImageApiResponse()` zamiast dodawania trzeciej kopii tej samej funkcji.
+
+## 5) Strategia reuse i generycznosci
+- Najpierw trzeba sprawdzic, czy dana usluga juz istnieje.
+- Dla tego endpointa istnieja juz dwa istotne reuse points:
+  - transport obrazu `ImageApiResponse`,
+  - helper `toImageDataUrl(image)`.
+- Najwazniejsza decyzja reuse:
+  - preview obrazu ma korzystac z istniejacego `imageEndpoint`,
+  - nie wolno odtwarzac URL-a na podstawie nazw folderow.
+- Poniewaz w repo sa juz powielone guardy `ImageApiResponse`, wejscie trzeciego klienta obrazu uzasadnia dodanie wspolnego helpera:
+  - `src/Frontend/src/api/shared/isImageApiResponse.ts`
+- Zakres generycznosci powinien byc umiarkowany:
+  - wspolny guard obrazu i wspolny `fetchJson()` tak,
+  - nowy feature-local hook `useUc18BoardImage()` tak,
+  - globalny, wspoldzielony cache obrazow dla calej aplikacji nie jest teraz konieczny.
+- Nie importowac typow stanu obrazu z `src/app/state.ts` do feature'a `uc18`, bo to psuje kierunek zaleznosci `feature -> app`.
+- Stan preview obrazu ma pozostac lokalny dla `UC-18`, ale kontrakt obrazu i helper data-url maja byc wspoldzielone.
+
+## 6) Model API w komunikacji z BE
+
+### 6.1 Request `FE -> BE`
+- Metoda i sciezka:
+  - `GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}/image`
+- Path params:
+  - `preparationName: string`
+  - `sourceName: string`
+  - `boardFolderName: string`
+- Query params:
+  - brak
+- Body:
+  - brak
+- Naglowki:
+  - `Accept: application/json`
+  - `Authorization: Bearer <token>` gdy sesja administratora jest aktywna
+
+### 6.2 Model wejscia po stronie FE
+- Formalnie endpoint przyjmuje tylko path params.
+- Praktycznie `FE` nie powinien ich ponownie sklejac do URL-a w `View`.
+- Preferred input dla warstwy `ViewController`:
+  - `imageEndpoint: string`
+  - `preparationName: string`
+  - `sourceName: string`
+  - `boardFolderName: string`
+- `imageEndpoint` pochodzi z kontraktu `DatasetPreparationBoardFileListItemApiResponse`.
+- Pozostale pola sa potrzebne glownie do:
+  - kluczy React,
+  - alt tekstu,
+  - lekkiego logowania,
+  - stabilnej identyfikacji karty.
+
+### 6.3 Model wyjsciowy sukcesu
+- Oczekiwany status:
+  - `200 OK`
+- Nalezy reuse'owac juz istniejacy kontrakt:
+  - `ImageApiResponse`
+    - `mimeType: string`
+    - `base64: string`
+
+Przyklad:
+
+```json
+{
+  "mimeType": "image/png",
+  "base64": "<base64>"
+}
+```
+
+### 6.4 Model bledu
+- Reuse:
+  - `ErrorApiResponse`
+    - `errorType: string`
+    - `message: string`
+
+### 6.5 Reguly kontraktowe
+- Nie tworzyc nowego typu `DatasetPreparationBoardImageApiResponse`, jesli odpowiedz ma taki sam ksztalt jak inne obrazy w repo.
+- Nie zmieniac nazw:
+  - `ImageApiResponse`
+  - `ErrorApiResponse`
+- Dane JSON pozostaja w `camelCase`.
+- Mimo ze dokument historyjki wspomina alternatywny opis payloadu obrazu, FE musi podporzadkowac sie juz istniejacemu kontraktowi repo:
+  - `mimeType`
+  - `base64`
+- `imageEndpoint` nalezy traktowac jako publiczna, juz policzona dana z `BE`, nie jako cos do rekonstrukcji po stronie klienta.
+
+## 7) Zachowanie z kazdej warstwy MVVC
+
+### Model
+- Obejmuje:
+  - `ImageApiResponse`,
+  - czyste helpery do identyfikacji i normalizacji requestu preview,
+  - konwersje `ImageApiResponse -> data URL`.
+- Nie zna Reacta, `fetch`, statusow HTTP ani `AbortController`.
+- Nie powinien przechowywac globalnego cache aplikacji.
+
+### View
+- Obejmuje:
+  - render karty preview w ramach jednej planszy,
+  - stany `idle/loading/success/error`,
+  - obraz `img`,
+  - placeholder,
+  - lokalny przycisk retry dla pojedynczej planszy.
+- Nie sklada URL-a endpointa.
+- Nie parsuje JSON.
+- Nie uruchamia pobierania listy plansz.
+
+### ViewController
+- Obejmuje:
+  - `useUc18BoardImage()`,
+  - start pobrania po montazu karty i zmianie `imageEndpoint`,
+  - `AbortController`,
+  - retry tylko dla jednego preview,
+  - reakcje na `401/404/5xx`,
+  - lekki log diagnostyczny bez spamowania.
+- Blad w tym hooku nie moze zmieniac stanu `useUc18BoardFiles()`.
+
+### Infrastructure
+- Obejmuje:
+  - walidacje JSON dla `ImageApiResponse`,
+  - klient HTTP pobierajacy obraz po `imageEndpoint`,
+  - podpiety `Authorization`,
+  - mapowanie bledow transportowych na `DatasetPreparationsApiError`.
+- `Infrastructure` ma konsumowac gotowy endpoint, a nie rekonstruowac trase z domenowych nazw.
+
+## 8) Pliki per warstwa i odpowiedzialnosci
+
+### 8.1 View
+- `[UPDATE]` `src/Frontend/src/features/uc18/api/Uc18BoardFilesPanel.tsx`
+  - zamienia placeholder preview na realny komponent obrazu per karta;
+  - nie przejmuje logiki `fetch`.
+- `[ADD]` `src/Frontend/src/features/uc18/api/Uc18BoardImagePreview.tsx`
+  - czysto prezentacyjny komponent jednego preview;
+  - przyjmuje dane planszy i wynik hooka;
+  - renderuje `loading/error/success`.
+- `[REUSE / CONTEXT]` `src/Frontend/src/features/uc18/api/Uc18BoardFoldersSection.tsx`
+  - pozostaje shellem calego kroku `UC-18`;
+  - bez nowego top-level stanu obrazu.
+- `[UPDATE]` `src/Frontend/src/styles/datasets.css`
+  - style placeholdera, obrazka, stanu bledu i retry dla preview.
+
+### 8.2 ViewController
+- `[ADD]` `src/Frontend/src/features/uc18/application/useUc18BoardImage.ts`
+  - glowny hook dla pojedynczego preview;
+  - pobiera obraz po `imageEndpoint`;
+  - utrzymuje lokalny stan i retry.
+- `[ADD]` `src/Frontend/src/features/uc18/application/uc18BoardImageTypes.ts`
+  - typy stanu, akcji i opcji hooka.
+- `[ADD]` `src/Frontend/src/features/uc18/application/uc18BoardImageReducer.ts`
+  - reduktor czystego stanu preview, zgodny z istniejacym stylem `UC-18`.
+- `[REUSE]` `src/Frontend/src/features/uc18/application/useUc18BoardFiles.ts`
+  - dostarcza `imageEndpoint` i dane planszy;
+  - nie powinien byc rozszerzany o stan obrazow wszystkich kart.
+
+### 8.3 Model
+- `[REUSE]` `src/Frontend/src/types/api.ts`
+  - `ImageApiResponse` pozostaje repozytoryjnym kontraktem transportowym obrazu.
+- `[REUSE]` `src/Frontend/src/shared/images/toImageDataUrl.ts`
+  - zamienia `ImageApiResponse` na `data:` URL dla `img src`.
+- `[ADD]` `src/Frontend/src/features/uc18/domain/resolveUc18BoardImageRequestUrl.ts`
+  - normalizuje `imageEndpoint` do finalnego URL-a requestu bez zgadywania sciezki z nazw folderow.
+- `[ADD]` `src/Frontend/src/features/uc18/domain/toUc18BoardImageRequestKey.ts`
+  - buduje stabilny klucz np. z `preparationName`, `sourceName`, `boardFolderName`;
+  - sluzy do identyfikacji instancji preview i bezpiecznego resetu stanu.
+
+### 8.4 Infrastructure
+- `[UPDATE]` `src/Frontend/src/api/datasetPreparations.ts`
+  - dodac klient pobierania obrazu po `imageEndpoint`, np.:
+    - `getDatasetPreparationBoardImageByEndpoint(...)`
+  - wykorzystac `fetchJson()`.
+- `[ADD]` `src/Frontend/src/api/shared/isImageApiResponse.ts`
+  - wspolny guard kontraktu obrazu.
+- `[REUSE]` `src/Frontend/src/api/shared/fetchJson.ts`
+  - wspolny mechanizm `fetch + parse + validate + errorFactory`.
+
+### 8.5 Pliki kontekstowe, ktorych nie nalezy tutaj przebudowywac
+- `[REUSE / CONTEXT]` `src/Frontend/src/api/examples.ts`
+  - ma lokalny guard `ImageApiResponse`; mozna go przepiac na wspolny helper tylko jesli zakres PR to obejmuje.
+- `[REUSE / CONTEXT]` `src/Frontend/src/api/sudokuOverlayCells.ts`
+  - analogicznie do `examples.ts`.
+- `[REUSE / UPSTREAM]` `src/Frontend/src/features/uc18/domain/uc18BoardFile.ts`
+  - przechowuje `imageEndpoint`.
+- `[LEGACY / NIE ROZWIJAC]` `src/Frontend/src/components/Uc12DatasetPreparationSection.tsx`
+  - dotyczy starego workflow.
+
+## 9) Glowne funkcje
+- `isImageApiResponse()`
+- `resolveUc18BoardImageRequestUrl()`
+- `toUc18BoardImageRequestKey()`
+- `getDatasetPreparationBoardImageByEndpoint()`
+- `useUc18BoardImage()`
+- `loadBoardImage()`
+- `retryLoadBoardImage()`
+- `uc18BoardImageReducer()`
+- `toImageDataUrl()`
+- `Uc18BoardImagePreview()`
+
+## 10) Zachowanie aplikacyjne
+- `Uc18BoardFilesPanel` pozostaje odpowiedzialny za:
+  - liste plansz,
+  - paginacje,
+  - render kart.
+- Kazda karta planszy ma wlasny, izolowany preview controller:
+  - startuje po wyrenderowaniu karty,
+  - pobiera tylko swoj obraz,
+  - nie blokuje innych kart.
+- `FE` ma pobierac obrazy tylko dla plansz z aktualnie renderowanej strony.
+- `FE` nie powinien:
+  - pobierac obrazow dla wszystkich stron z gory,
+  - pobierac obrazow dla wszystkich `sourceName`,
+  - pobierac obrazow dla `digit`.
+- Zmiana `page` lub `sourceName` powinna odmontowac stare karty i anulowac ich aktywne requesty.
+- W przypadku rerenderu tej samej karty z tym samym `imageEndpoint` hook nie powinien inicjowac nowego requestu bez realnej zmiany wejscia.
+
+## 11) Wyjatki, fallbacki i zachowanie bledowe
+
+### 11.1 Brak wejscia
+- Gdy `imageEndpoint` jest pusty lub sklada sie z bialych znakow:
+  - nie wysylac requestu,
+  - pokazac lokalny stan bledu preview,
+  - nie oznaczac calej listy plansz jako uszkodzonej.
+
+### 11.2 `401 Unauthorized`
+- Wywolac `onUnauthorized`.
+- Oznaczyc tylko dany preview jako blad.
+- Nie wykonywac automatycznego retry bez nowego logowania.
+
+### 11.3 `404 Not Found`
+- Traktowac jako brak aktualnosci tej jednej planszy lub obrazu.
+- Karta planszy zostaje na liscie, ale preview pokazuje stan bledu z przyciskiem retry.
+- Nie resetowac z tego powodu calej listy `board/files`.
+
+### 11.4 `403 Forbidden`
+- Pokazac lokalny blad dla karty.
+- Nie probowac cichego fallbacku.
+
+### 11.5 `5xx`, `502`, `503`, `504`
+- Pokazac lokalny blad tylko dla danej planszy.
+- Zachowac reszte kart bez zmian.
+- Pozwolic na reczne ponowienie dla pojedynczego preview.
+
+### 11.6 Niepoprawny ksztalt JSON przy `200`
+- Traktowac jako blad techniczny.
+- Nie zgadywac brakujacych pol.
+- Nie probowac parsowac `contentType/base64Content`, jesli kontrakt repo oczekuje `mimeType/base64`.
+
+### 11.7 Abort / szybka zmiana strony
+- Jesli karta zostala odmontowana lub request zastapiony nowszym:
+  - przerwac poprzedni request,
+  - nie nadpisywac stanu nowszej instancji starsza odpowiedzia.
+
+### 11.8 Dopuszczalne fallbacki
+- Placeholder / skeleton podczas ladowania.
+- Lokalny komunikat o bledzie zamiast obrazu.
+- Reczny retry dla jednej karty.
+- Zachowanie listy plansz nawet wtedy, gdy czesc preview sie nie zaladuje.
+
+### 11.9 Niedopuszczalne fallbacki
+- Rekonstrukcja `imageEndpoint` z nazw folderow po stronie `View`.
+- Generowanie falszywego obrazu z innych danych.
+- Automatyczne przeladowanie calej listy plansz po bledzie jednego preview.
+- Cichy retry w petli.
+- Bezposrednia komunikacja `FE -> ML`.
+
+## 12) Specyficzna logika i pseudokod
+
+### 12.1 Normalizacja URL-a requestu
+
+```text
+resolveUc18BoardImageRequestUrl(apiBaseUrl, imageEndpoint):
+  trimmedEndpoint = imageEndpoint.trim()
+
+  if trimmedEndpoint startsWith "http://" or "https://":
+    return trimmedEndpoint
+
+  if trimmedEndpoint startsWith "/":
+    return trimmedEndpoint
+
+  normalizedBase = apiBaseUrl without trailing "/"
+  normalizedPath = trimmedEndpoint without leading "/"
+
+  return `${normalizedBase}/${normalizedPath}`
+```
+
+### 12.2 Pobranie obrazu po gotowym endpointcie
+
+```text
+getDatasetPreparationBoardImageByEndpoint(apiBaseUrl, imageEndpoint, accessToken, signal):
+  url = resolveUc18BoardImageRequestUrl(apiBaseUrl, imageEndpoint)
+
+  return fetchJson({
+    url,
+    method: GET,
+    expectedStatus: 200,
+    validateResponse: isImageApiResponse
+  })
+```
+
+### 12.3 Hook pojedynczego preview
+
+```text
+loadBoardImage(boardFile):
+  if boardFile.imageEndpoint is empty:
+    set state = error("Brak endpointu preview.")
+    return
+
+  abort previous request
+  requestKey = toUc18BoardImageRequestKey(boardFile)
+  dispatch(loadStarted(requestKey))
+
+  response = await getDatasetPreparationBoardImageByEndpoint(...)
+
+  if aborted:
+    return
+
+  dispatch(loadSucceeded({
+    requestKey,
+    image: response
+  }))
+```
+
+### 12.4 Retry dla jednej karty
+
+```text
+retryLoadBoardImage():
+  if current boardFile is missing:
+    return
+
+  call loadBoardImage(currentBoardFile)
+```
+
+## 13) Logging i diagnostyka
+- Logowanie ma pomagac, ale nie moze spamowac przy kilkunastu kartach na stronie.
+
+### `console.info`
+- opcjonalnie tylko dla jawnego retry pojedynczej karty,
+- bez logowania sukcesu kazdego obrazka, bo to szybko zasypie konsola.
+
+### `console.warn`
+- `401` dla preview,
+- `403`,
+- `404`,
+- brak `imageEndpoint`,
+- wyczyszczenie starego requestu po zmianie karty tylko jesli potrzebne diagnostycznie.
+
+### `console.error`
+- `5xx`,
+- niepoprawny ksztalt `ImageApiResponse`,
+- inne nieoczekiwane wyjatki techniczne.
+
+### Guardraile logowania
+- nie logowac `base64`,
+- nie logowac tokena,
+- nie logowac pelnego payloadu obrazu,
+- nie logowac kazdego sukcesu na stronie,
+- logowac tylko lekkie metadane:
+  - `preparationName`,
+  - `sourceName`,
+  - `boardFolderName`,
+  - `httpStatus`,
+  - `errorType`.
+
+## 14) Mermaid - flow modeli
+
+```mermaid
+flowchart TD
+  A["DatasetPreparationBoardFileListItemApiResponse.imageEndpoint\n(types/api.ts)"] --> B["resolveUc18BoardImageRequestUrl()\n(domain/resolveUc18BoardImageRequestUrl.ts)"]
+  B --> C["getDatasetPreparationBoardImageByEndpoint()\n(api/datasetPreparations.ts)"]
+  C --> D["isImageApiResponse()\n(api/shared/isImageApiResponse.ts)"]
+  D --> E["ImageApiResponse\n(types/api.ts)"]
+  E --> F["toImageDataUrl()\n(shared/images/toImageDataUrl.ts)"]
+  F --> G["Uc18BoardImagePreview()\n(api/Uc18BoardImagePreview.tsx)"]
+```
+
+## 15) Mermaid - flow logiki aplikacji
+
+```mermaid
+flowchart TD
+  A["useUc18BoardFiles()\ndostarcza items z imageEndpoint"] --> B["Uc18BoardFilesPanel()\nrenderuje karty plansz"]
+  B --> C["Uc18BoardImagePreview()\nrender jednej karty preview"]
+  C --> D["useUc18BoardImage()\nstart requestu po montazu"]
+  D --> E["loadBoardImage()\nAbortController + dispatch loadStarted"]
+  E --> F["getDatasetPreparationBoardImageByEndpoint()\nwywolanie GET imageEndpoint"]
+  F --> G["uc18BoardImageReducer()\nloadSucceeded/loadFailed"]
+  G --> H["toImageDataUrl()\nzamiana kontraktu obrazu na data URL"]
+  H --> I["img src=...\npokaz preview"]
+  C --> J["retryLoadBoardImage()\nreczny retry jednej karty"]
+  J --> E
+```
+
+## 16) Opis przeplywu w obrebie BE potrzebny frontendowi
+- To nie jest plan implementacji `BE`.
+- Z perspektywy `FE` wymagany jest tylko taki przeplyw kontraktowy:
+  1. `FE` pobiera liste plansz przez `board/{sourceName}/files`.
+  2. `BE` zwraca `imageEndpoint` dla kazdej planszy.
+  3. `FE` wywoluje wskazany endpoint preview.
+  4. `BE` autoryzuje request.
+  5. `BE` zwraca `ImageApiResponse` dla `corrected-board.png`.
+  6. `BE` nie musi do tego endpointa uruchamiac `ML`.
+  7. `FE` nie zaklada nic o fizycznym polozeniu pliku poza semantyka publicznego API.
+
+## 17) Workflow GitHub i runtime
+- Ten endpoint nie wymaga nowej zmiennej srodowiskowej po stronie FE.
+- Aktualny workflow FE:
+  - `.github/workflows/frontend-cd.yml`
+  - buduje `src/Frontend`
+  - ustawia `VITE_API_BASE_URL="${FE_VITE_API_BASE_URL:-/api}"`
+  - pakuje statyczny build
+- Lokalnie:
+  - `FE` moze dzialac na stalym `/api` albo na lokalnym `VITE_API_BASE_URL`
+  - lokalne przypisanie pozostaje "na sztywno" w obecnym mechanizmie `VITE_API_BASE_URL`
+- Produkcyjnie:
+  - workflow `BE` moze podmieniac produkcyjny `appsettings`
+  - plan FE nie powinien od tego zalezec inaczej niz przez publiczne `/api`
+- Guardraile:
+  - nie dodawac nowego env-a tylko dla tego endpointa,
+  - nie hardcodowac produkcyjnych hostow w komponencie preview,
+  - nie traktowac `imageEndpoint` jako wartosci zalezonej od workflow.
+
+## 18) Kolejnosc implementacji kodu dla historyjki
+1. Zweryfikowac reuse aktualnego kontraktu `ImageApiResponse`.
+2. Dodac wspolny guard `isImageApiResponse()` do `src/api/shared`.
+3. Rozszerzyc `src/Frontend/src/api/datasetPreparations.ts` o klient obrazu po `imageEndpoint`.
+4. Dodac czyste helpery domenowe:
+   - `resolveUc18BoardImageRequestUrl()`
+   - `toUc18BoardImageRequestKey()`
+5. Dodac `uc18BoardImageTypes.ts` i `uc18BoardImageReducer.ts`.
+6. Dodac hook `useUc18BoardImage.ts`.
+7. Dodac komponent `Uc18BoardImagePreview.tsx`.
+8. Zintegrowac preview z `Uc18BoardFilesPanel.tsx`.
+9. Dopracowac style w `datasets.css`.
+10. Zweryfikowac scenariusze happy-path i bledowe.
+
+## 19) Guardraile implementacyjne
+- Nie budowac URL-a obrazu z `preparationName/sourceName/boardFolderName`, jesli upstream podal `imageEndpoint`.
+- Nie przenosic stanu preview wszystkich kart do `useUc18BoardFiles()`.
+- Nie importowac stanu `ImageStageState` z `app/state.ts` do feature'a `uc18`.
+- Nie tworzyc nowego kontraktu obrazu obok `ImageApiResponse`.
+- Nie logowac `base64`.
+- Nie robic retry w petli.
+- Nie blokowac calej listy plansz przez blad jednego preview.
+- Nie pobierac obrazow dla wszystkich stron lub wszystkich zrodel.
+- Nie tworzyc obejsc `FE -> ML`.
+
+## 20) Zaleznosci pomiedzy historyjkami
+
+### Wejsciowe
+- `UC-13`
+  - dostarcza sesje administracyjna i token.
+- `UC-17 GET /api/datasets/preparations`
+  - pozwala wybrac preparation.
+- `UC-17 GET /api/datasets/preparations/{preparationName}`
+  - daje kontekst rekordu preparation.
+- `UC-18 GET /api/datasets/preparations/{preparationName}/board/folders`
+  - pozwala wybrac `sourceName`.
+- `UC-18 GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files`
+  - dostarcza liste plansz i `imageEndpoint`.
+
+### Rownolegle / sasiednie
+- `UC-18 GET /api/datasets/preparations/{preparationName}/digit/folders`
+  - nie blokuje preview obrazu, ale jest czescia tego samego ekranu.
+
+### Wyjsciowe
+- `UC-18 DELETE /api/datasets/preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}`
+  - po usunieciu karty preview powinno zniknac razem z rekordem planszy.
+- `UC-19`
+  - korzysta z oczyszczonego preparation po review danych.
+
+## 21) Inne istotne reguly
+- `View` ma pozostac cienki: renderuje i deleguje akcje.
+- `ViewController` ma byc per-karta, a nie per-cala lista preview.
+- `Infrastructure` ma konsumowac publiczny kontrakt i walidowac odpowiedz.
+- Jesli refaktor wspolnego guarda obrazu zahacza o inne moduly, nalezy ograniczyc zmiany do bezpiecznego zakresu bez przemodelowania calego API layer.
+- Jesli w przyszlosci pojawi sie potrzeba optymalizacji masowego ladowania, to:
+  - `IntersectionObserver`,
+  - ograniczenie rownoleglosci,
+  - cache per endpoint
+  powinny byc osobna decyzja, a nie ukrytym rozszerzeniem tej historyjki.
+
+## 22) Podsumowanie decyzji
+- Ten endpoint powinien zostac zaimplementowany jako lekki, izolowany preview obrazu per karta planszy.
+- Najwazniejsze reuse:
+  - `ImageApiResponse`
+  - `toImageDataUrl()`
+  - `fetchJson()`
+  - `imageEndpoint` z upstream listy plansz
+- Najwazniejsze granice odpowiedzialnosci:
+  - `Infrastructure` pobiera i waliduje obraz,
+  - `ViewController` steruje pojedynczym requestem i retry,
+  - `Model` utrzymuje czyste helpery URL/klucza/data-url,
+  - `View` tylko renderuje placeholder, obraz albo blad.
+- Najwazniejsze guardraile:
+  - brak duplikacji kontraktu obrazu,
+  - brak rekonstrukcji URL-a po stronie `FE`,
+  - brak ciezkiego logowania,
+  - brak blokowania calej listy przez blad pojedynczego preview.

--- a/.ai/implementation-plan/fe/uc-18-fe-get-api-datasets-preparations-{preparationName}-board-{sourceName}-files.md
+++ b/.ai/implementation-plan/fe/uc-18-fe-get-api-datasets-preparations-{preparationName}-board-{sourceName}-files.md
@@ -1,0 +1,509 @@
+# UC-18-FE - Plan implementacyjny dla `GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files?page={page}&pageSize={pageSize}`
+
+## 1) Przeznaczenie endpointa
+- Endpoint zwraca paginowana liste logicznych plansz `board` dla jednego, juz wybranego zrodla `sourceName`.
+- Z perspektywy `FE` endpoint:
+  - nie sluzy do wyboru `preparation`,
+  - nie sluzy do wyboru listy zrodel `board`,
+  - nie wykonuje usuwania,
+  - nie zwraca jeszcze samej zawartosci obrazu,
+  - dostarcza dane do kolejnego kroku przegladu plansz w `UC-18`.
+- Ten endpoint jest drugim krokiem przegladania `board`:
+  1. `FE` wybiera `preparationName`,
+  2. `FE` pobiera `board/folders`,
+  3. operator wybiera `sourceName`,
+  4. dopiero wtedy `FE` pobiera `board/{sourceName}/files?page={page}&pageSize={pageSize}`.
+- `Backend` pozostaje jedynym zrodlem prawdy dla:
+  - istnienia `preparationName`,
+  - istnienia `sourceName`,
+  - kolejnosci rekordow na liscie,
+  - lacznej liczby rekordow,
+  - `imageEndpoint` przypisanego do danego `boardFolderName`.
+
+## 2) Zakres planu
+- Plan dotyczy wylacznie `FE`.
+- Plan nie projektuje implementacji `BE` ani `ML`; opiera sie tylko na:
+  - publicznym kontrakcie HTTP,
+  - wymaganiach `UC-18`,
+  - aktualnym stanie `src/Frontend`,
+  - juz dodanych historyjkach i kontraktach.
+- Nie nalezy sugerowac sie biezaca implementacja `BE` i `ML` poza uzgodnionym kontraktem API.
+- Plan ma byc warstwowy i zgodny z praktycznym ukladem `feature-based`:
+  - `src/features/*`
+  - `src/api/*`
+  - `src/types/*`
+  - `src/app/*`
+
+## 3) Zaleznosci miedzy historyjkami
+- `UC-13`
+  - dostarcza sesje administracyjna i `accessToken`; bez niej `401` ma zatrzymac przeplyw i wywolac `onUnauthorized`.
+- `UC-17`
+  - dostarcza wybor `preparationName` oraz szczegoly preparation.
+- `UC-18 board/folders`
+  - dostarcza wybor `sourceName`; ten plan zaklada reuse juz istniejacych:
+    - `useUc18BoardFolders()`
+    - `Uc18PreparationFoldersList`
+    - `Uc18BoardFoldersSection`
+- `UC-18 digit/folders`
+  - jest tylko kontekstem; nie blokuje listowania `board/files`.
+- `UC-18 board/{sourceName}/files/{boardFolderName}/image`
+  - downstream od tego planu; lista ma juz przechowywac `imageEndpoint`, ale nie wolno sztucznie budowac URL-i po stronie `FE`.
+- `UC-18 DELETE /files/{boardFolderName}`
+  - downstream od tego planu; stan listy i paginacji powinien byc przygotowany pod przyszle odswiezanie po delete.
+- `UC-19`
+  - korzysta z oczyszczonego preparation po `UC-18`; ten endpoint nie buduje `.npz`, ale pomaga operatorowi przejrzec dane przed kolejnym krokiem.
+
+## 4) Co juz istnieje i czego nalezy uzyc
+- Istnieje selekcja preparation:
+  - `src/Frontend/src/features/uc17/application/useUc17DatasetPreparations.ts`
+- Istnieje shell `UC-18`:
+  - `src/Frontend/src/features/uc18/api/Uc18BoardFoldersSection.tsx`
+- Istnieje selekcja zrodel `board`:
+  - `src/Frontend/src/features/uc18/application/useUc18BoardFolders.ts`
+  - `src/Frontend/src/features/uc18/application/uc18BoardFoldersReducer.ts`
+  - `src/Frontend/src/features/uc18/application/uc18BoardFoldersTypes.ts`
+- Istnieje wspolny klient preparation:
+  - `src/Frontend/src/api/datasetPreparations.ts`
+- Istnieje wspolny helper HTTP:
+  - `src/Frontend/src/api/shared/fetchJson.ts`
+- Istnieje wspolny kontrakt folders:
+  - `src/Frontend/src/types/api.ts`
+- Istnieje model folderow `UC-18`:
+  - `src/Frontend/src/features/uc18/domain/uc18PreparationFolder.ts`
+  - `src/Frontend/src/features/uc18/domain/mapDatasetPreparationFoldersToDomain.ts`
+  - `src/Frontend/src/features/uc18/domain/reconcileSelectedPreparationFolder.ts`
+
+Wniosek:
+- nie tworzyc rownoleglego klienta API poza `datasetPreparations.ts`,
+- nie duplikowac selekcji `preparation` ani `sourceName`,
+- nie wpychac logiki listowania plansz do `UC-17`,
+- nie rozszerzac starego `UC-12` legacy.
+
+## 5) Model API w komunikacji z BE
+
+### 5.1 Request `FE -> BE`
+- Metoda i sciezka:
+  - `GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files?page={page}&pageSize={pageSize}`
+- Path params:
+  - `preparationName: string`
+  - `sourceName: string`
+- Query params:
+  - `page: number`
+  - `pageSize: number`
+- Body:
+  - brak
+- Naglowki:
+  - `Accept: application/json`
+  - `Authorization: Bearer <token>` gdy sesja administratora jest aktywna
+
+### 5.2 Model wejscia po stronie FE
+- `FE` nie wysyla JSON body.
+- `FE` musi znac:
+  - `preparationName`,
+  - `sourceName`,
+  - `page`,
+  - `pageSize`.
+- `page` i `pageSize` musza byc kontrolowane przez `ViewController`, a nie wpisywane recznie w `View`.
+
+### 5.3 Model wyjsciowy sukcesu
+- Oczekiwany status:
+  - `200 OK`
+- Nalezy dodac do `src/Frontend/src/types/api.ts`:
+  - `DatasetPreparationBoardFileListItemApiResponse`
+    - `boardFolderName: string`
+    - `imageEndpoint: string`
+  - `DatasetPreparationBoardFilesApiResponse`
+    - `preparationName: string`
+    - `sourceName: string`
+    - `items: DatasetPreparationBoardFileListItemApiResponse[]`
+    - `page: number`
+    - `pageSize: number`
+    - `totalCount: number`
+
+Przyklad:
+
+```json
+{
+  "preparationName": "preparation-001",
+  "sourceName": "v1_training",
+  "items": [
+    {
+      "boardFolderName": "Image1",
+      "imageEndpoint": "/api/datasets/preparations/preparation-001/board/v1_training/files/Image1/image"
+    },
+    {
+      "boardFolderName": "Image2",
+      "imageEndpoint": "/api/datasets/preparations/preparation-001/board/v1_training/files/Image2/image"
+    }
+  ],
+  "page": 1,
+  "pageSize": 24,
+  "totalCount": 128
+}
+```
+
+### 5.4 Model bledu
+- Reuse istniejacego kontraktu:
+  - `ErrorApiResponse`
+    - `errorType: string`
+    - `message: string`
+
+### 5.5 Reguly kontraktowe
+- Nie zmieniac nazw juz istniejacych kontraktow.
+- Dane transportowe pozostaja w `camelCase`.
+- `imageEndpoint` traktowac jako dane z `Backendu`, a nie jako cos, co `FE` moze sobie odtworzyc z innych pol.
+- Ten plan dotyczy listy files, ale trzeba pamietac o zgodnosci downstream z istniejacym `ImageApiResponse` w `src/Frontend/src/types/api.ts`:
+  - `mimeType`
+  - `base64`
+- Nie wprowadzac nowego, rownoleglego modelu obrazu tylko dlatego, ze tekst historyjki opisuje go inaczej.
+
+## 6) Zachowanie z kazdej warstwy MVVC
+
+### Model
+- Obejmuje:
+  - kontrakty transportowe `DatasetPreparationBoardFilesApiResponse` i `DatasetPreparationBoardFileListItemApiResponse`,
+  - lokalny model domenowy planszy,
+  - czyste funkcje mapowania,
+  - czyste funkcje wyliczania stanu paginacji.
+- Nie zna Reacta, `fetch`, statusow HTTP ani `AbortController`.
+
+### View
+- Obejmuje:
+  - panel listy plansz dla wybranego `sourceName`,
+  - kontrolki `Poprzednia / Nastepna`,
+  - informacje o stronie i liczbie rekordow,
+  - stan `loading/error/empty/success`,
+  - placeholder pod przyszly preview obrazu.
+- Nie tworzy URL-i endpointow.
+- Nie wykonuje walidacji odpowiedzi.
+
+### ViewController
+- Obejmuje:
+  - automatyczne pobranie listy po zmianie `sourceName`,
+  - utrzymanie `page` i `pageSize`,
+  - reset strony do `1` po zmianie `sourceName`,
+  - `retryLoadBoardFiles()`,
+  - `goToNextPage()` / `goToPreviousPage()` / `goToPage(page)`,
+  - abort poprzedniego requestu,
+  - reakcje na `401`, `404`, `400`, `5xx`,
+  - lekki mechanizm fallbacku, gdy strona stala sie nieaktualna.
+
+### Infrastructure
+- Obejmuje:
+  - walidacje JSON,
+  - klient `GET /files`,
+  - kodowanie `preparationName` i `sourceName`,
+  - doklejenie query params `page` i `pageSize`,
+  - mapowanie bledow HTTP na `DatasetPreparationsApiError`.
+
+## 7) Pliki per warstwa i odpowiedzialnosci
+
+### 7.1 View
+- `[UPDATE]` `src/Frontend/src/features/uc18/api/Uc18BoardFoldersSection.tsx`
+  - pozostaje glownym shellem `UC-18`;
+  - po wybraniu `sourceName` osadza nowy panel listowania plansz;
+  - nie przejmuje logiki `fetch`.
+- `[ADD]` `src/Frontend/src/features/uc18/api/Uc18BoardFilesPanel.tsx`
+  - nowy panel kroku `board/files`;
+  - renderuje stany `loading/error/empty/success`;
+  - pokazuje liste plansz i paginacje;
+  - przyjmuje dane z hooka zamiast wykonywac `fetch`.
+- `[REUSE]` `src/Frontend/src/features/uc18/api/index.ts`
+  - publiczny export feature'a pozostaje ten sam.
+- `[REUSE / CONTEXT]` `src/Frontend/src/app/views/DatasetsView.tsx`
+  - bez nowego top-level kroku;
+  - `UC-18` nadal pozostaje jednym krokiem workflow datasetowego.
+- `[UPDATE]` `src/Frontend/src/styles/datasets.css`
+  - style panelu listy plansz, statusow, paginacji i placeholdera preview.
+
+### 7.2 ViewController
+- `[ADD]` `src/Frontend/src/features/uc18/application/useUc18BoardFiles.ts`
+  - glowny hook use-case'u dla tego endpointa;
+  - utrzymuje stan listy, paginacji, retry i abort.
+- `[ADD]` `src/Frontend/src/features/uc18/application/uc18BoardFilesReducer.ts`
+  - czysty reducer stanu listowania plansz.
+- `[ADD]` `src/Frontend/src/features/uc18/application/uc18BoardFilesTypes.ts`
+  - typy stanu, akcji, opcji hooka i stale domyslnego `pageSize`.
+- `[REUSE]` `src/Frontend/src/features/uc18/application/useUc18BoardFolders.ts`
+  - dalej dostarcza `selectedSourceName`;
+  - nie nalezy duplikowac w nim stanu plansz.
+
+### 7.3 Model
+- `[UPDATE]` `src/Frontend/src/types/api.ts`
+  - dodac transportowe typy `DatasetPreparationBoardFileListItemApiResponse` i `DatasetPreparationBoardFilesApiResponse`.
+- `[ADD]` `src/Frontend/src/features/uc18/domain/uc18BoardFile.ts`
+  - lokalny model planszy:
+    - `key`
+    - `preparationName`
+    - `sourceName`
+    - `boardFolderName`
+    - `imageEndpoint`
+- `[ADD]` `src/Frontend/src/features/uc18/domain/mapDatasetPreparationBoardFilesToDomain.ts`
+  - mapuje transport na model lokalny;
+  - waliduje spojnosc `preparationName` i `sourceName`.
+- `[ADD]` `src/Frontend/src/features/uc18/domain/resolveUc18BoardFilesPageAfterLoad.ts`
+  - czysta logika fallbacku strony po odpowiedzi.
+
+### 7.4 Infrastructure
+- `[UPDATE]` `src/Frontend/src/api/datasetPreparations.ts`
+  - dodac guard:
+    - `isDatasetPreparationBoardFileListItemApiResponse()`
+    - `isDatasetPreparationBoardFilesApiResponse()`
+  - dodac klient:
+    - `getDatasetPreparationBoardFiles(apiBaseUrl, params, accessToken, signal)`
+- `[REUSE]` `src/Frontend/src/api/shared/fetchJson.ts`
+  - wspolny mechanizm `fetch + parse + validate + errorFactory`.
+
+### 7.5 Pliki kontekstowe, ktorych nie nalezy tu rozwijac
+- `[REUSE / UPSTREAM]` `src/Frontend/src/features/uc17/application/useUc17DatasetPreparations.ts`
+  - selekcja `preparationName`.
+- `[REUSE / CONTEXT]` `src/Frontend/src/features/uc18/application/useUc18DigitFolders.ts`
+  - bez zmian; nie miesza sie z listowaniem `board/files`.
+- `[LEGACY / NIE ROZWIJAC]` `src/Frontend/src/components/Uc12DatasetPreparationSection.tsx`
+  - stary workflow, bez znaczenia dla nowego kroku `UC-18`.
+
+## 8) Strategia generycznosci i reuse
+- Najpierw sprawdzamy, czy usluga juz istnieje.
+- W tym repo istnieje wlasciwe miejsce rozszerzenia:
+  - `src/Frontend/src/api/datasetPreparations.ts`
+- Nie tworzyc nowego pliku API typu:
+  - `datasetPreparationBoardFiles.ts`
+  - `uc18BoardFilesApi.ts`
+- Nowa funkcja moze pozostac endpoint-specific:
+  - `getDatasetPreparationBoardFiles(...)`
+- Ale powinna byc napisana tak, by downstream dalo sie reuse'owac:
+  - ten sam klient bedzie uzywany przy odswiezaniu po delete,
+  - ten sam model danych bedzie uzywany przez przyszly preview obrazu,
+  - ta sama logika paginacji obsluzy ponowne ladowanie po zmianach listy.
+
+## 9) Glowne funkcje
+- `getDatasetPreparationBoardFiles()`
+- `isDatasetPreparationBoardFileListItemApiResponse()`
+- `isDatasetPreparationBoardFilesApiResponse()`
+- `useUc18BoardFiles()`
+- `loadBoardFiles()`
+- `retryLoadBoardFiles()`
+- `goToPage()`
+- `goToNextPage()`
+- `goToPreviousPage()`
+- `uc18BoardFilesReducer()`
+- `mapDatasetPreparationBoardFilesToDomain()`
+- `resolveUc18BoardFilesPageAfterLoad()`
+- `Uc18BoardFilesPanel()`
+
+## 10) Zachowanie aplikacyjne
+- Po zmianie `selectedSourceName`:
+  - reset strony do `1`,
+  - rozpoczecie ladowania plansz dla nowego zrodla.
+- Po zmianie samej strony:
+  - zostawic `preparationName` i `sourceName`,
+  - pobrac tylko nowy zakres listy.
+- W stanie `loading` dla tej samej kombinacji `preparationName + sourceName`:
+  - mozna zachowac poprzednie `items`, aby nie migal caly panel.
+- W stanie `loading` po zmianie `sourceName`:
+  - wyczyscic poprzednia strone, bo dane nalezaly do innego zrodla.
+- `View` ma pokazywac:
+  - nazwe preparation,
+  - nazwe source,
+  - `page`,
+  - `pageSize`,
+  - `totalCount`,
+  - liste `boardFolderName`.
+- `View` nie powinien jeszcze:
+  - pobierac `ImageApiResponse`,
+  - wykonywac `DELETE`,
+  - budowac fallbackowego `imageEndpoint`,
+  - skanowac katalogow lokalnie.
+
+## 11) Wyjatki i fallbacki
+
+### 11.1 Brak wejscia
+- Gdy `preparationName` jest puste:
+  - nie wysylac requestu,
+  - stan `idle`.
+- Gdy `sourceName` jest `null`:
+  - nie wysylac requestu,
+  - pokazac komunikat, ze trzeba wybrac zrodlo `board`.
+
+### 11.2 `401 Unauthorized`
+- Wywolac `onUnauthorized`.
+- Pokazac komunikat o wygaslej sesji.
+- Nie probowac cichego retry bez nowego logowania.
+
+### 11.3 `404 Not Found`
+- Traktowac jako utrate aktualnosci preparation albo source.
+- Wyczyscic stan listy plansz.
+- Zachowac informacje diagnostyczna w logu `warn`.
+- Pozostawic operatorowi jawny krok ponownego wyboru zrodla.
+
+### 11.4 `400 Bad Request`
+- To blad kontraktu lub lokalnej logiki paginacji.
+- Nie retry'owac automatycznie.
+- Zalogowac `warn`.
+- Pokazac komunikat techniczny i zostawic przycisk `Sprobuj ponownie`.
+
+### 11.5 `5xx`
+- Pokazac banner bledu.
+- Zachowac ostatnia poprawna liste dla tego samego `sourceName`, jesli byla juz zaladowana.
+- Pozwolic na reczne odswiezenie.
+
+### 11.6 Niepoprawny ksztalt JSON
+- Traktowac jako blad techniczny.
+- `console.error`.
+- Nie probowac sklejac danych z czesci odpowiedzi.
+
+### 11.7 Nieaktualna strona po zmianach danych
+- Mozliwy scenariusz:
+  - operator byl na wysokiej stronie,
+  - liczba rekordow zmniejszyla sie,
+  - backend zwrocil pusta strone albo strone spoza aktualnego zakresu.
+- Fallback:
+  - jednorazowo wyliczyc `lastPage = max(1, ceil(totalCount / pageSize))`,
+  - jesli `requestedPage > lastPage` i `totalCount > 0`, automatycznie przeladowac `lastPage`,
+  - zalogowac pojedyncze `warn`,
+  - nie wchodzic w petle retry.
+
+## 12) Lekka strategia logowania
+- `console.info`
+  - start ladowania listy,
+  - sukces ladowania,
+  - reczne odswiezenie,
+  - zmiana strony.
+- `console.warn`
+  - `401`,
+  - `404`,
+  - `400`,
+  - fallback z nieaktualnej strony na `lastPage`.
+- `console.error`
+  - `5xx`,
+  - niepoprawny ksztalt odpowiedzi,
+  - inne nieoczekiwane wyjatki.
+- Logi maja byc pojedyncze per przejscie stanu, bez spamowania na kazdy render.
+
+## 13) Przeplyw kontraktowy w obrebie BE widziany z FE
+- To nie jest plan implementacji `BE`.
+- Z perspektywy `FE` zakladamy tylko taki kontraktowy przeplyw:
+  1. `FE` wysyla `preparationName`, `sourceName`, `page`, `pageSize`.
+  2. `BE` autoryzuje request.
+  3. `BE` waliduje, czy wskazane `preparation` i `source` istnieja.
+  4. `BE` zwraca gotowa strone listy logicznych plansz.
+  5. `BE` zwraca `imageEndpoint` jako publiczny kontrakt do dalszego preview.
+  6. `FE` nie zaklada nic wiecej o strukturze plikow ani sposobie wyliczenia strony.
+
+## 14) Pseudokod dla logiki specyficznej
+
+```text
+function loadBoardFiles(preparationName, sourceName, requestedPage, pageSize):
+  if preparationName is empty or sourceName is empty:
+    reset state to idle
+    return
+
+  abort previous request
+  dispatch(loadStarted(preparationName, sourceName, requestedPage, pageSize))
+
+  response = await getDatasetPreparationBoardFiles(...)
+  items = mapDatasetPreparationBoardFilesToDomain(response, preparationName, sourceName)
+
+  pageResolution = resolveUc18BoardFilesPageAfterLoad(
+    requestedPage,
+    response.page,
+    response.pageSize,
+    response.totalCount,
+    items.length
+  )
+
+  if pageResolution.shouldReloadLastPage:
+    log warn once
+    dispatch(pageChanged(pageResolution.lastPage))
+    call loadBoardFiles(preparationName, sourceName, pageResolution.lastPage, response.pageSize)
+    return
+
+  dispatch(loadSucceeded({
+    preparationName,
+    sourceName,
+    items,
+    page: response.page,
+    pageSize: response.pageSize,
+    totalCount: response.totalCount
+  }))
+```
+
+## 15) Mermaid - flow modeli
+
+```mermaid
+flowchart TD
+  A["DatasetPreparationBoardFilesApiResponse\n(types/api.ts)"] --> B["isDatasetPreparationBoardFilesApiResponse()\n(api/datasetPreparations.ts)"]
+  B --> C["mapDatasetPreparationBoardFilesToDomain()\n(domain/mapDatasetPreparationBoardFilesToDomain.ts)"]
+  C --> D["Uc18BoardFile[]\n(domain/uc18BoardFile.ts)"]
+  D --> E["resolveUc18BoardFilesPageAfterLoad()\n(domain/resolveUc18BoardFilesPageAfterLoad.ts)"]
+  E --> F["Uc18BoardFilesState\n(application/uc18BoardFilesTypes.ts)"]
+  F --> G["Uc18BoardFilesPanel()\n(api/Uc18BoardFilesPanel.tsx)"]
+```
+
+## 16) Mermaid - flow logiki aplikacji
+
+```mermaid
+flowchart TD
+  A["useUc17DatasetPreparations()\nwybor preparation"] --> B["useUc18BoardFolders()\nwybor sourceName"]
+  B --> C["useUc18BoardFiles()\nreset page=1 po zmianie source"]
+  C --> D["loadBoardFiles()\nstart requestu + AbortController"]
+  D --> E["getDatasetPreparationBoardFiles()\napi/datasetPreparations.ts"]
+  E --> F["mapDatasetPreparationBoardFilesToDomain()\nmapowanie transport->domena"]
+  F --> G["resolveUc18BoardFilesPageAfterLoad()\nfallback strony"]
+  G --> H["uc18BoardFilesReducer()\nloadSucceeded/loadFailed"]
+  H --> I["Uc18BoardFilesPanel()\nrender listy i paginacji"]
+  I --> J["goToNextPage()/goToPreviousPage()/retryLoadBoardFiles()\nakcje operatora"]
+  J --> D
+```
+
+## 17) Workflow GitHub i konfiguracja
+- Dla tego endpointa nie widze potrzeby zmiany workflow `FE`.
+- Aktualny `frontend-cd.yml` juz buduje frontend z:
+  - `VITE_API_BASE_URL="${FE_VITE_API_BASE_URL:-/api}"`
+- Ten endpoint korzysta z tego samego `apiBaseUrl`, wiec:
+  - nie trzeba dodawac nowej zmiennej CI/CD,
+  - nie trzeba ruszac deployu,
+  - nie trzeba zmieniac build output.
+- `pageSize` dla tego kroku powinien byc lokalna, jawna stala w FE, a nie zmienna workflow.
+- Poniewaz plan dotyczy tylko `FE`, nie ma tu zmian w `appsettings`; wzmianka o produkcyjnym `appsettings` dotyczy glownie warstwy `BE`, nie tego endpointa.
+
+## 18) Kolejnosc implementacji kodu
+1. Rozszerzyc `src/Frontend/src/types/api.ts` o nowe kontrakty transportowe listy files.
+2. Rozszerzyc `src/Frontend/src/api/datasetPreparations.ts` o guardy i `getDatasetPreparationBoardFiles(...)`.
+3. Dodac model domenowy `Uc18BoardFile` oraz mapper.
+4. Dodac czysta logike fallbacku strony.
+5. Dodac `uc18BoardFilesTypes.ts` i `uc18BoardFilesReducer.ts`.
+6. Dodac hook `useUc18BoardFiles.ts`.
+7. Dodac `Uc18BoardFilesPanel.tsx`.
+8. Zintegrowac panel z `Uc18BoardFoldersSection.tsx`.
+9. Dopisac style do `datasets.css`.
+10. Zweryfikowac recznie scenariusze:
+   - wybor preparation,
+   - wybor source,
+   - przejscie miedzy stronami,
+   - `401`,
+   - `404`,
+   - pusty wynik,
+   - stale page po zmianie danych.
+
+## 19) Guardraile implementacyjne
+- Nie zgadywac `imageEndpoint` po stronie klienta.
+- Nie przenosic logiki `fetch` do komponentu `View`.
+- Nie mieszac stanu `board/files` ze stanem `board/folders`.
+- Nie dokladac nowego top-level kroku w `DatasetsView`.
+- Nie uzalezniac `UC-18` od `ML`.
+- Nie wprowadzac nowego kontraktu obrazu obok istniejacego `ImageApiResponse`.
+- Nie robic cichego nieskonczonego retry.
+- Nie deduplikowac i nie sortowac listy po stronie `FE`, jesli backend nie zleca tego w kontrakcie.
+- Nie wynosic `pageSize` do workflow ani do globalnej konfiguracji, dopoki nie ma realnej potrzeby produktowej.
+- Zachowac nazewnictwo zgodne z juz dodanym `UC-18`:
+  - `datasetPreparations.ts`
+  - `useUc18BoardFolders()`
+  - `Uc18BoardFoldersSection`
+
+## 20) Inne istotne reguly
+- `View` ma pozostac cienki, a logika pobierania i fallbackow ma pozostac w `ViewController`.
+- `sourceName` jest wybierane wyzej; nowy panel nie ma robic drugiej, rownoleglej selekcji zrodla.
+- Jesli ten endpoint zostanie zaimplementowany przed endpointem `image`, panel powinien byc gotowy na pozniejszy preview, ale bez sztucznych obejsc.
+- Jezeli w kolejnym kroku dojdzie delete, hook listy files powinien byc jedynym miejscem odswiezania po zmianie listy.
+- Caly plan ma pozostac w granicach `FE`, bez przepisywania odpowiedzialnosci na `BE` i `ML`.

--- a/.ai/implementation-plan/fe/uc-18-fe-get-api-datasets-preparations-{preparationName}-digit-folders.md
+++ b/.ai/implementation-plan/fe/uc-18-fe-get-api-datasets-preparations-{preparationName}-digit-folders.md
@@ -1,0 +1,722 @@
+# UC-18-FE - Plan implementacyjny dla `GET /api/datasets/preparations/{preparationName}/digit/folders`
+
+## 1) Przeznaczenie endpointa
+- Endpoint `GET /api/datasets/preparations/{preparationName}/digit/folders` zwraca liste logicznych zrodel typu `digit` dla wybranego preparation.
+- Z perspektywy `FE` ten endpoint:
+  - zasila pomocniczy, read-only widok `digit` w `UC-18`,
+  - pokazuje tylko nazwy folderow zrodlowych `digit`,
+  - nie laduje listy pojedynczych probek cyfr,
+  - nie laduje obrazow,
+  - nie wykonuje usuwania danych,
+  - nie odczytuje bezposrednio struktury katalogow runtime.
+- Wynik endpointa ma znaczenie informacyjne i kontekstowe:
+  - potwierdza, jakie logiczne zrodla `digit` sa czescia preparation,
+  - pozwala operatorowi sprawdzic komplet preparation,
+  - nie uruchamia kolejnego kroku przegladania w ramach `UC-18`, bo `digit` nie ma tutaj osobnego preview ani delete.
+- `Backend` pozostaje jedynym zrodlem prawdy dla:
+  - istnienia preparation,
+  - listy zrodel `digit`,
+  - kolejnosci elementow zwracanych z `digit/folders.json`,
+  - lacznej liczby rekordow.
+
+## 2) Zakres planu
+- Plan dotyczy wylacznie `FE`.
+- Plan nie projektuje implementacji `BE` ani `ML`; opiera sie tylko na:
+  - publicznym kontrakcie HTTP,
+  - wymaganiach `UC-18`,
+  - istniejacym kodzie `src/Frontend`,
+  - juz dodanym endpointcie `board/folders`.
+- Nie nalezy sugerowac sie biezaca implementacja `BE` i `ML` poza ustalonym kontraktem i semantyka use case'a.
+- Plan uwzglednia warstwowosc MVVC oraz obecny praktyczny uklad `feature-based`.
+- Plan musi podporzadkowac sie istniejacym nazwom i kontraktom z poprzednich historyjek:
+  - nie zmieniamy nazw juz dodanych typow,
+  - nie przepinamy odpowiedzialnosci miedzy warstwami,
+  - nie robimy nowego rownoleglego klienta API.
+
+## 3) Miejsce endpointa w docelowym workflow
+1. Uzytkownik ma juz istniejace preparation utworzone w `UC-17`.
+2. `FE` zna `preparationName` wybrane przez uzytkownika.
+3. `FE` wywoluje rownolegle lub sekwencyjnie dwa odczyty dla tego samego preparation:
+   - `GET /api/datasets/preparations/{preparationName}/board/folders`
+   - `GET /api/datasets/preparations/{preparationName}/digit/folders`
+4. `BE` zwraca liste nazw folderow zrodlowych `digit`.
+5. `FE` renderuje read-only liste `digit`.
+6. Uzytkownik otrzymuje kontekst preparation:
+   - jakie sa zrodla `board`,
+   - jakie sa zrodla `digit`.
+7. Tylko `board` prowadzi dalej do `GET /api/datasets/preparations/{preparationName}/board/{sourceName}/files`.
+8. `digit` w `UC-18` konczy sie na pokazaniu listy logicznych folderow.
+
+## 4) Glowne zalozenia architektoniczne
+- Globalna architektura FE jest formalnie nadal `TBD`, ale obecny kod jest praktycznie warstwowy i `feature-based`:
+  - `src/app/*`
+  - `src/features/*`
+  - `src/api/*`
+  - `src/types/*`
+- Dla tego endpointa trzeba utrzymac podzial:
+  - `Model`: kontrakt transportowy, lokalny model folderu i reguly mapowania,
+  - `View`: panel listy `digit`, stany `loading/error/empty/success`,
+  - `ViewController`: pobranie danych, abort, retry, reakcja na `401/404`,
+  - `Infrastructure`: klient HTTP, walidacja JSON, mapowanie bledow transportowych.
+- `FE` nie moze:
+  - skanowac katalogow,
+  - zgadywac nazw folderow `digit`,
+  - wyprowadzac listy `digit` z innych endpointow jako fallback sukcesu,
+  - komunikowac sie bezposrednio z `ML`.
+- `digit/folders` jest tylko odczytem kontekstowym, wiec warstwa `View` nie powinna doklejac sztucznej logiki selekcji ani downstream delete.
+- Jesli trzeba dodac nowa abstrakcje, najpierw nalezy sprawdzic, co juz istnieje i reuse'owac to, co daje realna wartosc.
+
+## 5) Strategia reuse i generycznosci
+- Generyczna warstwa `Infrastructure` dla `board | digit` juz istnieje i nalezy z niej korzystac:
+  - `src/Frontend/src/api/datasetPreparations.ts`
+  - `getDatasetPreparationFolders(...)`
+- Generyczna warstwa `Model` dla `board | digit` juz istnieje i nalezy z niej korzystac:
+  - `src/Frontend/src/features/uc18/domain/uc18PreparationFolder.ts`
+  - `src/Frontend/src/features/uc18/domain/mapDatasetPreparationFoldersToDomain.ts`
+  - `src/Frontend/src/features/uc18/domain/toUc18PreparationFolderKey.ts`
+- Nie nalezy tworzyc nowego klienta `getDatasetPreparationDigitFolders()`, bo powielalby juz gotowa warstwe `Infrastructure`.
+- Poniewaz `digit` ma inne zachowanie UI niz `board`, generycznosc powinna byc rozwazna:
+  - wspolne ma byc pobranie danych i mapowanie,
+  - `board` zachowuje wybor `sourceName`,
+  - `digit` pozostaje lista read-only.
+- Preferowany kierunek:
+  - zostawic publiczne nazwy juz dodanych elementow `board`,
+  - dodac wspolny, wewnetrzny loader zasobu folderow tylko wtedy, gdy realnie usuwa duplikacje,
+  - na zewnatrz nie zmieniac nazw juz uzywanych plikow ani hookow `board`.
+- Minimalna bezpieczna granica generycznosci:
+  - wspolny klient API,
+  - wspolny model domenowy,
+  - wspolna lista prezentacyjna po dopracowaniu tekstow dla trybu read-only.
+
+## 6) Model API w komunikacji z BE
+
+### 6.1 Request `FE -> BE`
+- Metoda i sciezka:
+  - `GET /api/datasets/preparations/{preparationName}/digit/folders`
+- Path params:
+  - `preparationName: string`
+- Query params:
+  - brak
+- Body:
+  - brak
+- Naglowki:
+  - `Accept: application/json`
+  - `Authorization: Bearer <token>` gdy aktywna jest sesja administratora
+
+### 6.2 Model wejsciowy
+- Brak payloadu JSON.
+- Jedynym wymaganym wejsciem jest poprawny `preparationName`.
+
+### 6.3 Model wyjsciowy sukcesu
+- Oczekiwany status HTTP:
+  - `200 OK`
+- Kontrakt transportowy:
+  - `DatasetPreparationFoldersApiResponse`
+    - `preparationName: string`
+    - `type: string`
+    - `items: string[]`
+    - `totalCount: number`
+
+Przyklad:
+
+```json
+{
+  "preparationName": "preparation-001",
+  "type": "digit",
+  "items": [
+    "mnist_train",
+    "mnist_test"
+  ],
+  "totalCount": 2
+}
+```
+
+### 6.4 Model bledu
+- `ErrorApiResponse`
+  - `errorType: string`
+  - `message: string`
+
+### 6.5 Reguly kontraktowe
+- Nie zmieniac nazw:
+  - `DatasetPreparationFoldersApiResponse`
+  - `ErrorApiResponse`
+- Dane transportowe pozostaja w `camelCase`.
+- `type` w `src/types/api.ts` pozostaje `string`.
+- Zawazenie do `board | digit` ma pozostac lokalne i domenowe.
+- Dla wywolania `/digit/folders` odpowiedz z `type != "digit"` nalezy traktowac jako blad kontraktu, a nie jako czesciowy sukces.
+
+## 7) Zachowanie z kazdej warstwy MVVC
+
+### Model
+- Obejmuje:
+  - kontrakt `DatasetPreparationFoldersApiResponse`,
+  - lokalny typ `Uc18PreparationFolderType`,
+  - lokalny model folderu do renderowania,
+  - reguly mapowania transportu do domeny.
+- Nie zna Reacta, `fetch` ani statusow HTTP.
+- Dla `digit` nie musi utrzymywac aktywnego `sourceName`, bo ten endpoint nie prowadzi do dalszej nawigacji w `UC-18`.
+
+### View
+- Obejmuje:
+  - panel listy `digit`,
+  - licznik rekordow,
+  - przycisk `Odswiez liste digit`,
+  - stany `loading/error/empty/success`.
+- Powinien byc read-only:
+  - bez delete,
+  - bez lazy-loadu obrazow,
+  - bez akcji przejscia do listy plikow.
+- Nie tworzy URL-i endpointow.
+- Nie zawiera walidacji transportu.
+
+### ViewController
+- Obejmuje:
+  - `loadDigitFolders(preparationName)`,
+  - `retryLoadDigitFolders()`,
+  - `AbortController`,
+  - reakcje na `401`,
+  - reakcje na `404`,
+  - lekkie logowanie diagnostyczne.
+- Nie powinien utrzymywac stanu selekcji, jesli widok jest read-only.
+
+### Infrastructure
+- Obejmuje:
+  - `getDatasetPreparationFolders()`,
+  - guard odpowiedzi JSON,
+  - `buildAuthHeaders()`,
+  - `fetchJson()`,
+  - mapowanie bledow HTTP na `DatasetPreparationsApiError`.
+
+## 8) Co juz istnieje i nalezy reuse'owac
+- Istnieje wspolny klient preparation:
+  - `src/Frontend/src/api/datasetPreparations.ts`
+- Istnieje wspolny helper HTTP:
+  - `src/Frontend/src/api/shared/fetchJson.ts`
+- Istnieja juz kontrakty transportowe:
+  - `src/Frontend/src/types/api.ts`
+- Istnieje juz model folderow `UC-18` obslugujacy `board | digit`:
+  - `src/Frontend/src/features/uc18/domain/uc18PreparationFolder.ts`
+  - `src/Frontend/src/features/uc18/domain/mapDatasetPreparationFoldersToDomain.ts`
+  - `src/Frontend/src/features/uc18/domain/toUc18PreparationFolderKey.ts`
+- Istnieje juz shell ekranu `UC-18`, ktory pobiera preparation i listuje `board/folders`:
+  - `src/Frontend/src/features/uc18/api/Uc18BoardFoldersSection.tsx`
+  - `src/Frontend/src/features/uc18/application/useUc18BoardFolders.ts`
+- Istnieje juz upstream do wyboru preparation:
+  - `src/Frontend/src/features/uc17/application/useUc17DatasetPreparations.ts`
+- Istnieje juz integracja kroku `UC-18` w module datasetowym:
+  - `src/Frontend/src/app/views/DatasetsView.tsx`
+- Istnieja juz style datasetowe:
+  - `src/Frontend/src/styles/datasets.css`
+
+Wniosek:
+- nie tworzyc nowego pliku API tylko dla `digit`,
+- nie tworzyc osobnej, rownoleglej reprezentacji modelu folderu,
+- nie dublowac selektora preparation z `UC-17`,
+- nie budowac osobnego top-level ekranu `UC-18` tylko dla `digit`.
+
+## 9) Pliki per warstwa i odpowiedzialnosci
+
+### 9.1 View
+- `[REUSE + UPDATE]` `src/Frontend/src/features/uc18/api/Uc18BoardFoldersSection.tsx`
+  - pozostaje glownym shellem `UC-18`;
+  - dalej odpowiada za wybor preparation i panel `board`;
+  - powinien zostac rozszerzony o osadzenie panelu `digit`, bez dublowania kroku wyboru preparation.
+- `[ADD]` `src/Frontend/src/features/uc18/api/Uc18DigitFoldersPanel.tsx`
+  - nowy panel read-only dla endpointa `digit/folders`;
+  - renderuje stany `loading/error/empty/success`;
+  - pokazuje licznik i liste nazw folderow `digit`;
+  - nie ma akcji wyboru do dalszego listowania.
+- `[REUSE + UPDATE]` `src/Frontend/src/features/uc18/api/Uc18PreparationFoldersList.tsx`
+  - wspolny komponent listy nazw folderow;
+  - powinien obslugiwac tryb:
+    - `selectable` dla `board`,
+    - `readonly` dla `digit`;
+  - teksty UI nie moga byc na stale zwiazane z `board`.
+- `[REUSE]` `src/Frontend/src/features/uc18/api/index.ts`
+  - publiczny export feature'a `UC-18`;
+  - nie wymaga zmiany publicznego kontraktu exportu, jesli top-level komponent pozostaje ten sam.
+- `[REUSE]` `src/Frontend/src/app/views/DatasetsView.tsx`
+  - osadza `UC-18` jako jeden krok workflow datasetowego;
+  - nie powinien dostawac dodatkowego kroku nawigacyjnego tylko dla `digit/folders`.
+- `[REUSE]` `src/Frontend/src/styles/datasets.css`
+  - style panelu `digit`, listy nazw, badge'y/liczniki, stany bannerow.
+
+### 9.2 ViewController
+- `[ADD]` `src/Frontend/src/features/uc18/application/useUc18DigitFolders.ts`
+  - glowny hook use case'u dla `digit/folders`;
+  - pobiera dane,
+  - utrzymuje loadable state,
+  - obsluguje retry, abort, `401`, `404`,
+  - nie utrzymuje selekcji.
+- `[OPTIONAL ADD - PREFERRED]` `src/Frontend/src/features/uc18/application/useUc18PreparationFoldersResource.ts`
+  - wewnetrzny, wspolny loader dla `board | digit`, jesli chcemy usunac duplikacje request/abort/log/error;
+  - nie musi byc publicznym API feature'a.
+- `[OPTIONAL ADD - PREFERRED]` `src/Frontend/src/features/uc18/application/uc18PreparationFoldersResourceReducer.ts`
+  - czysty reducer wspolnego stanu odczytu listy folderow.
+- `[OPTIONAL ADD - PREFERRED]` `src/Frontend/src/features/uc18/application/uc18PreparationFoldersResourceTypes.ts`
+  - typy stanu i akcji wspolnego loadera.
+- `[REUSE + UPDATE]` `src/Frontend/src/features/uc18/application/useUc18BoardFolders.ts`
+  - zachowuje istniejaca nazwe i publiczny interfejs;
+  - po ewentualnej ekstrakcji wspolnego loadera powinien dalej odpowiadac tylko za logike `board`, zwlaszcza selekcje `sourceName`.
+- `[CONTEXT ONLY]` `src/Frontend/src/features/uc17/application/useUc17DatasetPreparations.ts`
+  - dostarcza `selectedPreparationName`;
+  - nie powinien przejmowac logiki `digit/folders`.
+
+### 9.3 Model
+- `[REUSE]` `src/Frontend/src/types/api.ts`
+  - utrzymuje `DatasetPreparationFoldersApiResponse`.
+- `[REUSE]` `src/Frontend/src/features/uc18/domain/uc18PreparationFolder.ts`
+  - lokalny model domenowy folderu i typ `board | digit`.
+- `[REUSE]` `src/Frontend/src/features/uc18/domain/mapDatasetPreparationFoldersToDomain.ts`
+  - mapuje transport do modelu lokalnego;
+  - dla `digit/folders` wymusza `expectedType = "digit"`.
+- `[REUSE]` `src/Frontend/src/features/uc18/domain/toUc18PreparationFolderKey.ts`
+  - buduje stabilny klucz np. `digit:mnist_train`.
+- `[CONTEXT ONLY]` `src/Frontend/src/features/uc18/domain/reconcileSelectedPreparationFolder.ts`
+  - zostaje potrzebny dla `board`;
+  - nie powinien byc sztucznie doklejany do `digit`, jesli ten widok nie wymaga selekcji.
+
+### 9.4 Infrastructure
+- `[REUSE]` `src/Frontend/src/api/datasetPreparations.ts`
+  - juz zawiera `getDatasetPreparationFolders(...)`;
+  - jest jedynym klientem infrastrukturalnym dla `board/folders` i `digit/folders`.
+- `[REUSE]` `src/Frontend/src/api/shared/fetchJson.ts`
+  - wspolny mechanizm `fetch + parse + validate + errorFactory`.
+
+### 9.5 Pliki kontekstowe, ktorych nie rozwijac w tym endpointcie
+- `[CONTEXT ONLY]` `src/Frontend/src/features/uc17/api/Uc17RawCandidatesSection.tsx`
+  - dotyczy tworzenia preparation;
+  - nie jest miejscem renderowania listy `digit/folders`.
+- `[CONTEXT ONLY]` `src/Frontend/src/features/uc18/api/Uc18BoardFoldersSection.tsx`
+  - juz obsluguje `board/folders`;
+  - ma byc shellem ekranu, a nie miejscem kopiowania calego hooka `digit`.
+- `[LEGACY / NIE ROZWIJAC]` `src/Frontend/src/components/Uc12DatasetPreparationSection.tsx`
+  - dotyczy starego workflow `UC-12`;
+  - nie moze byc wzorcem dla `UC-18`.
+
+## 10) Co nalezy dodac lub dopracowac
+- Dodac panel widoku dla `digit/folders` wewnatrz istniejacego ekranu `UC-18`.
+- Dodac hook `useUc18DigitFolders()` bez dublowania klienta HTTP.
+- Uogolnic `Uc18PreparationFoldersList.tsx`, aby obslugiwal:
+  - tryb wybieralny dla `board`,
+  - tryb read-only dla `digit`.
+- Zachowac istniejacy shell `Uc18BoardFoldersSection.tsx`, ale rozszerzyc go o nowy panel `digit`.
+- Nie dodawac akcji:
+  - delete,
+  - preview,
+  - image fetch,
+  - dalszej nawigacji po `digit`.
+- Opcjonalnie wyciagnac wspolny loader folderow do warstwy `application`, jesli po dodaniu `digit` kod `board` i `digit` bylby niemal identyczny.
+
+## 11) Glowne funkcje
+- `getDatasetPreparationFolders()`
+- `isDatasetPreparationFoldersApiResponse()`
+- `useUc18DigitFolders()`
+- `loadDigitFolders()`
+- `retryLoadDigitFolders()`
+- `mapDatasetPreparationFoldersToDomain()`
+- `toUc18PreparationFolderKey()`
+- `Uc18DigitFoldersPanel()`
+- `Uc18PreparationFoldersList()`
+- `fetchJson()`
+
+Jesli wdrazamy ekstrakcje wspolnego loadera:
+- `useUc18PreparationFoldersResource()`
+- `uc18PreparationFoldersResourceReducer()`
+
+## 12) Zachowanie View
+- Po otrzymaniu poprawnego `preparationName` widok uruchamia pobranie listy folderow `digit`.
+- Widok pokazuje:
+  - nazwe wybranego preparation,
+  - licznik `totalCount`,
+  - liste nazw folderow `digit`,
+  - przycisk odswiezenia.
+- Widok nie powinien:
+  - pokazywac miniaturek cyfr,
+  - pobierac listy pojedynczych digit files,
+  - pobierac obrazow,
+  - wykonywac delete,
+  - udawac, ze `digit` ma ten sam flow dalszych krokow co `board`.
+- Widok ma charakter informacyjny:
+  - operator widzi, jakie logiczne zrodla `digit` naleza do preparation,
+  - ale nie przechodzi dalej do osobnego ekranu `digit`.
+
+## 13) Zachowanie ViewController
+- Hook powinien pobierac dane automatycznie po zmianie `preparationName`.
+- Jesli uzytkownik zmieni `preparationName` w trakcie requestu:
+  - poprzedni request trzeba anulowac,
+  - nowy request staje sie jedynym aktywnym.
+- W stanie `loading` nalezy zachowac poprzednia liste tylko dla tego samego `preparationName`.
+- Po sukcesie:
+  - zapisac nowa liste,
+  - wyczyscic blad,
+  - ustawic `httpStatus = 200`.
+- Przy `401`:
+  - wywolac `onUnauthorized`.
+- Przy `404`:
+  - pokazac blad stalego / nieaktualnego `preparationName`,
+  - nie zgadywac nowej listy `digit`.
+- Poniewaz widok jest read-only:
+  - brak `selectedSourceName`,
+  - brak reconcile selekcji,
+  - brak lokalnego draftu do kolejnego endpointa.
+
+## 14) Zachowanie Model
+- Lokalny model domenowy moze pozostac wspolny z `board`, bo format danych jest ten sam:
+  - `preparationName: string`
+  - `type: "board" | "digit"`
+  - `folderName: string`
+  - `key: string`
+- Mapowanie powinno:
+  - zachowac kolejnosc z `items`,
+  - wymusic `expectedType = "digit"`,
+  - nie zmieniac nazw folderow,
+  - nie obcinac wartosci,
+  - nie normalizowac wielkosci liter.
+- Dla `digit` lokalny model nie musi byc rozszerzany o stan wyboru, bo byloby to sztuczne i nieuzasadnione funkcjonalnie.
+
+## 15) Zachowanie Infrastructure
+- Klient powinien URL-encode'owac `preparationName`.
+- Funkcja `getDatasetPreparationFolders()` ma pozostac generyczna po `folderType`, ale dla tego endpointa wywolywana z `"digit"`.
+- Oczekiwany status:
+  - `200`
+- Guard odpowiedzi ma sprawdzac:
+  - `preparationName` jako `string`,
+  - `type` jako `string`,
+  - `items` jako `string[]`,
+  - `totalCount` jako `number`.
+- Bledny ksztalt JSON jest bledem technicznym, a nie pustym stanem.
+- `Infrastructure` nie moze robic fallbacku do innego endpointa przy bledzie `digit/folders`.
+
+## 16) Specyficzna logika i pseudokod
+
+### 16.1 Wywolanie endpointa `digit/folders`
+
+```text
+loadDigitFolders(preparationName):
+  normalizedPreparationName = preparationName.trim()
+
+  if normalizedPreparationName is empty:
+    reset state
+    do not call backend
+    return
+
+  abort previous request
+  set state = loading
+
+  response = getDatasetPreparationFolders(
+    apiBaseUrl,
+    normalizedPreparationName,
+    "digit",
+    accessToken,
+    signal
+  )
+
+  folders = mapDatasetPreparationFoldersToDomain(response, "digit")
+
+  set state = success(folders)
+```
+
+### 16.2 Mapowanie odpowiedzi do modelu domenowego
+
+```text
+mapDatasetPreparationFoldersToDomain(response, expectedType):
+  if response.type is not "board" and is not "digit":
+    throw contract error
+
+  if response.type != expectedType:
+    throw contract error
+
+  return response.items.map(folderName => ({
+    preparationName: response.preparationName,
+    type: expectedType,
+    folderName,
+    key: `${expectedType}:${folderName}`
+  }))
+```
+
+### 16.3 Orkiestracja shellem `UC-18`
+
+```text
+Uc18BoardFoldersSection():
+  datasetPreparations = useUc17DatasetPreparations(...)
+
+  boardFolders = useUc18BoardFolders({
+    preparationName: datasetPreparations.selectedPreparationName
+  })
+
+  digitFolders = useUc18DigitFolders({
+    preparationName: datasetPreparations.selectedPreparationName
+  })
+
+  render:
+    panel wyboru preparation
+    panel szczegolow preparation
+    panel board folders
+    panel digit folders
+```
+
+### 16.4 Render listy wspolnym komponentem
+
+```text
+Uc18PreparationFoldersList({
+  folders,
+  mode,
+  onSelect
+}):
+  if folders.length == 0:
+    render empty state
+
+  if mode == "readonly":
+    render static list items
+    do not render button labels typu "Wybierz zrodlo"
+
+  if mode == "selectable":
+    render buttons i selected state
+```
+
+## 17) Wyjatki, fallbacki i zachowanie bledowe
+
+### 17.1 Statusy HTTP
+- `200 OK`
+  - lista poprawna;
+  - moze byc pusta.
+- `401 Unauthorized`
+  - sesja administratora wygasla albo token jest niepoprawny;
+  - `FE` wywoluje `onUnauthorized`.
+- `403 Forbidden`
+  - uzytkownik nie ma dostepu do kroku administracyjnego;
+  - `FE` pokazuje blad bez retry automatycznego.
+- `404 Not Found`
+  - preparation nie istnieje albo nie jest juz dostepne;
+  - `FE` traktuje to jako stale / nieaktualne wejscie.
+- `500 Internal Server Error`
+  - blad backendu.
+- `502`, `503`, `504`
+  - blad infrastrukturalny na sciezce przegladarka -> nginx -> backend.
+
+### 17.2 Bledy kontraktu
+- Jesli odpowiedz `200` ma zly ksztalt:
+  - traktowac to jako blad techniczny,
+  - nie zamieniac tego na pusta liste,
+  - nie zgadywac brakujacych pol.
+- Jesli endpoint `/digit/folders` zwroci `type = "board"` albo inny typ:
+  - traktowac to jako blad kontraktowy,
+  - nie renderowac listy jako sukcesu.
+
+### 17.3 Fallbacki dopuszczalne
+- Zachowanie poprzedniej listy podczas kolejnego `loading` dla tego samego `preparationName`.
+- Zachowanie poprzedniej listy przy chwilowym `500`, `502`, `503`, `504`, jesli nie zmienil sie `preparationName`.
+- Pokazanie pustego stanu przy `200` i `items: []`.
+
+### 17.4 Fallbacki niedopuszczalne
+- Zgadywanie listy `digit` na podstawie `sources` z `GET /api/datasets/preparations/{preparationName}` jako sukcesu.
+- Samodzielne budowanie listy po nazwach katalogow po stronie FE.
+- Sortowanie listy alfabetycznie "dla wygody", jesli backend zwrocil inna kolejnosc.
+- Bezposrednie przejscie `FE -> ML`.
+- Tworzenie sztucznej selekcji `digit`, jesli use case nie wymaga dalszego wyboru.
+
+### 17.5 Zachowanie UI
+- `idle`
+  - stan przed pierwszym pobraniem lub przy braku `preparationName`.
+- `loading`
+  - blokuje przycisk odswiezenia;
+  - moze zachowac poprzednia liste.
+- `error`
+  - pokazuje banner z bledem;
+  - przy `401` dopisuje komunikat o ponownym logowaniu;
+  - przy `404` sugeruje ponowny wybor preparation.
+- `success + empty`
+  - pokazuje informacje, ze preparation nie ma jeszcze zadnych zrodel `digit`.
+- `success + data`
+  - lista jest czytelna, ale read-only.
+
+## 18) Logging i diagnostyka FE
+- Logi maja pomagac w diagnozie, ale nie moga spamowac ani logowac duzych payloadow.
+
+### `console.info`
+- start ladowania folderow `digit`,
+- reczne odswiezenie listy,
+- sukces pobrania listy wraz z `totalCount`.
+
+### `console.warn`
+- `401` i wyczyszczenie sesji,
+- `404` dla nieaktualnego `preparationName`,
+- proba renderowania nieaktualnego kroku po zmianie preparation.
+
+### `console.error`
+- `5xx`,
+- blad walidacji ksztaltu odpowiedzi,
+- niespojny `type` odpowiedzi,
+- nieprzetwarzalna odpowiedz backendu.
+
+### Guardraile logowania
+- nie logowac tokena,
+- nie logowac pelnej odpowiedzi backendu,
+- nie logowac calej listy `items`,
+- logowac tylko lekkie metadane:
+  - `preparationName`,
+  - `type`,
+  - `httpStatus`,
+  - `errorType`,
+  - `totalCount`.
+
+## 19) Mermaid flowchart - flow modeli
+
+```mermaid
+flowchart TD
+    A["getDatasetPreparationFolders()<br/>pobiera DatasetPreparationFoldersApiResponse"] --> B["isDatasetPreparationFoldersApiResponse()<br/>walidacja kontraktu HTTP"]
+    B --> C["mapDatasetPreparationFoldersToDomain()<br/>mapuje items do Uc18PreparationFolder[]"]
+    C --> D["Uc18PreparationFolder[]<br/>preparationName + type + folderName + key"]
+    D --> E["useUc18DigitFolders()<br/>zapisuje stan sukcesu bez selekcji"]
+    E --> F["Uc18DigitFoldersPanel()<br/>render read-only listy digit"]
+```
+
+## 20) Mermaid flowchart - logika aplikacji z funkcjami
+
+```mermaid
+flowchart TD
+    A["DatasetsView()<br/>osadza krok UC-18"] --> B["Uc18BoardFoldersSection()<br/>shell ekranu UC-18"]
+    B --> C["useUc17DatasetPreparations()<br/>dostarcza selectedPreparationName"]
+    C --> D["useUc18DigitFolders()<br/>hook use-case'u digit/folders"]
+    D --> E["loadDigitFolders()<br/>start pobrania"]
+    E --> F["getDatasetPreparationFolders()<br/>GET /api/datasets/preparations/{preparationName}/digit/folders"]
+    F --> G["fetchJson()<br/>status + parse JSON + validate"]
+    G --> H["mapDatasetPreparationFoldersToDomain()<br/>mapowanie do modelu FE"]
+    H --> I["useUc18DigitFolders()<br/>loadSucceeded"]
+    I --> J["Uc18DigitFoldersPanel()<br/>render licznika i listy"]
+    J --> K["Uc18PreparationFoldersList()<br/>readonly render itemow digit"]
+```
+
+## 21) Opis przeplywu w obrebie BE potrzebny frontendowi
+Ta sekcja opisuje tylko kontraktowe minimum potrzebne `FE`.
+
+1. `FE` wysyla `GET /api/datasets/preparations/{preparationName}/digit/folders`.
+2. `BE` weryfikuje autoryzacje.
+3. `BE` rozpoznaje preparation na podstawie `preparationName`.
+4. `BE` odczytuje logiczna liste zrodel `digit` dla tego preparation.
+5. `BE` zwraca:
+   - `preparationName`,
+   - `type = "digit"`,
+   - `items`,
+   - `totalCount`.
+6. `BE` nie wywoluje `ML` dla tego endpointa.
+7. `FE` nie zaklada nic o fizycznym layoutcie katalogow poza publiczna semantyka kontraktu.
+
+## 22) Workflow GitHub i runtime
+- Ten endpoint nie wymaga nowej zmiennej srodowiskowej po stronie FE.
+- Obowiazujacy workflow FE w `.github/workflows/frontend-cd.yml` juz:
+  - buduje `src/Frontend`,
+  - ustawia `VITE_API_BASE_URL="${FE_VITE_API_BASE_URL:-/api}"`,
+  - pakuje `dist`,
+  - publikuje statyczny build.
+- Lokalnie:
+  - `FE` powinien dzialac na stalym `/api` albo lokalnym `VITE_API_BASE_URL`,
+  - nie dotykamy z poziomu FE zadnych `appsettings`,
+  - lokalne przypisanie pozostaje "na sztywno" w ramach obecnego mechanizmu `VITE_API_BASE_URL` / `/api`.
+- Produkcyjnie:
+  - workflow backendowy moze podmieniac produkcyjne `appsettings`,
+  - ten plan FE nie moze od tego zalezec inaczej niz przez publiczny adres `/api`.
+- Dla tego endpointa nie ma potrzeby zmiany `.github/workflows/frontend-cd.yml`.
+- Jesli w przyszlosci zostana dodane testy FE dla `UC-18`, ich uruchomienie w workflow nalezy rozwazac osobno, bo obecne `package.json` nie ma skryptu testowego.
+
+## 23) Kolejnosc implementacji kodu dla historyjki
+1. Zweryfikowac, ze `src/Frontend/src/api/datasetPreparations.ts` pozostaje jedynym klientem dla `digit/folders`.
+2. Zweryfikowac, ze `src/Frontend/src/types/api.ts` nie wymaga nowego kontraktu transportowego, bo `DatasetPreparationFoldersApiResponse` juz istnieje.
+3. Dodac `useUc18DigitFolders.ts`.
+4. Dodac `Uc18DigitFoldersPanel.tsx`.
+5. Uogolnic `Uc18PreparationFoldersList.tsx`, aby obslugiwal tryb `readonly` i nie byl tekstowo zwiazany tylko z `board`.
+6. Rozszerzyc `Uc18BoardFoldersSection.tsx`, aby jako shell `UC-18` renderowal rowniez panel `digit`.
+7. Opcjonalnie dopiero na tym etapie wyciagnac wspolny loader folderow, jesli kod `board` i `digit` zacznie sie istotnie duplikowac.
+8. Dopracowac lekkie logowanie diagnostyczne.
+9. Uruchomic kontrole jakosci FE.
+
+## 24) Guardraile implementacyjne
+- Nie tworzyc nowego klienta HTTP poza `datasetPreparations.ts`.
+- Nie dublowac `buildAuthHeaders()`.
+- Nie przenosic `fetch` do komponentow React.
+- Nie importowac logiki `UC-18` do legacy `UC-12`.
+- Nie traktowac `items: []` jako bledu.
+- Nie zgadywac listy `digit` z innych danych.
+- Nie sortowac odpowiedzi po stronie FE bez twardego wymagania.
+- Nie dodawac delete ani preview dla `digit` w tej historyjce.
+- Nie tworzyc sztucznego `selectedSourceName` tylko po to, by reuse'owac komponent 1:1.
+- Nie dodawac ciezkiego logowania ani `console.log` na kazdy render elementu listy.
+
+## 25) Zaleznosci pomiedzy historyjkami
+
+### Wejsciowe
+- `UC-13`
+  - dostarcza sesje administracyjna i token.
+- `UC-17 POST /api/datasets/preparations`
+  - tworzy preparation, na ktorym pracuje `UC-18`.
+- `UC-17 GET /api/datasets/preparations`
+  - daje liste preparation do wyboru.
+- `UC-17 GET /api/datasets/preparations/{preparationName}`
+  - daje kontekst statusu i szczegolow preparation.
+- `UC-18 GET /api/datasets/preparations/{preparationName}/board/folders`
+  - juz istnieje;
+  - stanowi glowna sciezke przegladu `UC-18`;
+  - daje gotowy wzorzec dla warstw `Infrastructure` i `Model`.
+
+### Rownolegle / sasiednie
+- `UC-18 GET /api/datasets/preparations/{preparationName}/digit/folders`
+  - ma korzystac z tej samej infrastruktury i tego samego modelu folderow co `board/folders`,
+  - ale z innym zachowaniem `View`.
+
+### Wyjsciowe
+- `UC-18 board/{sourceName}/files`
+  - downstream tylko dla `board`, nie dla `digit`.
+- `UC-19`
+  - wykorzysta oczyszczone preparation po zakonczonym `UC-18`;
+  - lista `digit` z tego endpointa jest tylko kontekstem przygotowania.
+
+## 26) Inne istotne reguly
+- Trzymac sie istniejacych kontraktow i nazw typow z poprzednich historyjek.
+- Nie zmieniac nazw istniejacych plikow `board`, jesli nie ma takiej koniecznosci.
+- `digit/folders` ma pozostac cienkim read-only dodatkiem do ekranu `UC-18`, a nie nowym, niezaleznym workflow.
+- `FE` ma renderowac tylko publiczna semantyke API, nie layout runtime.
+- Kolejnosc z backendu jest istotna i nie powinna byc przepisywana przez frontend.
+- Jesli po dodaniu `digit` komponent listy staje sie zbyt mocno "board-specific", nalezy go uogolnic, a nie kopiowac do drugiego pliku 1:1.
+- Generycznosc ma sluzyc realnemu reuse'owi, a nie tworzeniu nadmiarowych abstrakcji przed potrzeba.
+
+## 27) Plan weryfikacji minimum
+- `npm run check`
+- `npm run build`
+- scenariusz happy path:
+  - poprawny `preparationName`,
+  - backend zwraca `type = "digit"`,
+  - lista folderow renderuje sie poprawnie,
+  - licznik `totalCount` zgadza sie z odpowiedzia.
+- scenariusz pustej listy:
+  - `200 OK`,
+  - UI pokazuje pusty stan bez bledu.
+- scenariusz `401`:
+  - `onUnauthorized` zostaje wywolane.
+- scenariusz `404`:
+  - UI pokazuje blad stalego / niedostepnego preparation.
+- scenariusz niepoprawnego `type` w response:
+  - odpowiedz jest traktowana jako blad kontraktowy.
+- scenariusz szybkiej zmiany preparation:
+  - starsza odpowiedz nie nadpisuje nowszego stanu.
+
+## 28) Podsumowanie decyzji
+- Dla `GET /api/datasets/preparations/{preparationName}/digit/folders` wiekszosc warstw jest juz przygotowana:
+  - `Infrastructure` jest gotowe,
+  - `Model` jest gotowy,
+  - brakujace sa glownie elementy `View` i `ViewController`.
+- Najwazniejsze granice odpowiedzialnosci:
+  - `Infrastructure` pobiera i waliduje kontrakt,
+  - `ViewController` steruje requestem i stanem,
+  - `Model` mapuje dane,
+  - `View` tylko renderuje read-only liste `digit`.
+- Najwazniejsze guardraile:
+  - brak duplikacji klienta API,
+  - brak mieszania z `UC-12`,
+  - brak zgadywania danych po stronie FE,
+  - brak preview/delete dla `digit`,
+  - brak ciezkiego logowania.
+- Najwazniejsza decyzja pod reuse:
+  - wykorzystac istniejace `getDatasetPreparationFolders(...)` i wspolny model domenowy,
+  - nie zmieniac istniejacych publicznych nazw z `board/folders`,
+  - dopisac `digit` jako lekki panel oparty o te same fundamenty, ale z read-only zachowaniem zgodnym z `UC-18`.

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -55,6 +55,7 @@ jobs:
       BE_RAW_DATASETS_DIGITS_SUBDIRECTORY: ${{ vars.BE_RAW_DATASETS_DIGITS_SUBDIRECTORY }}
       BE_DATASETS_PREP_BOARDS_SUBDIRECTORY: ${{ vars.BE_DATASETS_PREP_BOARDS_SUBDIRECTORY }}
       BE_DATASETS_PREP_DIGITS_SUBDIRECTORY: ${{ vars.BE_DATASETS_PREP_DIGITS_SUBDIRECTORY }}
+      BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH: ${{ vars.BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH }}
       BE_DATASETS_PREP_PROCESSED_DIRECTORY_PATH: ${{ vars.BE_DATASETS_PREP_PROCESSED_DIRECTORY_PATH }}
       BE_DATASETS_PREP_TEMPORARY_ARTIFACTS_DIRECTORY_PATH: ${{ vars.BE_DATASETS_PREP_TEMPORARY_ARTIFACTS_DIRECTORY_PATH }}
       BE_DATASETS_PREP_DEFAULT_PREPROCESSING_PROFILE: ${{ vars.BE_DATASETS_PREP_DEFAULT_PREPROCESSING_PROFILE }}
@@ -155,6 +156,11 @@ jobs:
 
           if [ -z "$BE_DATASETS_PREP_DIGITS_SUBDIRECTORY" ]; then
             echo "Missing BE_DATASETS_PREP_DIGITS_SUBDIRECTORY variable for the selected GitHub environment."
+            exit 1
+          fi
+
+          if [ -z "$BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH" ]; then
+            echo "Missing BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH variable for the selected GitHub environment."
             exit 1
           fi
 
@@ -293,6 +299,7 @@ jobs:
               "BE_RAW_DATASETS_DIGITS_SUBDIRECTORY",
               "BE_DATASETS_PREP_BOARDS_SUBDIRECTORY",
               "BE_DATASETS_PREP_DIGITS_SUBDIRECTORY",
+              "BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH",
               "BE_DATASETS_PREP_PROCESSED_DIRECTORY_PATH",
               "BE_DATASETS_PREP_TEMPORARY_ARTIFACTS_DIRECTORY_PATH",
               "BE_DATASETS_PREP_DEFAULT_PREPROCESSING_PROFILE",
@@ -390,6 +397,7 @@ jobs:
           datasets_preparation = config.setdefault("DatasetsPreparation", {})
           datasets_preparation["BoardsSubdirectory"] = os.environ["BE_DATASETS_PREP_BOARDS_SUBDIRECTORY"]
           datasets_preparation["DigitsSubdirectory"] = os.environ["BE_DATASETS_PREP_DIGITS_SUBDIRECTORY"]
+          datasets_preparation["PreparationsDirectoryPath"] = os.environ["BE_DATASETS_PREP_PREPARATIONS_DIRECTORY_PATH"]
           datasets_preparation["ProcessedDatasetsDirectoryPath"] = os.environ["BE_DATASETS_PREP_PROCESSED_DIRECTORY_PATH"]
           datasets_preparation["TemporaryArtifactsDirectoryPath"] = os.environ["BE_DATASETS_PREP_TEMPORARY_ARTIFACTS_DIRECTORY_PATH"]
           datasets_preparation["DefaultPreprocessingProfile"] = os.environ["BE_DATASETS_PREP_DEFAULT_PREPROCESSING_PROFILE"]

--- a/src/Backend/Sudoku/Application.Tests/DatasetPreparationArtifactsGatewayTests.cs
+++ b/src/Backend/Sudoku/Application.Tests/DatasetPreparationArtifactsGatewayTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.Extensions.Options;
+using Sudoku.Application.Datasets;
+using Sudoku.Infrastructure.Storage;
+
+namespace Application.Tests;
+
+public sealed class DatasetPreparationArtifactsGatewayTests
+{
+    [Fact]
+    public async Task GetSourceFolderNamesAsync_ReadsManifestFromProcessedPreparationsFallback()
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var preparationsDirectoryPath = Path.Combine(tempDirectory.FullName, "preparations");
+            var processedDatasetsDirectoryPath = Path.Combine(tempDirectory.FullName, "processed");
+            var manifestDirectoryPath = Path.Combine(
+                processedDatasetsDirectoryPath,
+                "preparations",
+                "preparation-001",
+                "digit");
+
+            Directory.CreateDirectory(manifestDirectoryPath);
+            await File.WriteAllTextAsync(
+                Path.Combine(manifestDirectoryPath, "folders.json"),
+                """
+                ["mnist_train","mnist_test"]
+                """);
+
+            var gateway = CreateGateway(preparationsDirectoryPath, processedDatasetsDirectoryPath);
+
+            var result = await gateway.GetSourceFolderNamesAsync("preparation-001", "digit");
+
+            Assert.Equal(["mnist_train", "mnist_test"], result);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task GetBoardFileNamesAsync_ReadsManifestFromProcessedPreparationsFallback()
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var preparationsDirectoryPath = Path.Combine(tempDirectory.FullName, "preparations");
+            var processedDatasetsDirectoryPath = Path.Combine(tempDirectory.FullName, "processed");
+            var manifestDirectoryPath = Path.Combine(
+                processedDatasetsDirectoryPath,
+                "preparations",
+                "preparation-001",
+                "board",
+                "v1_training");
+
+            Directory.CreateDirectory(manifestDirectoryPath);
+            await File.WriteAllTextAsync(
+                Path.Combine(manifestDirectoryPath, "file.json"),
+                """
+                ["Image1","Image2"]
+                """);
+
+            var gateway = CreateGateway(preparationsDirectoryPath, processedDatasetsDirectoryPath);
+
+            var result = await gateway.GetBoardFileNamesAsync("preparation-001", "v1_training");
+
+            Assert.Equal(["Image1", "Image2"], result);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    private static DatasetPreparationArtifactsGateway CreateGateway(
+        string preparationsDirectoryPath,
+        string processedDatasetsDirectoryPath)
+    {
+        return new DatasetPreparationArtifactsGateway(
+            new LocalFileStorageGateway(),
+            Options.Create(new DatasetsPreparationOptions
+            {
+                BoardsSubdirectory = "/tmp/raw/boards",
+                DigitsSubdirectory = "/tmp/raw/digits",
+                PreparationsDirectoryPath = preparationsDirectoryPath,
+                ProcessedDatasetsDirectoryPath = processedDatasetsDirectoryPath,
+                TemporaryArtifactsDirectoryPath = "/tmp/datasets-temp",
+                DefaultPreprocessingProfile = "default-28x28-v1",
+                DefaultMixSplitRatios = new DatasetsPreparationOptions.MixSplitRatiosOptions()
+            }));
+    }
+}

--- a/src/Backend/Sudoku/Application.Tests/DatasetsControllerTests.cs
+++ b/src/Backend/Sudoku/Application.Tests/DatasetsControllerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
 using Sudoku.Application.Datasets;
+using Sudoku.Application.Storage;
 using Sudoku.Controllers;
 using Sudoku.Contracts;
 
@@ -239,6 +240,633 @@ public sealed class DatasetsControllerTests
 
         var payload = Assert.IsType<ErrorApiResponse>(objectResult.Value);
         Assert.Equal(GetDatasetPreparationDetailsErrorTypes.DatasetPreparationReadFailed, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardFoldersAsync_ReturnsOkAndMapsResponse()
+    {
+        var sender = new StubSender(new GetDatasetPreparationFoldersQueryResultDto(
+            PreparationName: "preparation-001",
+            Type: "board",
+            Items: ["v1_training", "v2_training"],
+            TotalCount: 2));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardFoldersAsync("preparation-001", CancellationToken.None);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var query = Assert.IsType<GetDatasetPreparationFoldersQuery>(sender.LastRequest);
+        Assert.Equal("preparation-001", query.PreparationName);
+        Assert.Equal("board", query.Type);
+
+        var payload = Assert.IsType<DatasetPreparationFoldersApiResponse>(okResult.Value);
+        Assert.Equal("preparation-001", payload.PreparationName);
+        Assert.Equal("board", payload.Type);
+        Assert.Equal(2, payload.TotalCount);
+        Assert.Equal(["v1_training", "v2_training"], payload.Items);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardFoldersAsync_ReturnsBadRequest_WhenValidationFails()
+    {
+        var sender = new StubSender(new ValidationException([
+            new ValidationFailure(nameof(GetDatasetPreparationFoldersQuery.PreparationName), "Pole 'preparationName' jest wymagane.")
+            {
+                ErrorCode = GetDatasetPreparationFoldersErrorTypes.InvalidDatasetPreparationName
+            }
+        ]));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardFoldersAsync(null, CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(objectResult.Value);
+        Assert.Equal(GetDatasetPreparationFoldersErrorTypes.InvalidDatasetPreparationName, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardFoldersAsync_ReturnsNotFound_WhenPreparationDoesNotExist()
+    {
+        var sender = new StubSender(new DatasetPreparationNotFoundException("missing"));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardFoldersAsync("missing", CancellationToken.None);
+
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal(StatusCodes.Status404NotFound, notFoundResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(notFoundResult.Value);
+        Assert.Equal(GetDatasetPreparationFoldersErrorTypes.DatasetPreparationNotFound, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardFoldersAsync_ReturnsConflict_WhenArtifactsAreNotReady()
+    {
+        var sender = new StubSender(new DatasetPreparationArtifactsNotReadyException("preparation-001", "running"));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardFoldersAsync("preparation-001", CancellationToken.None);
+
+        var conflictResult = Assert.IsType<ConflictObjectResult>(result);
+        Assert.Equal(StatusCodes.Status409Conflict, conflictResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(conflictResult.Value);
+        Assert.Equal(GetDatasetPreparationFoldersErrorTypes.DatasetPreparationArtifactsNotReady, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardFoldersAsync_ReturnsInternalServerError_WhenReadFails()
+    {
+        var sender = new StubSender(new InvalidDataException("broken manifest"));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardFoldersAsync("preparation-001", CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, objectResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(objectResult.Value);
+        Assert.Equal(GetDatasetPreparationFoldersErrorTypes.DatasetPreparationFoldersReadFailed, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationDigitFoldersAsync_ReturnsOkAndMapsResponse()
+    {
+        var sender = new StubSender(new GetDatasetPreparationFoldersQueryResultDto(
+            PreparationName: "preparation-001",
+            Type: "digit",
+            Items: ["mnist_train", "mnist_test"],
+            TotalCount: 2));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationDigitFoldersAsync("preparation-001", CancellationToken.None);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var query = Assert.IsType<GetDatasetPreparationFoldersQuery>(sender.LastRequest);
+        Assert.Equal("preparation-001", query.PreparationName);
+        Assert.Equal("digit", query.Type);
+
+        var payload = Assert.IsType<DatasetPreparationFoldersApiResponse>(okResult.Value);
+        Assert.Equal("preparation-001", payload.PreparationName);
+        Assert.Equal("digit", payload.Type);
+        Assert.Equal(2, payload.TotalCount);
+        Assert.Equal(["mnist_train", "mnist_test"], payload.Items);
+    }
+
+    [Fact]
+    public async Task GetPreparationDigitFoldersAsync_ReturnsBadRequest_WhenValidationFails()
+    {
+        var sender = new StubSender(new ValidationException([
+            new ValidationFailure(nameof(GetDatasetPreparationFoldersQuery.PreparationName), "Pole 'preparationName' jest wymagane.")
+            {
+                ErrorCode = GetDatasetPreparationFoldersErrorTypes.InvalidDatasetPreparationName
+            }
+        ]));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationDigitFoldersAsync(null, CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(objectResult.Value);
+        Assert.Equal(GetDatasetPreparationFoldersErrorTypes.InvalidDatasetPreparationName, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationDigitFoldersAsync_ReturnsNotFound_WhenPreparationDoesNotExist()
+    {
+        var sender = new StubSender(new DatasetPreparationNotFoundException("missing"));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationDigitFoldersAsync("missing", CancellationToken.None);
+
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal(StatusCodes.Status404NotFound, notFoundResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(notFoundResult.Value);
+        Assert.Equal(GetDatasetPreparationFoldersErrorTypes.DatasetPreparationNotFound, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationDigitFoldersAsync_ReturnsConflict_WhenArtifactsAreNotReady()
+    {
+        var sender = new StubSender(new DatasetPreparationArtifactsNotReadyException("preparation-001", "running"));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationDigitFoldersAsync("preparation-001", CancellationToken.None);
+
+        var conflictResult = Assert.IsType<ConflictObjectResult>(result);
+        Assert.Equal(StatusCodes.Status409Conflict, conflictResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(conflictResult.Value);
+        Assert.Equal(GetDatasetPreparationFoldersErrorTypes.DatasetPreparationArtifactsNotReady, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationDigitFoldersAsync_ReturnsInternalServerError_WhenReadFails()
+    {
+        var sender = new StubSender(new InvalidDataException("broken manifest"));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationDigitFoldersAsync("preparation-001", CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, objectResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(objectResult.Value);
+        Assert.Equal(GetDatasetPreparationFoldersErrorTypes.DatasetPreparationFoldersReadFailed, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardFilesAsync_ReturnsOkAndMapsResponse()
+    {
+        var sender = new StubSender(new GetDatasetPreparationBoardFilesQueryResultDto(
+            PreparationName: "preparation-001",
+            SourceName: "v1_training",
+            Items:
+            [
+                new DatasetPreparationBoardFileListItemDto("Image1"),
+                new DatasetPreparationBoardFileListItemDto("Image 2")
+            ],
+            Page: 2,
+            PageSize: 2,
+            TotalCount: 5));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardFilesAsync(
+            "preparation-001",
+            "v1_training",
+            2,
+            2,
+            CancellationToken.None);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var query = Assert.IsType<GetDatasetPreparationBoardFilesQuery>(sender.LastRequest);
+        Assert.Equal("preparation-001", query.PreparationName);
+        Assert.Equal("v1_training", query.SourceName);
+        Assert.Equal(2, query.Page);
+        Assert.Equal(2, query.PageSize);
+
+        var payload = Assert.IsType<DatasetPreparationBoardFilesApiResponse>(okResult.Value);
+        Assert.Equal("preparation-001", payload.PreparationName);
+        Assert.Equal("v1_training", payload.SourceName);
+        Assert.Equal(2, payload.Page);
+        Assert.Equal(2, payload.PageSize);
+        Assert.Equal(5, payload.TotalCount);
+        Assert.Collection(
+            payload.Items,
+            item =>
+            {
+                Assert.Equal("Image1", item.BoardFolderName);
+                Assert.Equal("/api/datasets/preparations/preparation-001/board/v1_training/files/Image1/image", item.ImageEndpoint);
+            },
+            item =>
+            {
+                Assert.Equal("Image 2", item.BoardFolderName);
+                Assert.Equal("/api/datasets/preparations/preparation-001/board/v1_training/files/Image%202/image", item.ImageEndpoint);
+            });
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardFilesAsync_ReturnsBadRequest_WhenValidationFails()
+    {
+        var sender = new StubSender(new ValidationException([
+            new ValidationFailure(nameof(GetDatasetPreparationBoardFilesQuery.SourceName), "Pole 'sourceName' jest wymagane.")
+            {
+                ErrorCode = GetDatasetPreparationBoardFilesErrorTypes.InvalidDatasetPreparationSourceName
+            }
+        ]));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardFilesAsync(
+            "preparation-001",
+            null,
+            1,
+            50,
+            CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(objectResult.Value);
+        Assert.Equal(GetDatasetPreparationBoardFilesErrorTypes.InvalidDatasetPreparationSourceName, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardFilesAsync_ReturnsNotFound_WhenPreparationDoesNotExist()
+    {
+        var sender = new StubSender(new DatasetPreparationNotFoundException("missing"));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardFilesAsync(
+            "missing",
+            "v1_training",
+            1,
+            50,
+            CancellationToken.None);
+
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal(StatusCodes.Status404NotFound, notFoundResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(notFoundResult.Value);
+        Assert.Equal(GetDatasetPreparationBoardFilesErrorTypes.DatasetPreparationNotFound, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardFilesAsync_ReturnsNotFound_WhenSourceDoesNotExist()
+    {
+        var sender = new StubSender(new DatasetPreparationSourceNotFoundException("preparation-001", "missing-source"));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardFilesAsync(
+            "preparation-001",
+            "missing-source",
+            1,
+            50,
+            CancellationToken.None);
+
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal(StatusCodes.Status404NotFound, notFoundResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(notFoundResult.Value);
+        Assert.Equal(GetDatasetPreparationBoardFilesErrorTypes.DatasetPreparationSourceNotFound, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardFilesAsync_ReturnsConflict_WhenArtifactsAreNotReady()
+    {
+        var sender = new StubSender(new DatasetPreparationArtifactsNotReadyException("preparation-001", "running"));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardFilesAsync(
+            "preparation-001",
+            "v1_training",
+            1,
+            50,
+            CancellationToken.None);
+
+        var conflictResult = Assert.IsType<ConflictObjectResult>(result);
+        Assert.Equal(StatusCodes.Status409Conflict, conflictResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(conflictResult.Value);
+        Assert.Equal(GetDatasetPreparationBoardFilesErrorTypes.DatasetPreparationArtifactsNotReady, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardFilesAsync_ReturnsInternalServerError_WhenReadFails()
+    {
+        var sender = new StubSender(new InvalidDataException("broken file manifest"));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardFilesAsync(
+            "preparation-001",
+            "v1_training",
+            1,
+            50,
+            CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, objectResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(objectResult.Value);
+        Assert.Equal(GetDatasetPreparationBoardFilesErrorTypes.DatasetPreparationBoardFilesReadFailed, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardImageAsync_ReturnsOkAndMapsResponse()
+    {
+        var sender = new StubSender(new GetDatasetPreparationBoardImageQueryResultDto(
+            MimeType: "image/png",
+            Base64: "AQID"));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardImageAsync(
+            "preparation-001",
+            "v1_training",
+            "Image 1",
+            CancellationToken.None);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var query = Assert.IsType<GetDatasetPreparationBoardImageQuery>(sender.LastRequest);
+        Assert.Equal("preparation-001", query.PreparationName);
+        Assert.Equal("v1_training", query.SourceName);
+        Assert.Equal("Image 1", query.BoardFolderName);
+
+        var payload = Assert.IsType<ImageApiResponse>(okResult.Value);
+        Assert.Equal("image/png", payload.MimeType);
+        Assert.Equal("AQID", payload.Base64);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardImageAsync_ReturnsBadRequest_WhenValidationFails()
+    {
+        var sender = new StubSender(new ValidationException([
+            new ValidationFailure(nameof(GetDatasetPreparationBoardImageQuery.BoardFolderName), "Pole 'boardFolderName' jest wymagane.")
+            {
+                ErrorCode = GetDatasetPreparationBoardImageErrorTypes.InvalidDatasetPreparationBoardFolderName
+            }
+        ]));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardImageAsync(
+            "preparation-001",
+            "v1_training",
+            null,
+            CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(objectResult.Value);
+        Assert.Equal(GetDatasetPreparationBoardImageErrorTypes.InvalidDatasetPreparationBoardFolderName, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardImageAsync_ReturnsNotFound_WhenPreparationDoesNotExist()
+    {
+        var sender = new StubSender(new DatasetPreparationNotFoundException("missing"));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardImageAsync(
+            "missing",
+            "v1_training",
+            "Image1",
+            CancellationToken.None);
+
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal(StatusCodes.Status404NotFound, notFoundResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(notFoundResult.Value);
+        Assert.Equal(GetDatasetPreparationBoardImageErrorTypes.DatasetPreparationNotFound, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardImageAsync_ReturnsNotFound_WhenSourceDoesNotExist()
+    {
+        var sender = new StubSender(new DatasetPreparationSourceNotFoundException("preparation-001", "missing-source"));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardImageAsync(
+            "preparation-001",
+            "missing-source",
+            "Image1",
+            CancellationToken.None);
+
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal(StatusCodes.Status404NotFound, notFoundResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(notFoundResult.Value);
+        Assert.Equal(GetDatasetPreparationBoardImageErrorTypes.DatasetPreparationSourceNotFound, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardImageAsync_ReturnsNotFound_WhenBoardFolderDoesNotExist()
+    {
+        var sender = new StubSender(new DatasetPreparationBoardFileNotFoundException("preparation-001", "v1_training", "Image404"));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardImageAsync(
+            "preparation-001",
+            "v1_training",
+            "Image404",
+            CancellationToken.None);
+
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal(StatusCodes.Status404NotFound, notFoundResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(notFoundResult.Value);
+        Assert.Equal(GetDatasetPreparationBoardImageErrorTypes.DatasetPreparationBoardFileNotFound, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardImageAsync_ReturnsConflict_WhenArtifactsAreNotReady()
+    {
+        var sender = new StubSender(new DatasetPreparationArtifactsNotReadyException("preparation-001", "running"));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardImageAsync(
+            "preparation-001",
+            "v1_training",
+            "Image1",
+            CancellationToken.None);
+
+        var conflictResult = Assert.IsType<ConflictObjectResult>(result);
+        Assert.Equal(StatusCodes.Status409Conflict, conflictResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(conflictResult.Value);
+        Assert.Equal(GetDatasetPreparationBoardImageErrorTypes.DatasetPreparationArtifactsNotReady, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPreparationBoardImageAsync_ReturnsInternalServerError_WhenReadFails()
+    {
+        var sender = new StubSender(new FileStorageItemNotFoundException("Wskazany plik nie istnieje."));
+        var controller = CreateController(sender);
+
+        var result = await controller.GetPreparationBoardImageAsync(
+            "preparation-001",
+            "v1_training",
+            "Image1",
+            CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, objectResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(objectResult.Value);
+        Assert.Equal(GetDatasetPreparationBoardImageErrorTypes.DatasetPreparationBoardImageReadFailed, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task DeletePreparationBoardFileAsync_ReturnsOkAndMapsResponse()
+    {
+        var sender = new StubSender(new DeleteDatasetPreparationBoardFileCommandResultDto(
+            PreparationName: "preparation-001",
+            SourceName: "v1_training",
+            BoardFolderName: "Image 1",
+            Deleted: true,
+            RemainingItemsCount: 41));
+        var controller = CreateController(sender);
+
+        var result = await controller.DeletePreparationBoardFileAsync(
+            "preparation-001",
+            "v1_training",
+            "Image 1",
+            CancellationToken.None);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var command = Assert.IsType<DeleteDatasetPreparationBoardFileCommand>(sender.LastRequest);
+        Assert.Equal("preparation-001", command.PreparationName);
+        Assert.Equal("v1_training", command.SourceName);
+        Assert.Equal("Image 1", command.BoardFolderName);
+
+        var payload = Assert.IsType<DeleteDatasetPreparationBoardFileApiResponse>(okResult.Value);
+        Assert.Equal("preparation-001", payload.PreparationName);
+        Assert.Equal("v1_training", payload.SourceName);
+        Assert.Equal("Image 1", payload.BoardFolderName);
+        Assert.True(payload.Deleted);
+        Assert.Equal(41, payload.RemainingItemsCount);
+    }
+
+    [Fact]
+    public async Task DeletePreparationBoardFileAsync_ReturnsBadRequest_WhenValidationFails()
+    {
+        var sender = new StubSender(new ValidationException([
+            new ValidationFailure(nameof(DeleteDatasetPreparationBoardFileCommand.BoardFolderName), "Pole 'boardFolderName' jest wymagane.")
+            {
+                ErrorCode = DeleteDatasetPreparationBoardFileErrorTypes.InvalidDatasetPreparationBoardFolderName
+            }
+        ]));
+        var controller = CreateController(sender);
+
+        var result = await controller.DeletePreparationBoardFileAsync(
+            "preparation-001",
+            "v1_training",
+            null,
+            CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(objectResult.Value);
+        Assert.Equal(DeleteDatasetPreparationBoardFileErrorTypes.InvalidDatasetPreparationBoardFolderName, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task DeletePreparationBoardFileAsync_ReturnsNotFound_WhenPreparationDoesNotExist()
+    {
+        var sender = new StubSender(new DatasetPreparationNotFoundException("missing"));
+        var controller = CreateController(sender);
+
+        var result = await controller.DeletePreparationBoardFileAsync(
+            "missing",
+            "v1_training",
+            "Image1",
+            CancellationToken.None);
+
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal(StatusCodes.Status404NotFound, notFoundResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(notFoundResult.Value);
+        Assert.Equal(DeleteDatasetPreparationBoardFileErrorTypes.DatasetPreparationNotFound, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task DeletePreparationBoardFileAsync_ReturnsNotFound_WhenSourceDoesNotExist()
+    {
+        var sender = new StubSender(new DatasetPreparationSourceNotFoundException("preparation-001", "missing-source"));
+        var controller = CreateController(sender);
+
+        var result = await controller.DeletePreparationBoardFileAsync(
+            "preparation-001",
+            "missing-source",
+            "Image1",
+            CancellationToken.None);
+
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal(StatusCodes.Status404NotFound, notFoundResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(notFoundResult.Value);
+        Assert.Equal(DeleteDatasetPreparationBoardFileErrorTypes.DatasetPreparationSourceNotFound, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task DeletePreparationBoardFileAsync_ReturnsNotFound_WhenBoardFolderDoesNotExist()
+    {
+        var sender = new StubSender(new DatasetPreparationBoardFileNotFoundException("preparation-001", "v1_training", "Image404"));
+        var controller = CreateController(sender);
+
+        var result = await controller.DeletePreparationBoardFileAsync(
+            "preparation-001",
+            "v1_training",
+            "Image404",
+            CancellationToken.None);
+
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal(StatusCodes.Status404NotFound, notFoundResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(notFoundResult.Value);
+        Assert.Equal(DeleteDatasetPreparationBoardFileErrorTypes.DatasetPreparationBoardFileNotFound, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task DeletePreparationBoardFileAsync_ReturnsConflict_WhenArtifactsAreNotReady()
+    {
+        var sender = new StubSender(new DatasetPreparationArtifactsNotReadyException("preparation-001", "running"));
+        var controller = CreateController(sender);
+
+        var result = await controller.DeletePreparationBoardFileAsync(
+            "preparation-001",
+            "v1_training",
+            "Image1",
+            CancellationToken.None);
+
+        var conflictResult = Assert.IsType<ConflictObjectResult>(result);
+        Assert.Equal(StatusCodes.Status409Conflict, conflictResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(conflictResult.Value);
+        Assert.Equal(DeleteDatasetPreparationBoardFileErrorTypes.DatasetPreparationArtifactsNotReady, payload.ErrorType);
+    }
+
+    [Fact]
+    public async Task DeletePreparationBoardFileAsync_ReturnsInternalServerError_WhenDeleteFails()
+    {
+        var sender = new StubSender(new IOException("delete failed"));
+        var controller = CreateController(sender);
+
+        var result = await controller.DeletePreparationBoardFileAsync(
+            "preparation-001",
+            "v1_training",
+            "Image1",
+            CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, objectResult.StatusCode);
+
+        var payload = Assert.IsType<ErrorApiResponse>(objectResult.Value);
+        Assert.Equal(DeleteDatasetPreparationBoardFileErrorTypes.DatasetPreparationBoardFileDeleteFailed, payload.ErrorType);
     }
 
     private static DatasetsController CreateController(StubSender sender)

--- a/src/Backend/Sudoku/Application.Tests/DeleteDatasetPreparationBoardFileCommandHandlerTests.cs
+++ b/src/Backend/Sudoku/Application.Tests/DeleteDatasetPreparationBoardFileCommandHandlerTests.cs
@@ -1,0 +1,393 @@
+using Sudoku.Application.Abstractions;
+using Sudoku.Application.Datasets;
+using Sudoku.Models.Datasets;
+
+namespace Application.Tests;
+
+public sealed class DeleteDatasetPreparationBoardFileCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_DeletesBoardAndUpdatesManifest_WhenRequestIsValid()
+    {
+        var metadata = CreateMetadata("preparation-001", DatasetPreparationStatus.Completed);
+        var artifactsGateway = new StubDatasetPreparationArtifactsGateway(
+            sourceFolderNames: ["v1_training"],
+            boardFileNames: ["Image1", "Image2", "Image3"]);
+        var handler = CreateHandler(metadata, artifactsGateway);
+
+        var result = await handler.Handle(
+            new DeleteDatasetPreparationBoardFileCommand("preparation-001", "v1_training", "Image2"),
+            CancellationToken.None);
+
+        Assert.Equal("preparation-001", result.PreparationName);
+        Assert.Equal("v1_training", result.SourceName);
+        Assert.Equal("Image2", result.BoardFolderName);
+        Assert.True(result.Deleted);
+        Assert.Equal(2, result.RemainingItemsCount);
+        Assert.Equal("preparation-001", artifactsGateway.LastPreparationNameForSources);
+        Assert.Equal("board", artifactsGateway.LastSourceType);
+        Assert.Equal("preparation-001", artifactsGateway.LastPreparationNameForBoardFiles);
+        Assert.Equal("v1_training", artifactsGateway.LastSourceNameForBoardFiles);
+        Assert.Equal("preparation-001", artifactsGateway.LastPreparationNameForManifestReplace);
+        Assert.Equal("v1_training", artifactsGateway.LastSourceNameForManifestReplace);
+        Assert.Equal(["Image1", "Image3"], artifactsGateway.ReplacedBoardFileNames);
+        Assert.Equal("preparation-001", artifactsGateway.LastPreparationNameForDeletedBoardDirectory);
+        Assert.Equal("v1_training", artifactsGateway.LastSourceNameForDeletedBoardDirectory);
+        Assert.Equal("Image2", artifactsGateway.LastDeletedBoardFolderName);
+        Assert.Equal(1, artifactsGateway.ReplaceBoardFileNamesCallCount);
+        Assert.Equal(1, artifactsGateway.DeleteBoardDirectoryCallCount);
+    }
+
+    [Fact]
+    public async Task Handle_AllowsDeletingLastBoardEntry_AndPersistsEmptyManifest()
+    {
+        var handler = CreateHandler(
+            CreateMetadata("preparation-001", DatasetPreparationStatus.Completed),
+            new StubDatasetPreparationArtifactsGateway(
+                sourceFolderNames: ["v1_training"],
+                boardFileNames: ["Image1"]));
+
+        var result = await handler.Handle(
+            new DeleteDatasetPreparationBoardFileCommand("preparation-001", "v1_training", "Image1"),
+            CancellationToken.None);
+
+        Assert.True(result.Deleted);
+        Assert.Equal(0, result.RemainingItemsCount);
+    }
+
+    [Fact]
+    public async Task Handle_ThrowsNotFound_WhenPreparationDoesNotExist()
+    {
+        var handler = CreateHandler(
+            metadata: null,
+            new StubDatasetPreparationArtifactsGateway(
+                sourceFolderNames: ["v1_training"],
+                boardFileNames: ["Image1"]));
+
+        await Assert.ThrowsAsync<DatasetPreparationNotFoundException>(() =>
+            handler.Handle(
+                new DeleteDatasetPreparationBoardFileCommand("missing", "v1_training", "Image1"),
+                CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData(DatasetPreparationStatus.Queued)]
+    [InlineData(DatasetPreparationStatus.Running)]
+    [InlineData(DatasetPreparationStatus.Failed)]
+    public async Task Handle_ThrowsConflict_WhenPreparationArtifactsAreNotReady(string status)
+    {
+        var handler = CreateHandler(
+            CreateMetadata("preparation-001", status),
+            new StubDatasetPreparationArtifactsGateway(
+                sourceFolderNames: ["v1_training"],
+                boardFileNames: ["Image1"]));
+
+        var exception = await Assert.ThrowsAsync<DatasetPreparationArtifactsNotReadyException>(() =>
+            handler.Handle(
+                new DeleteDatasetPreparationBoardFileCommand("preparation-001", "v1_training", "Image1"),
+                CancellationToken.None));
+
+        Assert.Equal("preparation-001", exception.PreparationName);
+        Assert.Equal(status, exception.Status);
+    }
+
+    [Fact]
+    public async Task Handle_ThrowsNotFound_WhenBoardSourceDoesNotExist()
+    {
+        var handler = CreateHandler(
+            CreateMetadata("preparation-001", DatasetPreparationStatus.Completed),
+            new StubDatasetPreparationArtifactsGateway(
+                sourceFolderNames: ["v2_training"],
+                boardFileNames: ["Image1"]));
+
+        var exception = await Assert.ThrowsAsync<DatasetPreparationSourceNotFoundException>(() =>
+            handler.Handle(
+                new DeleteDatasetPreparationBoardFileCommand("preparation-001", "v1_training", "Image1"),
+                CancellationToken.None));
+
+        Assert.Equal("preparation-001", exception.PreparationName);
+        Assert.Equal("v1_training", exception.SourceName);
+    }
+
+    [Fact]
+    public async Task Handle_ThrowsNotFound_WhenBoardFolderDoesNotExistInManifest()
+    {
+        var handler = CreateHandler(
+            CreateMetadata("preparation-001", DatasetPreparationStatus.Completed),
+            new StubDatasetPreparationArtifactsGateway(
+                sourceFolderNames: ["v1_training"],
+                boardFileNames: ["Image2"]));
+
+        var exception = await Assert.ThrowsAsync<DatasetPreparationBoardFileNotFoundException>(() =>
+            handler.Handle(
+                new DeleteDatasetPreparationBoardFileCommand("preparation-001", "v1_training", "Image1"),
+                CancellationToken.None));
+
+        Assert.Equal("preparation-001", exception.PreparationName);
+        Assert.Equal("v1_training", exception.SourceName);
+        Assert.Equal("Image1", exception.BoardFolderName);
+    }
+
+    [Fact]
+    public async Task Handle_PropagatesManifestWriteFailure_WithoutDeletingDirectory()
+    {
+        var artifactsGateway = new StubDatasetPreparationArtifactsGateway(
+            sourceFolderNames: ["v1_training"],
+            boardFileNames: ["Image1", "Image2"],
+            replaceBoardFileNamesException: new IOException("manifest write failed"));
+        var handler = CreateHandler(
+            CreateMetadata("preparation-001", DatasetPreparationStatus.Completed),
+            artifactsGateway);
+
+        await Assert.ThrowsAsync<IOException>(() =>
+            handler.Handle(
+                new DeleteDatasetPreparationBoardFileCommand("preparation-001", "v1_training", "Image1"),
+                CancellationToken.None));
+
+        Assert.Equal(1, artifactsGateway.ReplaceBoardFileNamesCallCount);
+        Assert.Equal(0, artifactsGateway.DeleteBoardDirectoryCallCount);
+    }
+
+    [Fact]
+    public async Task Handle_RollsBackManifest_WhenDirectoryDeleteFails()
+    {
+        var artifactsGateway = new StubDatasetPreparationArtifactsGateway(
+            sourceFolderNames: ["v1_training"],
+            boardFileNames: ["Image1", "Image2"],
+            deleteBoardDirectoryException: new IOException("delete failed"));
+        var handler = CreateHandler(
+            CreateMetadata("preparation-001", DatasetPreparationStatus.Completed),
+            artifactsGateway);
+
+        await Assert.ThrowsAsync<IOException>(() =>
+            handler.Handle(
+                new DeleteDatasetPreparationBoardFileCommand("preparation-001", "v1_training", "Image1"),
+                CancellationToken.None));
+
+        Assert.Equal(2, artifactsGateway.ReplaceBoardFileNamesCallCount);
+        Assert.Equal(["Image1", "Image2"], artifactsGateway.ReplacedBoardFileNamesHistory[1]);
+        Assert.Equal(1, artifactsGateway.DeleteBoardDirectoryCallCount);
+    }
+
+    [Fact]
+    public async Task Handle_StillPropagatesDeleteFailure_WhenRollbackAlsoFails()
+    {
+        var artifactsGateway = new StubDatasetPreparationArtifactsGateway(
+            sourceFolderNames: ["v1_training"],
+            boardFileNames: ["Image1", "Image2"],
+            deleteBoardDirectoryException: new IOException("delete failed"),
+            replaceBoardFileNamesExceptionSequence:
+            [
+                null,
+                new UnauthorizedAccessException("rollback failed")
+            ]);
+        var handler = CreateHandler(
+            CreateMetadata("preparation-001", DatasetPreparationStatus.Completed),
+            artifactsGateway);
+
+        var exception = await Assert.ThrowsAsync<IOException>(() =>
+            handler.Handle(
+                new DeleteDatasetPreparationBoardFileCommand("preparation-001", "v1_training", "Image1"),
+                CancellationToken.None));
+
+        Assert.Equal("delete failed", exception.Message);
+        Assert.Equal(2, artifactsGateway.ReplaceBoardFileNamesCallCount);
+        Assert.Equal(1, artifactsGateway.DeleteBoardDirectoryCallCount);
+    }
+
+    private static DeleteDatasetPreparationBoardFileCommandHandler CreateHandler(
+        DatasetPreparationMetadataDto? metadata,
+        StubDatasetPreparationArtifactsGateway artifactsGateway)
+    {
+        return new DeleteDatasetPreparationBoardFileCommandHandler(
+            new StubDatasetPreparationsGateway(metadata),
+            artifactsGateway);
+    }
+
+    private static DatasetPreparationMetadataDto CreateMetadata(string preparationName, string status)
+    {
+        return new DatasetPreparationMetadataDto(
+            PreparationName: preparationName,
+            Status: status,
+            CreatedAtUtc: DateTimeOffset.Parse("2026-06-19T18:42:11Z"),
+            Sources:
+            [
+                new CreateDatasetPreparationSourceDto("v1_training", "board")
+            ],
+            SourceReports:
+            [
+                new DatasetPreparationSourceReportDto("v1_training", "board", 24, 0, 0)
+            ],
+            Warnings: []);
+    }
+
+    private sealed class StubDatasetPreparationsGateway : IDatasetPreparationsGateway
+    {
+        private readonly DatasetPreparationMetadataDto? _metadata;
+
+        public StubDatasetPreparationsGateway(DatasetPreparationMetadataDto? metadata)
+        {
+            _metadata = metadata;
+        }
+
+        public Task<IReadOnlyList<DatasetPreparationMetadataDto>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<DatasetPreparationMetadataDto?> GetByNameAsync(
+            string preparationName,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_metadata);
+        }
+
+        public Task<bool> TryCreateAsync(
+            DatasetPreparationMetadataDto metadata,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task UpdateAsync(
+            DatasetPreparationMetadataDto metadata,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task CleanupGeneratedContentAsync(
+            string preparationName,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class StubDatasetPreparationArtifactsGateway : IDatasetPreparationArtifactsGateway
+    {
+        private readonly IReadOnlyList<string> _sourceFolderNames;
+        private readonly IReadOnlyList<string> _boardFileNames;
+        private readonly Exception? _replaceBoardFileNamesException;
+        private readonly Queue<Exception?> _replaceBoardFileNamesExceptionSequence;
+        private readonly Exception? _deleteBoardDirectoryException;
+
+        public StubDatasetPreparationArtifactsGateway(
+            IReadOnlyList<string> sourceFolderNames,
+            IReadOnlyList<string> boardFileNames,
+            Exception? replaceBoardFileNamesException = null,
+            Exception? deleteBoardDirectoryException = null,
+            IReadOnlyList<Exception?>? replaceBoardFileNamesExceptionSequence = null)
+        {
+            _sourceFolderNames = sourceFolderNames;
+            _boardFileNames = boardFileNames;
+            _replaceBoardFileNamesException = replaceBoardFileNamesException;
+            _deleteBoardDirectoryException = deleteBoardDirectoryException;
+            _replaceBoardFileNamesExceptionSequence = new Queue<Exception?>(
+                replaceBoardFileNamesExceptionSequence ?? Array.Empty<Exception?>());
+        }
+
+        public string? LastPreparationNameForSources { get; private set; }
+
+        public string? LastSourceType { get; private set; }
+
+        public string? LastPreparationNameForBoardFiles { get; private set; }
+
+        public string? LastSourceNameForBoardFiles { get; private set; }
+
+        public string? LastPreparationNameForManifestReplace { get; private set; }
+
+        public string? LastSourceNameForManifestReplace { get; private set; }
+
+        public IReadOnlyList<string>? ReplacedBoardFileNames { get; private set; }
+
+        public List<IReadOnlyList<string>> ReplacedBoardFileNamesHistory { get; } = [];
+
+        public int ReplaceBoardFileNamesCallCount { get; private set; }
+
+        public string? LastPreparationNameForDeletedBoardDirectory { get; private set; }
+
+        public string? LastSourceNameForDeletedBoardDirectory { get; private set; }
+
+        public string? LastDeletedBoardFolderName { get; private set; }
+
+        public int DeleteBoardDirectoryCallCount { get; private set; }
+
+        public Task<IReadOnlyList<string>> GetSourceFolderNamesAsync(
+            string preparationName,
+            string sourceType,
+            CancellationToken cancellationToken = default)
+        {
+            LastPreparationNameForSources = preparationName;
+            LastSourceType = sourceType;
+            return Task.FromResult(_sourceFolderNames);
+        }
+
+        public Task<IReadOnlyList<string>> GetBoardFileNamesAsync(
+            string preparationName,
+            string sourceName,
+            CancellationToken cancellationToken = default)
+        {
+            LastPreparationNameForBoardFiles = preparationName;
+            LastSourceNameForBoardFiles = sourceName;
+            return Task.FromResult(_boardFileNames);
+        }
+
+        public Task<Stream> OpenBoardArtifactReadAsync(
+            string preparationName,
+            string sourceName,
+            string boardFolderName,
+            string artifactFileName,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task ReplaceBoardFileNamesAsync(
+            string preparationName,
+            string sourceName,
+            IReadOnlyList<string> boardFileNames,
+            CancellationToken cancellationToken = default)
+        {
+            ReplaceBoardFileNamesCallCount++;
+            LastPreparationNameForManifestReplace = preparationName;
+            LastSourceNameForManifestReplace = sourceName;
+            ReplacedBoardFileNames = boardFileNames.ToArray();
+            ReplacedBoardFileNamesHistory.Add(boardFileNames.ToArray());
+
+            if (_replaceBoardFileNamesExceptionSequence.Count > 0)
+            {
+                var exception = _replaceBoardFileNamesExceptionSequence.Dequeue();
+                if (exception is not null)
+                {
+                    throw exception;
+                }
+            }
+            else if (_replaceBoardFileNamesException is not null)
+            {
+                throw _replaceBoardFileNamesException;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteBoardDirectoryAsync(
+            string preparationName,
+            string sourceName,
+            string boardFolderName,
+            CancellationToken cancellationToken = default)
+        {
+            DeleteBoardDirectoryCallCount++;
+            LastPreparationNameForDeletedBoardDirectory = preparationName;
+            LastSourceNameForDeletedBoardDirectory = sourceName;
+            LastDeletedBoardFolderName = boardFolderName;
+
+            if (_deleteBoardDirectoryException is not null)
+            {
+                throw _deleteBoardDirectoryException;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Backend/Sudoku/Application.Tests/DeleteDatasetPreparationBoardFileCommandValidatorTests.cs
+++ b/src/Backend/Sudoku/Application.Tests/DeleteDatasetPreparationBoardFileCommandValidatorTests.cs
@@ -1,0 +1,120 @@
+using Sudoku.Application.Datasets;
+
+namespace Application.Tests;
+
+public sealed class DeleteDatasetPreparationBoardFileCommandValidatorTests
+{
+    private readonly DeleteDatasetPreparationBoardFileCommandValidator _validator = new();
+
+    [Fact]
+    public void Validate_ReturnsNoErrors_ForValidRequest()
+    {
+        var result = _validator.Validate(new DeleteDatasetPreparationBoardFileCommand(
+            PreparationName: "preparation-001",
+            SourceName: "v1_training",
+            BoardFolderName: "Image1"));
+
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ReturnsInvalidPreparationName_WhenPreparationNameIsMissing(string? preparationName)
+    {
+        var result = _validator.Validate(new DeleteDatasetPreparationBoardFileCommand(
+            PreparationName: preparationName,
+            SourceName: "v1_training",
+            BoardFolderName: "Image1"));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(DeleteDatasetPreparationBoardFileErrorTypes.InvalidDatasetPreparationName, failure.ErrorCode);
+        Assert.Equal(nameof(DeleteDatasetPreparationBoardFileCommand.PreparationName), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData("../prep")]
+    [InlineData("prep/name")]
+    [InlineData("prep\\name")]
+    [InlineData("prep:name")]
+    public void Validate_ReturnsInvalidPreparationName_WhenPreparationNameContainsForbiddenCharacters(
+        string preparationName)
+    {
+        var result = _validator.Validate(new DeleteDatasetPreparationBoardFileCommand(
+            PreparationName: preparationName,
+            SourceName: "v1_training",
+            BoardFolderName: "Image1"));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(DeleteDatasetPreparationBoardFileErrorTypes.InvalidDatasetPreparationName, failure.ErrorCode);
+        Assert.Equal(nameof(DeleteDatasetPreparationBoardFileCommand.PreparationName), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ReturnsInvalidSourceName_WhenSourceNameIsMissing(string? sourceName)
+    {
+        var result = _validator.Validate(new DeleteDatasetPreparationBoardFileCommand(
+            PreparationName: "preparation-001",
+            SourceName: sourceName,
+            BoardFolderName: "Image1"));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(DeleteDatasetPreparationBoardFileErrorTypes.InvalidDatasetPreparationSourceName, failure.ErrorCode);
+        Assert.Equal(nameof(DeleteDatasetPreparationBoardFileCommand.SourceName), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData("../source")]
+    [InlineData("source/name")]
+    [InlineData("source\\name")]
+    [InlineData("source:name")]
+    public void Validate_ReturnsInvalidSourceName_WhenSourceNameContainsForbiddenCharacters(string sourceName)
+    {
+        var result = _validator.Validate(new DeleteDatasetPreparationBoardFileCommand(
+            PreparationName: "preparation-001",
+            SourceName: sourceName,
+            BoardFolderName: "Image1"));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(DeleteDatasetPreparationBoardFileErrorTypes.InvalidDatasetPreparationSourceName, failure.ErrorCode);
+        Assert.Equal(nameof(DeleteDatasetPreparationBoardFileCommand.SourceName), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ReturnsInvalidBoardFolderName_WhenBoardFolderNameIsMissing(string? boardFolderName)
+    {
+        var result = _validator.Validate(new DeleteDatasetPreparationBoardFileCommand(
+            PreparationName: "preparation-001",
+            SourceName: "v1_training",
+            BoardFolderName: boardFolderName));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(DeleteDatasetPreparationBoardFileErrorTypes.InvalidDatasetPreparationBoardFolderName, failure.ErrorCode);
+        Assert.Equal(nameof(DeleteDatasetPreparationBoardFileCommand.BoardFolderName), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData("../Image1")]
+    [InlineData("Image/1")]
+    [InlineData("Image\\1")]
+    [InlineData("Image:1")]
+    public void Validate_ReturnsInvalidBoardFolderName_WhenBoardFolderNameContainsForbiddenCharacters(
+        string boardFolderName)
+    {
+        var result = _validator.Validate(new DeleteDatasetPreparationBoardFileCommand(
+            PreparationName: "preparation-001",
+            SourceName: "v1_training",
+            BoardFolderName: boardFolderName));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(DeleteDatasetPreparationBoardFileErrorTypes.InvalidDatasetPreparationBoardFolderName, failure.ErrorCode);
+        Assert.Equal(nameof(DeleteDatasetPreparationBoardFileCommand.BoardFolderName), failure.PropertyName);
+    }
+}

--- a/src/Backend/Sudoku/Application.Tests/GetDatasetPreparationBoardFilesQueryHandlerTests.cs
+++ b/src/Backend/Sudoku/Application.Tests/GetDatasetPreparationBoardFilesQueryHandlerTests.cs
@@ -1,0 +1,255 @@
+using Sudoku.Application.Abstractions;
+using Sudoku.Application.Datasets;
+using Sudoku.Models.Datasets;
+
+namespace Application.Tests;
+
+public sealed class GetDatasetPreparationBoardFilesQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_ReturnsPaginatedBoardFiles_WhenPreparationIsCompletedAndSourceExists()
+    {
+        var metadata = CreateMetadata("preparation-001", DatasetPreparationStatus.Completed);
+        var artifactsGateway = new StubDatasetPreparationArtifactsGateway(
+            sourceFolderNames: ["v1_training", "v2_training"],
+            boardFileNames: ["Image1", "Image2", "Image3"]);
+        var handler = new GetDatasetPreparationBoardFilesQueryHandler(
+            new StubDatasetPreparationsGateway(metadata),
+            artifactsGateway);
+
+        var result = await handler.Handle(
+            new GetDatasetPreparationBoardFilesQuery("preparation-001", "v1_training", 2, 2),
+            CancellationToken.None);
+
+        Assert.Equal("preparation-001", result.PreparationName);
+        Assert.Equal("v1_training", result.SourceName);
+        Assert.Equal(2, result.Page);
+        Assert.Equal(2, result.PageSize);
+        Assert.Equal(3, result.TotalCount);
+        Assert.Collection(
+            result.Items,
+            item => Assert.Equal("Image3", item.BoardFolderName));
+        Assert.Equal("preparation-001", artifactsGateway.LastPreparationNameForSources);
+        Assert.Equal("board", artifactsGateway.LastSourceType);
+        Assert.Equal("preparation-001", artifactsGateway.LastPreparationNameForBoardFiles);
+        Assert.Equal("v1_training", artifactsGateway.LastSourceNameForBoardFiles);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsEmptyItems_WhenBoardManifestIsEmpty()
+    {
+        var handler = new GetDatasetPreparationBoardFilesQueryHandler(
+            new StubDatasetPreparationsGateway(CreateMetadata("preparation-001", DatasetPreparationStatus.Completed)),
+            new StubDatasetPreparationArtifactsGateway(
+                sourceFolderNames: ["v1_training"],
+                boardFileNames: []));
+
+        var result = await handler.Handle(
+            new GetDatasetPreparationBoardFilesQuery("preparation-001", "v1_training", 1, 50),
+            CancellationToken.None);
+
+        Assert.Empty(result.Items);
+        Assert.Equal(0, result.TotalCount);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsEmptyItems_WhenRequestedPageIsOutsideAvailableRange()
+    {
+        var handler = new GetDatasetPreparationBoardFilesQueryHandler(
+            new StubDatasetPreparationsGateway(CreateMetadata("preparation-001", DatasetPreparationStatus.Completed)),
+            new StubDatasetPreparationArtifactsGateway(
+                sourceFolderNames: ["v1_training"],
+                boardFileNames: ["Image1", "Image2"]));
+
+        var result = await handler.Handle(
+            new GetDatasetPreparationBoardFilesQuery("preparation-001", "v1_training", 3, 2),
+            CancellationToken.None);
+
+        Assert.Empty(result.Items);
+        Assert.Equal(2, result.TotalCount);
+    }
+
+    [Fact]
+    public async Task Handle_ThrowsNotFound_WhenPreparationDoesNotExist()
+    {
+        var handler = new GetDatasetPreparationBoardFilesQueryHandler(
+            new StubDatasetPreparationsGateway(metadata: null),
+            new StubDatasetPreparationArtifactsGateway(
+                sourceFolderNames: ["v1_training"],
+                boardFileNames: ["Image1"]));
+
+        await Assert.ThrowsAsync<DatasetPreparationNotFoundException>(() =>
+            handler.Handle(
+                new GetDatasetPreparationBoardFilesQuery("missing", "v1_training", 1, 50),
+                CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData(DatasetPreparationStatus.Queued)]
+    [InlineData(DatasetPreparationStatus.Running)]
+    [InlineData(DatasetPreparationStatus.Failed)]
+    public async Task Handle_ThrowsConflict_WhenPreparationArtifactsAreNotReady(string status)
+    {
+        var handler = new GetDatasetPreparationBoardFilesQueryHandler(
+            new StubDatasetPreparationsGateway(CreateMetadata("preparation-001", status)),
+            new StubDatasetPreparationArtifactsGateway(
+                sourceFolderNames: ["v1_training"],
+                boardFileNames: ["Image1"]));
+
+        var exception = await Assert.ThrowsAsync<DatasetPreparationArtifactsNotReadyException>(() =>
+            handler.Handle(
+                new GetDatasetPreparationBoardFilesQuery("preparation-001", "v1_training", 1, 50),
+                CancellationToken.None));
+
+        Assert.Equal("preparation-001", exception.PreparationName);
+        Assert.Equal(status, exception.Status);
+    }
+
+    [Fact]
+    public async Task Handle_ThrowsNotFound_WhenBoardSourceDoesNotExist()
+    {
+        var handler = new GetDatasetPreparationBoardFilesQueryHandler(
+            new StubDatasetPreparationsGateway(CreateMetadata("preparation-001", DatasetPreparationStatus.Completed)),
+            new StubDatasetPreparationArtifactsGateway(
+                sourceFolderNames: ["v2_training"],
+                boardFileNames: ["Image1"]));
+
+        var exception = await Assert.ThrowsAsync<DatasetPreparationSourceNotFoundException>(() =>
+            handler.Handle(
+                new GetDatasetPreparationBoardFilesQuery("preparation-001", "v1_training", 1, 50),
+                CancellationToken.None));
+
+        Assert.Equal("preparation-001", exception.PreparationName);
+        Assert.Equal("v1_training", exception.SourceName);
+    }
+
+    private static DatasetPreparationMetadataDto CreateMetadata(string preparationName, string status)
+    {
+        return new DatasetPreparationMetadataDto(
+            PreparationName: preparationName,
+            Status: status,
+            CreatedAtUtc: DateTimeOffset.Parse("2026-06-19T18:42:11Z"),
+            Sources:
+            [
+                new CreateDatasetPreparationSourceDto("v1_training", "board")
+            ],
+            SourceReports:
+            [
+                new DatasetPreparationSourceReportDto("v1_training", "board", 24, 0, 0)
+            ],
+            Warnings: []);
+    }
+
+    private sealed class StubDatasetPreparationsGateway : IDatasetPreparationsGateway
+    {
+        private readonly DatasetPreparationMetadataDto? _metadata;
+
+        public StubDatasetPreparationsGateway(DatasetPreparationMetadataDto? metadata)
+        {
+            _metadata = metadata;
+        }
+
+        public Task<IReadOnlyList<DatasetPreparationMetadataDto>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<DatasetPreparationMetadataDto?> GetByNameAsync(
+            string preparationName,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_metadata);
+        }
+
+        public Task<bool> TryCreateAsync(
+            DatasetPreparationMetadataDto metadata,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task UpdateAsync(
+            DatasetPreparationMetadataDto metadata,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task CleanupGeneratedContentAsync(
+            string preparationName,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class StubDatasetPreparationArtifactsGateway : IDatasetPreparationArtifactsGateway
+    {
+        private readonly IReadOnlyList<string> _sourceFolderNames;
+        private readonly IReadOnlyList<string> _boardFileNames;
+
+        public StubDatasetPreparationArtifactsGateway(
+            IReadOnlyList<string> sourceFolderNames,
+            IReadOnlyList<string> boardFileNames)
+        {
+            _sourceFolderNames = sourceFolderNames;
+            _boardFileNames = boardFileNames;
+        }
+
+        public string? LastPreparationNameForSources { get; private set; }
+
+        public string? LastSourceType { get; private set; }
+
+        public string? LastPreparationNameForBoardFiles { get; private set; }
+
+        public string? LastSourceNameForBoardFiles { get; private set; }
+
+        public Task<IReadOnlyList<string>> GetSourceFolderNamesAsync(
+            string preparationName,
+            string sourceType,
+            CancellationToken cancellationToken = default)
+        {
+            LastPreparationNameForSources = preparationName;
+            LastSourceType = sourceType;
+            return Task.FromResult(_sourceFolderNames);
+        }
+
+        public Task<IReadOnlyList<string>> GetBoardFileNamesAsync(
+            string preparationName,
+            string sourceName,
+            CancellationToken cancellationToken = default)
+        {
+            LastPreparationNameForBoardFiles = preparationName;
+            LastSourceNameForBoardFiles = sourceName;
+            return Task.FromResult(_boardFileNames);
+        }
+
+        public Task<Stream> OpenBoardArtifactReadAsync(
+            string preparationName,
+            string sourceName,
+            string boardFolderName,
+            string artifactFileName,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task ReplaceBoardFileNamesAsync(
+            string preparationName,
+            string sourceName,
+            IReadOnlyList<string> boardFileNames,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task DeleteBoardDirectoryAsync(
+            string preparationName,
+            string sourceName,
+            string boardFolderName,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Backend/Sudoku/Application.Tests/GetDatasetPreparationBoardFilesQueryValidatorTests.cs
+++ b/src/Backend/Sudoku/Application.Tests/GetDatasetPreparationBoardFilesQueryValidatorTests.cs
@@ -1,0 +1,127 @@
+using Sudoku.Application.Datasets;
+
+namespace Application.Tests;
+
+public sealed class GetDatasetPreparationBoardFilesQueryValidatorTests
+{
+    private readonly GetDatasetPreparationBoardFilesQueryValidator _validator = new();
+
+    [Fact]
+    public void Validate_ReturnsNoErrors_ForValidRequest()
+    {
+        var result = _validator.Validate(new GetDatasetPreparationBoardFilesQuery(
+            PreparationName: "preparation-001",
+            SourceName: "v1_training",
+            Page: 1,
+            PageSize: 50));
+
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ReturnsInvalidPreparationName_WhenPreparationNameIsMissing(string? preparationName)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationBoardFilesQuery(
+            PreparationName: preparationName,
+            SourceName: "v1_training",
+            Page: 1,
+            PageSize: 50));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(GetDatasetPreparationBoardFilesErrorTypes.InvalidDatasetPreparationName, failure.ErrorCode);
+        Assert.Equal(nameof(GetDatasetPreparationBoardFilesQuery.PreparationName), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData("../prep")]
+    [InlineData("prep/name")]
+    [InlineData("prep\\name")]
+    [InlineData("prep:name")]
+    public void Validate_ReturnsInvalidPreparationName_WhenPreparationNameContainsForbiddenCharacters(
+        string preparationName)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationBoardFilesQuery(
+            PreparationName: preparationName,
+            SourceName: "v1_training",
+            Page: 1,
+            PageSize: 50));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(GetDatasetPreparationBoardFilesErrorTypes.InvalidDatasetPreparationName, failure.ErrorCode);
+        Assert.Equal(nameof(GetDatasetPreparationBoardFilesQuery.PreparationName), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ReturnsInvalidSourceName_WhenSourceNameIsMissing(string? sourceName)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationBoardFilesQuery(
+            PreparationName: "preparation-001",
+            SourceName: sourceName,
+            Page: 1,
+            PageSize: 50));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(GetDatasetPreparationBoardFilesErrorTypes.InvalidDatasetPreparationSourceName, failure.ErrorCode);
+        Assert.Equal(nameof(GetDatasetPreparationBoardFilesQuery.SourceName), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData("../source")]
+    [InlineData("source/name")]
+    [InlineData("source\\name")]
+    [InlineData("source:name")]
+    public void Validate_ReturnsInvalidSourceName_WhenSourceNameContainsForbiddenCharacters(
+        string sourceName)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationBoardFilesQuery(
+            PreparationName: "preparation-001",
+            SourceName: sourceName,
+            Page: 1,
+            PageSize: 50));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(GetDatasetPreparationBoardFilesErrorTypes.InvalidDatasetPreparationSourceName, failure.ErrorCode);
+        Assert.Equal(nameof(GetDatasetPreparationBoardFilesQuery.SourceName), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_ReturnsInvalidPage_WhenPageIsMissingOrLessThanOne(int? page)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationBoardFilesQuery(
+            PreparationName: "preparation-001",
+            SourceName: "v1_training",
+            Page: page,
+            PageSize: 50));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(GetDatasetPreparationBoardFilesErrorTypes.InvalidDatasetPreparationBoardFilesPage, failure.ErrorCode);
+        Assert.Equal(nameof(GetDatasetPreparationBoardFilesQuery.Page), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(201)]
+    public void Validate_ReturnsInvalidPageSize_WhenPageSizeIsOutsideAllowedRange(int? pageSize)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationBoardFilesQuery(
+            PreparationName: "preparation-001",
+            SourceName: "v1_training",
+            Page: 1,
+            PageSize: pageSize));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(GetDatasetPreparationBoardFilesErrorTypes.InvalidDatasetPreparationBoardFilesPageSize, failure.ErrorCode);
+        Assert.Equal(nameof(GetDatasetPreparationBoardFilesQuery.PageSize), failure.PropertyName);
+    }
+}

--- a/src/Backend/Sudoku/Application.Tests/GetDatasetPreparationBoardImageQueryHandlerTests.cs
+++ b/src/Backend/Sudoku/Application.Tests/GetDatasetPreparationBoardImageQueryHandlerTests.cs
@@ -1,0 +1,285 @@
+using Sudoku.Application.Abstractions;
+using Sudoku.Application.Datasets;
+using Sudoku.Application.Storage;
+using Sudoku.Models.Datasets;
+
+namespace Application.Tests;
+
+public sealed class GetDatasetPreparationBoardImageQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_ReturnsImageAsBase64_WhenPreparationIsCompletedAndBoardExists()
+    {
+        var metadata = CreateMetadata("preparation-001", DatasetPreparationStatus.Completed);
+        var artifactsGateway = new StubDatasetPreparationArtifactsGateway(
+            sourceFolderNames: ["v1_training"],
+            boardFileNames: ["Image1"],
+            artifactBytes: [0x01, 0x02, 0x03, 0x04]);
+        var handler = new GetDatasetPreparationBoardImageQueryHandler(
+            new StubDatasetPreparationsGateway(metadata),
+            artifactsGateway);
+
+        var result = await handler.Handle(
+            new GetDatasetPreparationBoardImageQuery("preparation-001", "v1_training", "Image1"),
+            CancellationToken.None);
+
+        Assert.Equal("image/png", result.MimeType);
+        Assert.Equal(Convert.ToBase64String([0x01, 0x02, 0x03, 0x04]), result.Base64);
+        Assert.Equal("preparation-001", artifactsGateway.LastPreparationNameForSources);
+        Assert.Equal("board", artifactsGateway.LastSourceType);
+        Assert.Equal("preparation-001", artifactsGateway.LastPreparationNameForBoardFiles);
+        Assert.Equal("v1_training", artifactsGateway.LastSourceNameForBoardFiles);
+        Assert.Equal("preparation-001", artifactsGateway.LastPreparationNameForArtifact);
+        Assert.Equal("v1_training", artifactsGateway.LastSourceNameForArtifact);
+        Assert.Equal("Image1", artifactsGateway.LastBoardFolderNameForArtifact);
+        Assert.Equal(DatasetPreparationBoardArtifactNames.CorrectedBoardFileName, artifactsGateway.LastArtifactFileName);
+    }
+
+    [Fact]
+    public async Task Handle_ThrowsNotFound_WhenPreparationDoesNotExist()
+    {
+        var handler = new GetDatasetPreparationBoardImageQueryHandler(
+            new StubDatasetPreparationsGateway(metadata: null),
+            new StubDatasetPreparationArtifactsGateway(
+                sourceFolderNames: ["v1_training"],
+                boardFileNames: ["Image1"],
+                artifactBytes: [0x01]));
+
+        await Assert.ThrowsAsync<DatasetPreparationNotFoundException>(() =>
+            handler.Handle(
+                new GetDatasetPreparationBoardImageQuery("missing", "v1_training", "Image1"),
+                CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData(DatasetPreparationStatus.Queued)]
+    [InlineData(DatasetPreparationStatus.Running)]
+    [InlineData(DatasetPreparationStatus.Failed)]
+    public async Task Handle_ThrowsConflict_WhenPreparationArtifactsAreNotReady(string status)
+    {
+        var handler = new GetDatasetPreparationBoardImageQueryHandler(
+            new StubDatasetPreparationsGateway(CreateMetadata("preparation-001", status)),
+            new StubDatasetPreparationArtifactsGateway(
+                sourceFolderNames: ["v1_training"],
+                boardFileNames: ["Image1"],
+                artifactBytes: [0x01]));
+
+        var exception = await Assert.ThrowsAsync<DatasetPreparationArtifactsNotReadyException>(() =>
+            handler.Handle(
+                new GetDatasetPreparationBoardImageQuery("preparation-001", "v1_training", "Image1"),
+                CancellationToken.None));
+
+        Assert.Equal("preparation-001", exception.PreparationName);
+        Assert.Equal(status, exception.Status);
+    }
+
+    [Fact]
+    public async Task Handle_ThrowsNotFound_WhenBoardSourceDoesNotExist()
+    {
+        var handler = new GetDatasetPreparationBoardImageQueryHandler(
+            new StubDatasetPreparationsGateway(CreateMetadata("preparation-001", DatasetPreparationStatus.Completed)),
+            new StubDatasetPreparationArtifactsGateway(
+                sourceFolderNames: ["v2_training"],
+                boardFileNames: ["Image1"],
+                artifactBytes: [0x01]));
+
+        var exception = await Assert.ThrowsAsync<DatasetPreparationSourceNotFoundException>(() =>
+            handler.Handle(
+                new GetDatasetPreparationBoardImageQuery("preparation-001", "v1_training", "Image1"),
+                CancellationToken.None));
+
+        Assert.Equal("preparation-001", exception.PreparationName);
+        Assert.Equal("v1_training", exception.SourceName);
+    }
+
+    [Fact]
+    public async Task Handle_ThrowsNotFound_WhenBoardFolderDoesNotExistInManifest()
+    {
+        var handler = new GetDatasetPreparationBoardImageQueryHandler(
+            new StubDatasetPreparationsGateway(CreateMetadata("preparation-001", DatasetPreparationStatus.Completed)),
+            new StubDatasetPreparationArtifactsGateway(
+                sourceFolderNames: ["v1_training"],
+                boardFileNames: ["Image2"],
+                artifactBytes: [0x01]));
+
+        var exception = await Assert.ThrowsAsync<DatasetPreparationBoardFileNotFoundException>(() =>
+            handler.Handle(
+                new GetDatasetPreparationBoardImageQuery("preparation-001", "v1_training", "Image1"),
+                CancellationToken.None));
+
+        Assert.Equal("preparation-001", exception.PreparationName);
+        Assert.Equal("v1_training", exception.SourceName);
+        Assert.Equal("Image1", exception.BoardFolderName);
+    }
+
+    [Fact]
+    public async Task Handle_PropagatesTechnicalFailure_WhenArtifactIsMissingForManifestEntry()
+    {
+        var handler = new GetDatasetPreparationBoardImageQueryHandler(
+            new StubDatasetPreparationsGateway(CreateMetadata("preparation-001", DatasetPreparationStatus.Completed)),
+            new StubDatasetPreparationArtifactsGateway(
+                sourceFolderNames: ["v1_training"],
+                boardFileNames: ["Image1"],
+                artifactOpenException: new FileStorageItemNotFoundException("Wskazany plik nie istnieje.")));
+
+        await Assert.ThrowsAsync<FileStorageItemNotFoundException>(() =>
+            handler.Handle(
+                new GetDatasetPreparationBoardImageQuery("preparation-001", "v1_training", "Image1"),
+                CancellationToken.None));
+    }
+
+    private static DatasetPreparationMetadataDto CreateMetadata(string preparationName, string status)
+    {
+        return new DatasetPreparationMetadataDto(
+            PreparationName: preparationName,
+            Status: status,
+            CreatedAtUtc: DateTimeOffset.Parse("2026-06-19T18:42:11Z"),
+            Sources:
+            [
+                new CreateDatasetPreparationSourceDto("v1_training", "board")
+            ],
+            SourceReports:
+            [
+                new DatasetPreparationSourceReportDto("v1_training", "board", 24, 0, 0)
+            ],
+            Warnings: []);
+    }
+
+    private sealed class StubDatasetPreparationsGateway : IDatasetPreparationsGateway
+    {
+        private readonly DatasetPreparationMetadataDto? _metadata;
+
+        public StubDatasetPreparationsGateway(DatasetPreparationMetadataDto? metadata)
+        {
+            _metadata = metadata;
+        }
+
+        public Task<IReadOnlyList<DatasetPreparationMetadataDto>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<DatasetPreparationMetadataDto?> GetByNameAsync(
+            string preparationName,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_metadata);
+        }
+
+        public Task<bool> TryCreateAsync(
+            DatasetPreparationMetadataDto metadata,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task UpdateAsync(
+            DatasetPreparationMetadataDto metadata,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task CleanupGeneratedContentAsync(
+            string preparationName,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class StubDatasetPreparationArtifactsGateway : IDatasetPreparationArtifactsGateway
+    {
+        private readonly IReadOnlyList<string> _sourceFolderNames;
+        private readonly IReadOnlyList<string> _boardFileNames;
+        private readonly byte[]? _artifactBytes;
+        private readonly Exception? _artifactOpenException;
+
+        public StubDatasetPreparationArtifactsGateway(
+            IReadOnlyList<string> sourceFolderNames,
+            IReadOnlyList<string> boardFileNames,
+            byte[]? artifactBytes = null,
+            Exception? artifactOpenException = null)
+        {
+            _sourceFolderNames = sourceFolderNames;
+            _boardFileNames = boardFileNames;
+            _artifactBytes = artifactBytes;
+            _artifactOpenException = artifactOpenException;
+        }
+
+        public string? LastPreparationNameForSources { get; private set; }
+
+        public string? LastSourceType { get; private set; }
+
+        public string? LastPreparationNameForBoardFiles { get; private set; }
+
+        public string? LastSourceNameForBoardFiles { get; private set; }
+
+        public string? LastPreparationNameForArtifact { get; private set; }
+
+        public string? LastSourceNameForArtifact { get; private set; }
+
+        public string? LastBoardFolderNameForArtifact { get; private set; }
+
+        public string? LastArtifactFileName { get; private set; }
+
+        public Task<IReadOnlyList<string>> GetSourceFolderNamesAsync(
+            string preparationName,
+            string sourceType,
+            CancellationToken cancellationToken = default)
+        {
+            LastPreparationNameForSources = preparationName;
+            LastSourceType = sourceType;
+            return Task.FromResult(_sourceFolderNames);
+        }
+
+        public Task<IReadOnlyList<string>> GetBoardFileNamesAsync(
+            string preparationName,
+            string sourceName,
+            CancellationToken cancellationToken = default)
+        {
+            LastPreparationNameForBoardFiles = preparationName;
+            LastSourceNameForBoardFiles = sourceName;
+            return Task.FromResult(_boardFileNames);
+        }
+
+        public Task<Stream> OpenBoardArtifactReadAsync(
+            string preparationName,
+            string sourceName,
+            string boardFolderName,
+            string artifactFileName,
+            CancellationToken cancellationToken = default)
+        {
+            LastPreparationNameForArtifact = preparationName;
+            LastSourceNameForArtifact = sourceName;
+            LastBoardFolderNameForArtifact = boardFolderName;
+            LastArtifactFileName = artifactFileName;
+
+            if (_artifactOpenException is not null)
+            {
+                throw _artifactOpenException;
+            }
+
+            Stream stream = new MemoryStream(_artifactBytes ?? []);
+            return Task.FromResult(stream);
+        }
+
+        public Task ReplaceBoardFileNamesAsync(
+            string preparationName,
+            string sourceName,
+            IReadOnlyList<string> boardFileNames,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task DeleteBoardDirectoryAsync(
+            string preparationName,
+            string sourceName,
+            string boardFolderName,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Backend/Sudoku/Application.Tests/GetDatasetPreparationBoardImageQueryValidatorTests.cs
+++ b/src/Backend/Sudoku/Application.Tests/GetDatasetPreparationBoardImageQueryValidatorTests.cs
@@ -1,0 +1,121 @@
+using Sudoku.Application.Datasets;
+
+namespace Application.Tests;
+
+public sealed class GetDatasetPreparationBoardImageQueryValidatorTests
+{
+    private readonly GetDatasetPreparationBoardImageQueryValidator _validator = new();
+
+    [Fact]
+    public void Validate_ReturnsNoErrors_ForValidRequest()
+    {
+        var result = _validator.Validate(new GetDatasetPreparationBoardImageQuery(
+            PreparationName: "preparation-001",
+            SourceName: "v1_training",
+            BoardFolderName: "Image1"));
+
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ReturnsInvalidPreparationName_WhenPreparationNameIsMissing(string? preparationName)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationBoardImageQuery(
+            PreparationName: preparationName,
+            SourceName: "v1_training",
+            BoardFolderName: "Image1"));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(GetDatasetPreparationBoardImageErrorTypes.InvalidDatasetPreparationName, failure.ErrorCode);
+        Assert.Equal(nameof(GetDatasetPreparationBoardImageQuery.PreparationName), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData("../prep")]
+    [InlineData("prep/name")]
+    [InlineData("prep\\name")]
+    [InlineData("prep:name")]
+    public void Validate_ReturnsInvalidPreparationName_WhenPreparationNameContainsForbiddenCharacters(
+        string preparationName)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationBoardImageQuery(
+            PreparationName: preparationName,
+            SourceName: "v1_training",
+            BoardFolderName: "Image1"));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(GetDatasetPreparationBoardImageErrorTypes.InvalidDatasetPreparationName, failure.ErrorCode);
+        Assert.Equal(nameof(GetDatasetPreparationBoardImageQuery.PreparationName), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ReturnsInvalidSourceName_WhenSourceNameIsMissing(string? sourceName)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationBoardImageQuery(
+            PreparationName: "preparation-001",
+            SourceName: sourceName,
+            BoardFolderName: "Image1"));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(GetDatasetPreparationBoardImageErrorTypes.InvalidDatasetPreparationSourceName, failure.ErrorCode);
+        Assert.Equal(nameof(GetDatasetPreparationBoardImageQuery.SourceName), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData("../source")]
+    [InlineData("source/name")]
+    [InlineData("source\\name")]
+    [InlineData("source:name")]
+    public void Validate_ReturnsInvalidSourceName_WhenSourceNameContainsForbiddenCharacters(
+        string sourceName)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationBoardImageQuery(
+            PreparationName: "preparation-001",
+            SourceName: sourceName,
+            BoardFolderName: "Image1"));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(GetDatasetPreparationBoardImageErrorTypes.InvalidDatasetPreparationSourceName, failure.ErrorCode);
+        Assert.Equal(nameof(GetDatasetPreparationBoardImageQuery.SourceName), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ReturnsInvalidBoardFolderName_WhenBoardFolderNameIsMissing(string? boardFolderName)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationBoardImageQuery(
+            PreparationName: "preparation-001",
+            SourceName: "v1_training",
+            BoardFolderName: boardFolderName));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(GetDatasetPreparationBoardImageErrorTypes.InvalidDatasetPreparationBoardFolderName, failure.ErrorCode);
+        Assert.Equal(nameof(GetDatasetPreparationBoardImageQuery.BoardFolderName), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData("../Image1")]
+    [InlineData("Image/1")]
+    [InlineData("Image\\1")]
+    [InlineData("Image:1")]
+    public void Validate_ReturnsInvalidBoardFolderName_WhenBoardFolderNameContainsForbiddenCharacters(
+        string boardFolderName)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationBoardImageQuery(
+            PreparationName: "preparation-001",
+            SourceName: "v1_training",
+            BoardFolderName: boardFolderName));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(GetDatasetPreparationBoardImageErrorTypes.InvalidDatasetPreparationBoardFolderName, failure.ErrorCode);
+        Assert.Equal(nameof(GetDatasetPreparationBoardImageQuery.BoardFolderName), failure.PropertyName);
+    }
+}

--- a/src/Backend/Sudoku/Application.Tests/GetDatasetPreparationFoldersQueryHandlerTests.cs
+++ b/src/Backend/Sudoku/Application.Tests/GetDatasetPreparationFoldersQueryHandlerTests.cs
@@ -1,0 +1,213 @@
+using Sudoku.Application.Abstractions;
+using Sudoku.Application.Datasets;
+using Sudoku.Models.Datasets;
+
+namespace Application.Tests;
+
+public sealed class GetDatasetPreparationFoldersQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_ReturnsFoldersFromManifest_WhenPreparationIsCompleted()
+    {
+        var metadata = CreateMetadata("preparation-001", DatasetPreparationStatus.Completed);
+        var artifactsGateway = new StubDatasetPreparationArtifactsGateway(["v2_training", "v1_training"]);
+        var handler = new GetDatasetPreparationFoldersQueryHandler(
+            new StubDatasetPreparationsGateway(metadata),
+            artifactsGateway);
+
+        var result = await handler.Handle(
+            new GetDatasetPreparationFoldersQuery("preparation-001", "board"),
+            CancellationToken.None);
+
+        Assert.Equal("preparation-001", result.PreparationName);
+        Assert.Equal("board", result.Type);
+        Assert.Equal(2, result.TotalCount);
+        Assert.Equal(["v2_training", "v1_training"], result.Items);
+        Assert.Equal("preparation-001", artifactsGateway.LastPreparationName);
+        Assert.Equal("board", artifactsGateway.LastSourceType);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsEmptyItems_WhenManifestIsEmpty()
+    {
+        var handler = new GetDatasetPreparationFoldersQueryHandler(
+            new StubDatasetPreparationsGateway(CreateMetadata("preparation-001", DatasetPreparationStatus.Completed)),
+            new StubDatasetPreparationArtifactsGateway([]));
+
+        var result = await handler.Handle(
+            new GetDatasetPreparationFoldersQuery("preparation-001", "board"),
+            CancellationToken.None);
+
+        Assert.Empty(result.Items);
+        Assert.Equal(0, result.TotalCount);
+    }
+
+    [Fact]
+    public async Task Handle_PassesDigitTypeToArtifactsGateway_WhenDigitFoldersAreRequested()
+    {
+        var metadata = CreateMetadata("preparation-001", DatasetPreparationStatus.Completed);
+        var artifactsGateway = new StubDatasetPreparationArtifactsGateway(["mnist_train", "mnist_test"]);
+        var handler = new GetDatasetPreparationFoldersQueryHandler(
+            new StubDatasetPreparationsGateway(metadata),
+            artifactsGateway);
+
+        var result = await handler.Handle(
+            new GetDatasetPreparationFoldersQuery("preparation-001", "digit"),
+            CancellationToken.None);
+
+        Assert.Equal("preparation-001", result.PreparationName);
+        Assert.Equal("digit", result.Type);
+        Assert.Equal(2, result.TotalCount);
+        Assert.Equal(["mnist_train", "mnist_test"], result.Items);
+        Assert.Equal("preparation-001", artifactsGateway.LastPreparationName);
+        Assert.Equal("digit", artifactsGateway.LastSourceType);
+    }
+
+    [Fact]
+    public async Task Handle_ThrowsNotFound_WhenPreparationDoesNotExist()
+    {
+        var handler = new GetDatasetPreparationFoldersQueryHandler(
+            new StubDatasetPreparationsGateway(metadata: null),
+            new StubDatasetPreparationArtifactsGateway(["v1_training"]));
+
+        await Assert.ThrowsAsync<DatasetPreparationNotFoundException>(() =>
+            handler.Handle(new GetDatasetPreparationFoldersQuery("missing", "board"), CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData(DatasetPreparationStatus.Queued)]
+    [InlineData(DatasetPreparationStatus.Running)]
+    [InlineData(DatasetPreparationStatus.Failed)]
+    public async Task Handle_ThrowsConflict_WhenPreparationArtifactsAreNotReady(string status)
+    {
+        var handler = new GetDatasetPreparationFoldersQueryHandler(
+            new StubDatasetPreparationsGateway(CreateMetadata("preparation-001", status)),
+            new StubDatasetPreparationArtifactsGateway(["v1_training"]));
+
+        var exception = await Assert.ThrowsAsync<DatasetPreparationArtifactsNotReadyException>(() =>
+            handler.Handle(new GetDatasetPreparationFoldersQuery("preparation-001", "board"), CancellationToken.None));
+
+        Assert.Equal("preparation-001", exception.PreparationName);
+        Assert.Equal(status, exception.Status);
+    }
+
+    private static DatasetPreparationMetadataDto CreateMetadata(string preparationName, string status)
+    {
+        return new DatasetPreparationMetadataDto(
+            PreparationName: preparationName,
+            Status: status,
+            CreatedAtUtc: DateTimeOffset.Parse("2026-06-19T18:42:11Z"),
+            Sources:
+            [
+                new CreateDatasetPreparationSourceDto("v1_training", "board")
+            ],
+            SourceReports:
+            [
+                new DatasetPreparationSourceReportDto("v1_training", "board", 24, 0, 0)
+            ],
+            Warnings: []);
+    }
+
+    private sealed class StubDatasetPreparationsGateway : IDatasetPreparationsGateway
+    {
+        private readonly DatasetPreparationMetadataDto? _metadata;
+
+        public StubDatasetPreparationsGateway(DatasetPreparationMetadataDto? metadata)
+        {
+            _metadata = metadata;
+        }
+
+        public Task<IReadOnlyList<DatasetPreparationMetadataDto>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<DatasetPreparationMetadataDto?> GetByNameAsync(
+            string preparationName,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_metadata);
+        }
+
+        public Task<bool> TryCreateAsync(
+            DatasetPreparationMetadataDto metadata,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task UpdateAsync(
+            DatasetPreparationMetadataDto metadata,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task CleanupGeneratedContentAsync(
+            string preparationName,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class StubDatasetPreparationArtifactsGateway : IDatasetPreparationArtifactsGateway
+    {
+        private readonly IReadOnlyList<string> _items;
+
+        public StubDatasetPreparationArtifactsGateway(IReadOnlyList<string> items)
+        {
+            _items = items;
+        }
+
+        public string? LastPreparationName { get; private set; }
+
+        public string? LastSourceType { get; private set; }
+
+        public Task<IReadOnlyList<string>> GetSourceFolderNamesAsync(
+            string preparationName,
+            string sourceType,
+            CancellationToken cancellationToken = default)
+        {
+            LastPreparationName = preparationName;
+            LastSourceType = sourceType;
+            return Task.FromResult(_items);
+        }
+
+        public Task<IReadOnlyList<string>> GetBoardFileNamesAsync(
+            string preparationName,
+            string sourceName,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<Stream> OpenBoardArtifactReadAsync(
+            string preparationName,
+            string sourceName,
+            string boardFolderName,
+            string artifactFileName,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task ReplaceBoardFileNamesAsync(
+            string preparationName,
+            string sourceName,
+            IReadOnlyList<string> boardFileNames,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task DeleteBoardDirectoryAsync(
+            string preparationName,
+            string sourceName,
+            string boardFolderName,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Backend/Sudoku/Application.Tests/GetDatasetPreparationFoldersQueryValidatorTests.cs
+++ b/src/Backend/Sudoku/Application.Tests/GetDatasetPreparationFoldersQueryValidatorTests.cs
@@ -1,0 +1,71 @@
+using Sudoku.Application.Datasets;
+
+namespace Application.Tests;
+
+public sealed class GetDatasetPreparationFoldersQueryValidatorTests
+{
+    private readonly GetDatasetPreparationFoldersQueryValidator _validator = new();
+
+    [Theory]
+    [InlineData("board")]
+    [InlineData("digit")]
+    public void Validate_ReturnsNoErrors_ForSupportedType(string type)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationFoldersQuery("preparation-001", type));
+
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ReturnsInvalidPreparationName_WhenPreparationNameIsMissing(string? preparationName)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationFoldersQuery(preparationName, "board"));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(GetDatasetPreparationFoldersErrorTypes.InvalidDatasetPreparationName, failure.ErrorCode);
+        Assert.Equal(nameof(GetDatasetPreparationFoldersQuery.PreparationName), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData("../prep")]
+    [InlineData("prep/name")]
+    [InlineData("prep\\name")]
+    [InlineData("prep:name")]
+    public void Validate_ReturnsInvalidPreparationName_WhenPreparationNameContainsForbiddenCharacters(
+        string preparationName)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationFoldersQuery(preparationName, "board"));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(GetDatasetPreparationFoldersErrorTypes.InvalidDatasetPreparationName, failure.ErrorCode);
+        Assert.Equal(nameof(GetDatasetPreparationFoldersQuery.PreparationName), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ReturnsInvalidType_WhenTypeIsMissing(string? type)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationFoldersQuery("preparation-001", type));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(GetDatasetPreparationFoldersErrorTypes.InvalidDatasetPreparationType, failure.ErrorCode);
+        Assert.Equal(nameof(GetDatasetPreparationFoldersQuery.Type), failure.PropertyName);
+    }
+
+    [Theory]
+    [InlineData("cells")]
+    [InlineData("raw")]
+    public void Validate_ReturnsInvalidType_WhenTypeIsUnsupported(string type)
+    {
+        var result = _validator.Validate(new GetDatasetPreparationFoldersQuery("preparation-001", type));
+
+        var failure = Assert.Single(result.Errors);
+        Assert.Equal(GetDatasetPreparationFoldersErrorTypes.InvalidDatasetPreparationType, failure.ErrorCode);
+        Assert.Equal(nameof(GetDatasetPreparationFoldersQuery.Type), failure.PropertyName);
+    }
+}

--- a/src/Backend/Sudoku/Application/Abstractions/IDatasetPreparationArtifactsGateway.cs
+++ b/src/Backend/Sudoku/Application/Abstractions/IDatasetPreparationArtifactsGateway.cs
@@ -1,0 +1,33 @@
+namespace Sudoku.Application.Abstractions;
+
+public interface IDatasetPreparationArtifactsGateway
+{
+    Task<IReadOnlyList<string>> GetSourceFolderNamesAsync(
+        string preparationName,
+        string sourceType,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<string>> GetBoardFileNamesAsync(
+        string preparationName,
+        string sourceName,
+        CancellationToken cancellationToken = default);
+
+    Task<Stream> OpenBoardArtifactReadAsync(
+        string preparationName,
+        string sourceName,
+        string boardFolderName,
+        string artifactFileName,
+        CancellationToken cancellationToken = default);
+
+    Task ReplaceBoardFileNamesAsync(
+        string preparationName,
+        string sourceName,
+        IReadOnlyList<string> boardFileNames,
+        CancellationToken cancellationToken = default);
+
+    Task DeleteBoardDirectoryAsync(
+        string preparationName,
+        string sourceName,
+        string boardFolderName,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Backend/Sudoku/Application/Datasets/DatasetPreparationArtifactsNotReadyException.cs
+++ b/src/Backend/Sudoku/Application/Datasets/DatasetPreparationArtifactsNotReadyException.cs
@@ -1,0 +1,16 @@
+namespace Sudoku.Application.Datasets;
+
+public sealed class DatasetPreparationArtifactsNotReadyException : Exception
+{
+    public DatasetPreparationArtifactsNotReadyException(string preparationName, string status)
+        : base(
+            $"Przygotowanie datasetu '{preparationName}' ma status '{status}' i nie jest gotowe do odczytu artefaktów.")
+    {
+        PreparationName = preparationName;
+        Status = status;
+    }
+
+    public string PreparationName { get; }
+
+    public string Status { get; }
+}

--- a/src/Backend/Sudoku/Application/Datasets/DatasetPreparationBoardArtifactNames.cs
+++ b/src/Backend/Sudoku/Application/Datasets/DatasetPreparationBoardArtifactNames.cs
@@ -1,0 +1,6 @@
+namespace Sudoku.Application.Datasets;
+
+public static class DatasetPreparationBoardArtifactNames
+{
+    public const string CorrectedBoardFileName = "corrected-board.png";
+}

--- a/src/Backend/Sudoku/Application/Datasets/DatasetPreparationBoardFileListItemDto.cs
+++ b/src/Backend/Sudoku/Application/Datasets/DatasetPreparationBoardFileListItemDto.cs
@@ -1,0 +1,3 @@
+namespace Sudoku.Application.Datasets;
+
+public sealed record DatasetPreparationBoardFileListItemDto(string BoardFolderName);

--- a/src/Backend/Sudoku/Application/Datasets/DatasetPreparationBoardFileNotFoundException.cs
+++ b/src/Backend/Sudoku/Application/Datasets/DatasetPreparationBoardFileNotFoundException.cs
@@ -1,0 +1,22 @@
+namespace Sudoku.Application.Datasets;
+
+public sealed class DatasetPreparationBoardFileNotFoundException : Exception
+{
+    public DatasetPreparationBoardFileNotFoundException(
+        string preparationName,
+        string sourceName,
+        string boardFolderName)
+        : base(
+            $"Nie znaleziono planszy '{boardFolderName}' w źródle '{sourceName}' przygotowania datasetu '{preparationName}'.")
+    {
+        PreparationName = preparationName;
+        SourceName = sourceName;
+        BoardFolderName = boardFolderName;
+    }
+
+    public string PreparationName { get; }
+
+    public string SourceName { get; }
+
+    public string BoardFolderName { get; }
+}

--- a/src/Backend/Sudoku/Application/Datasets/DatasetPreparationBoardFolderNameValidationRules.cs
+++ b/src/Backend/Sudoku/Application/Datasets/DatasetPreparationBoardFolderNameValidationRules.cs
@@ -1,0 +1,52 @@
+using FluentValidation;
+using FluentValidation.Results;
+
+namespace Sudoku.Application.Datasets;
+
+public static class DatasetPreparationBoardFolderNameValidationRules
+{
+    private const int MaxBoardFolderNameLength = 160;
+
+    public static void Validate<T>(
+        string? boardFolderName,
+        ValidationContext<T> context,
+        string propertyName,
+        string errorCode)
+    {
+        if (string.IsNullOrWhiteSpace(boardFolderName))
+        {
+            context.AddFailure(CreateFailure(propertyName, errorCode, "Pole 'boardFolderName' jest wymagane."));
+            return;
+        }
+
+        var trimmedBoardFolderName = boardFolderName.Trim();
+        if (trimmedBoardFolderName.Length > MaxBoardFolderNameLength)
+        {
+            context.AddFailure(CreateFailure(
+                propertyName,
+                errorCode,
+                $"Pole 'boardFolderName' nie może być dłuższe niż {MaxBoardFolderNameLength} znaków."));
+        }
+
+        if (trimmedBoardFolderName.Contains("..", StringComparison.Ordinal)
+            || trimmedBoardFolderName.Contains('/', StringComparison.Ordinal)
+            || trimmedBoardFolderName.Contains('\\', StringComparison.Ordinal)
+            || trimmedBoardFolderName.Contains(':', StringComparison.Ordinal)
+            || trimmedBoardFolderName.Any(char.IsControl)
+            || trimmedBoardFolderName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            context.AddFailure(CreateFailure(
+                propertyName,
+                errorCode,
+                "Pole 'boardFolderName' zawiera niedozwolone znaki."));
+        }
+    }
+
+    private static ValidationFailure CreateFailure(string propertyName, string errorCode, string message)
+    {
+        return new ValidationFailure(propertyName, message)
+        {
+            ErrorCode = errorCode
+        };
+    }
+}

--- a/src/Backend/Sudoku/Application/Datasets/DatasetPreparationNameValidationRules.cs
+++ b/src/Backend/Sudoku/Application/Datasets/DatasetPreparationNameValidationRules.cs
@@ -1,0 +1,52 @@
+using FluentValidation;
+using FluentValidation.Results;
+
+namespace Sudoku.Application.Datasets;
+
+public static class DatasetPreparationNameValidationRules
+{
+    private const int MaxPreparationNameLength = 160;
+
+    public static void Validate<T>(
+        string? preparationName,
+        ValidationContext<T> context,
+        string propertyName,
+        string errorCode)
+    {
+        if (string.IsNullOrWhiteSpace(preparationName))
+        {
+            context.AddFailure(CreateFailure(propertyName, errorCode, "Pole 'preparationName' jest wymagane."));
+            return;
+        }
+
+        var trimmedPreparationName = preparationName.Trim();
+        if (trimmedPreparationName.Length > MaxPreparationNameLength)
+        {
+            context.AddFailure(CreateFailure(
+                propertyName,
+                errorCode,
+                $"Pole 'preparationName' nie może być dłuższe niż {MaxPreparationNameLength} znaków."));
+        }
+
+        if (trimmedPreparationName.Contains("..", StringComparison.Ordinal)
+            || trimmedPreparationName.Contains('/', StringComparison.Ordinal)
+            || trimmedPreparationName.Contains('\\', StringComparison.Ordinal)
+            || trimmedPreparationName.Contains(':', StringComparison.Ordinal)
+            || trimmedPreparationName.Any(char.IsControl)
+            || trimmedPreparationName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            context.AddFailure(CreateFailure(
+                propertyName,
+                errorCode,
+                "Pole 'preparationName' zawiera niedozwolone znaki."));
+        }
+    }
+
+    private static ValidationFailure CreateFailure(string propertyName, string errorCode, string message)
+    {
+        return new ValidationFailure(propertyName, message)
+        {
+            ErrorCode = errorCode
+        };
+    }
+}

--- a/src/Backend/Sudoku/Application/Datasets/DatasetPreparationSourceNameValidationRules.cs
+++ b/src/Backend/Sudoku/Application/Datasets/DatasetPreparationSourceNameValidationRules.cs
@@ -1,0 +1,52 @@
+using FluentValidation;
+using FluentValidation.Results;
+
+namespace Sudoku.Application.Datasets;
+
+public static class DatasetPreparationSourceNameValidationRules
+{
+    private const int MaxSourceNameLength = 160;
+
+    public static void Validate<T>(
+        string? sourceName,
+        ValidationContext<T> context,
+        string propertyName,
+        string errorCode)
+    {
+        if (string.IsNullOrWhiteSpace(sourceName))
+        {
+            context.AddFailure(CreateFailure(propertyName, errorCode, "Pole 'sourceName' jest wymagane."));
+            return;
+        }
+
+        var trimmedSourceName = sourceName.Trim();
+        if (trimmedSourceName.Length > MaxSourceNameLength)
+        {
+            context.AddFailure(CreateFailure(
+                propertyName,
+                errorCode,
+                $"Pole 'sourceName' nie może być dłuższe niż {MaxSourceNameLength} znaków."));
+        }
+
+        if (trimmedSourceName.Contains("..", StringComparison.Ordinal)
+            || trimmedSourceName.Contains('/', StringComparison.Ordinal)
+            || trimmedSourceName.Contains('\\', StringComparison.Ordinal)
+            || trimmedSourceName.Contains(':', StringComparison.Ordinal)
+            || trimmedSourceName.Any(char.IsControl)
+            || trimmedSourceName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            context.AddFailure(CreateFailure(
+                propertyName,
+                errorCode,
+                "Pole 'sourceName' zawiera niedozwolone znaki."));
+        }
+    }
+
+    private static ValidationFailure CreateFailure(string propertyName, string errorCode, string message)
+    {
+        return new ValidationFailure(propertyName, message)
+        {
+            ErrorCode = errorCode
+        };
+    }
+}

--- a/src/Backend/Sudoku/Application/Datasets/DatasetPreparationSourceNotFoundException.cs
+++ b/src/Backend/Sudoku/Application/Datasets/DatasetPreparationSourceNotFoundException.cs
@@ -1,0 +1,15 @@
+namespace Sudoku.Application.Datasets;
+
+public sealed class DatasetPreparationSourceNotFoundException : Exception
+{
+    public DatasetPreparationSourceNotFoundException(string preparationName, string sourceName)
+        : base($"Nie znaleziono źródła '{sourceName}' w przygotowaniu datasetu '{preparationName}'.")
+    {
+        PreparationName = preparationName;
+        SourceName = sourceName;
+    }
+
+    public string PreparationName { get; }
+
+    public string SourceName { get; }
+}

--- a/src/Backend/Sudoku/Application/Datasets/DeleteDatasetPreparationBoardFileCommand.cs
+++ b/src/Backend/Sudoku/Application/Datasets/DeleteDatasetPreparationBoardFileCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace Sudoku.Application.Datasets;
+
+public sealed record DeleteDatasetPreparationBoardFileCommand(
+    string? PreparationName,
+    string? SourceName,
+    string? BoardFolderName)
+    : IRequest<DeleteDatasetPreparationBoardFileCommandResultDto>;

--- a/src/Backend/Sudoku/Application/Datasets/DeleteDatasetPreparationBoardFileCommandHandler.cs
+++ b/src/Backend/Sudoku/Application/Datasets/DeleteDatasetPreparationBoardFileCommandHandler.cs
@@ -1,0 +1,170 @@
+using MediatR;
+using Sudoku.Application.Abstractions;
+using Sudoku.Models.Datasets;
+
+namespace Sudoku.Application.Datasets;
+
+public sealed class DeleteDatasetPreparationBoardFileCommandHandler
+    : IRequestHandler<DeleteDatasetPreparationBoardFileCommand, DeleteDatasetPreparationBoardFileCommandResultDto>
+{
+    private const string BoardSourceType = "board";
+
+    private readonly IDatasetPreparationsGateway _datasetPreparationsGateway;
+    private readonly IDatasetPreparationArtifactsGateway _datasetPreparationArtifactsGateway;
+
+    public DeleteDatasetPreparationBoardFileCommandHandler(
+        IDatasetPreparationsGateway datasetPreparationsGateway,
+        IDatasetPreparationArtifactsGateway datasetPreparationArtifactsGateway)
+    {
+        _datasetPreparationsGateway = datasetPreparationsGateway;
+        _datasetPreparationArtifactsGateway = datasetPreparationArtifactsGateway;
+    }
+
+    public async Task<DeleteDatasetPreparationBoardFileCommandResultDto> Handle(
+        DeleteDatasetPreparationBoardFileCommand request,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.PreparationName)
+            || string.IsNullOrWhiteSpace(request.SourceName)
+            || string.IsNullOrWhiteSpace(request.BoardFolderName))
+        {
+            throw new InvalidOperationException(
+                "DeleteDatasetPreparationBoardFileCommand must be validated before handler execution.");
+        }
+
+        var preparationName = request.PreparationName.Trim();
+        var sourceName = request.SourceName.Trim();
+        var boardFolderName = request.BoardFolderName.Trim();
+
+        var metadata = await _datasetPreparationsGateway.GetByNameAsync(preparationName, cancellationToken);
+        if (metadata is null)
+        {
+            throw new DatasetPreparationNotFoundException(preparationName);
+        }
+
+        EnsurePreparationCompleted(metadata);
+
+        var boardSources = await _datasetPreparationArtifactsGateway.GetSourceFolderNamesAsync(
+            preparationName,
+            BoardSourceType,
+            cancellationToken);
+        EnsureBoardSourceExists(metadata.PreparationName, sourceName, boardSources);
+
+        var boardFolderNames = await _datasetPreparationArtifactsGateway.GetBoardFileNamesAsync(
+            preparationName,
+            sourceName,
+            cancellationToken);
+        EnsureBoardFolderExists(metadata.PreparationName, sourceName, boardFolderName, boardFolderNames);
+
+        var remainingBoardFileNames = BuildRemainingBoardFileNames(boardFolderNames, boardFolderName);
+
+        await PersistManifestThenDeleteBoardAsync(
+            preparationName,
+            sourceName,
+            boardFolderName,
+            boardFolderNames,
+            remainingBoardFileNames,
+            cancellationToken);
+
+        return new DeleteDatasetPreparationBoardFileCommandResultDto(
+            PreparationName: metadata.PreparationName,
+            SourceName: sourceName,
+            BoardFolderName: boardFolderName,
+            Deleted: true,
+            RemainingItemsCount: remainingBoardFileNames.Count);
+    }
+
+    private static void EnsurePreparationCompleted(DatasetPreparationMetadataDto metadata)
+    {
+        if (!string.Equals(metadata.Status, DatasetPreparationStatus.Completed, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new DatasetPreparationArtifactsNotReadyException(metadata.PreparationName, metadata.Status);
+        }
+    }
+
+    private static void EnsureBoardSourceExists(
+        string preparationName,
+        string sourceName,
+        IReadOnlyList<string> boardSources)
+    {
+        if (!boardSources.Contains(sourceName, StringComparer.Ordinal))
+        {
+            throw new DatasetPreparationSourceNotFoundException(preparationName, sourceName);
+        }
+    }
+
+    private static void EnsureBoardFolderExists(
+        string preparationName,
+        string sourceName,
+        string boardFolderName,
+        IReadOnlyList<string> boardFolderNames)
+    {
+        if (!boardFolderNames.Contains(boardFolderName, StringComparer.Ordinal))
+        {
+            throw new DatasetPreparationBoardFileNotFoundException(preparationName, sourceName, boardFolderName);
+        }
+    }
+
+    private static IReadOnlyList<string> BuildRemainingBoardFileNames(
+        IReadOnlyList<string> boardFolderNames,
+        string boardFolderName)
+    {
+        return boardFolderNames
+            .Where(item => !string.Equals(item, boardFolderName, StringComparison.Ordinal))
+            .ToArray();
+    }
+
+    private async Task PersistManifestThenDeleteBoardAsync(
+        string preparationName,
+        string sourceName,
+        string boardFolderName,
+        IReadOnlyList<string> originalBoardFileNames,
+        IReadOnlyList<string> remainingBoardFileNames,
+        CancellationToken cancellationToken)
+    {
+        await _datasetPreparationArtifactsGateway.ReplaceBoardFileNamesAsync(
+            preparationName,
+            sourceName,
+            remainingBoardFileNames,
+            cancellationToken);
+
+        try
+        {
+            await _datasetPreparationArtifactsGateway.DeleteBoardDirectoryAsync(
+                preparationName,
+                sourceName,
+                boardFolderName,
+                cancellationToken);
+        }
+        catch (Exception)
+        {
+            await TryRollbackBoardManifestAsync(
+                preparationName,
+                sourceName,
+                originalBoardFileNames,
+                cancellationToken);
+
+            throw;
+        }
+    }
+
+    private async Task TryRollbackBoardManifestAsync(
+        string preparationName,
+        string sourceName,
+        IReadOnlyList<string> originalBoardFileNames,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _datasetPreparationArtifactsGateway.ReplaceBoardFileNamesAsync(
+                preparationName,
+                sourceName,
+                originalBoardFileNames,
+                cancellationToken);
+        }
+        catch
+        {
+            // Główny błąd usuwania ma zostać propagowany; rollback jest best-effort.
+        }
+    }
+}

--- a/src/Backend/Sudoku/Application/Datasets/DeleteDatasetPreparationBoardFileCommandResultDto.cs
+++ b/src/Backend/Sudoku/Application/Datasets/DeleteDatasetPreparationBoardFileCommandResultDto.cs
@@ -1,0 +1,8 @@
+namespace Sudoku.Application.Datasets;
+
+public sealed record DeleteDatasetPreparationBoardFileCommandResultDto(
+    string PreparationName,
+    string SourceName,
+    string BoardFolderName,
+    bool Deleted,
+    int RemainingItemsCount);

--- a/src/Backend/Sudoku/Application/Datasets/DeleteDatasetPreparationBoardFileCommandValidator.cs
+++ b/src/Backend/Sudoku/Application/Datasets/DeleteDatasetPreparationBoardFileCommandValidator.cs
@@ -1,0 +1,31 @@
+using FluentValidation;
+
+namespace Sudoku.Application.Datasets;
+
+public sealed class DeleteDatasetPreparationBoardFileCommandValidator
+    : AbstractValidator<DeleteDatasetPreparationBoardFileCommand>
+{
+    public DeleteDatasetPreparationBoardFileCommandValidator()
+    {
+        RuleFor(command => command.PreparationName)
+            .Custom((preparationName, context) => DatasetPreparationNameValidationRules.Validate(
+                preparationName,
+                context,
+                nameof(DeleteDatasetPreparationBoardFileCommand.PreparationName),
+                DeleteDatasetPreparationBoardFileErrorTypes.InvalidDatasetPreparationName));
+
+        RuleFor(command => command.SourceName)
+            .Custom((sourceName, context) => DatasetPreparationSourceNameValidationRules.Validate(
+                sourceName,
+                context,
+                nameof(DeleteDatasetPreparationBoardFileCommand.SourceName),
+                DeleteDatasetPreparationBoardFileErrorTypes.InvalidDatasetPreparationSourceName));
+
+        RuleFor(command => command.BoardFolderName)
+            .Custom((boardFolderName, context) => DatasetPreparationBoardFolderNameValidationRules.Validate(
+                boardFolderName,
+                context,
+                nameof(DeleteDatasetPreparationBoardFileCommand.BoardFolderName),
+                DeleteDatasetPreparationBoardFileErrorTypes.InvalidDatasetPreparationBoardFolderName));
+    }
+}

--- a/src/Backend/Sudoku/Application/Datasets/DeleteDatasetPreparationBoardFileErrorTypes.cs
+++ b/src/Backend/Sudoku/Application/Datasets/DeleteDatasetPreparationBoardFileErrorTypes.cs
@@ -1,0 +1,13 @@
+namespace Sudoku.Application.Datasets;
+
+public static class DeleteDatasetPreparationBoardFileErrorTypes
+{
+    public const string InvalidDatasetPreparationName = "invalid_dataset_preparation_name";
+    public const string InvalidDatasetPreparationSourceName = "invalid_dataset_preparation_source_name";
+    public const string InvalidDatasetPreparationBoardFolderName = "invalid_dataset_preparation_board_folder_name";
+    public const string DatasetPreparationNotFound = "dataset_preparation_not_found";
+    public const string DatasetPreparationSourceNotFound = "dataset_preparation_source_not_found";
+    public const string DatasetPreparationBoardFileNotFound = "dataset_preparation_board_file_not_found";
+    public const string DatasetPreparationArtifactsNotReady = "dataset_preparation_artifacts_not_ready";
+    public const string DatasetPreparationBoardFileDeleteFailed = "dataset_preparation_board_file_delete_failed";
+}

--- a/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardFilesErrorTypes.cs
+++ b/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardFilesErrorTypes.cs
@@ -1,0 +1,13 @@
+namespace Sudoku.Application.Datasets;
+
+public static class GetDatasetPreparationBoardFilesErrorTypes
+{
+    public const string InvalidDatasetPreparationName = "invalid_dataset_preparation_name";
+    public const string InvalidDatasetPreparationSourceName = "invalid_dataset_preparation_source_name";
+    public const string InvalidDatasetPreparationBoardFilesPage = "invalid_dataset_preparation_board_files_page";
+    public const string InvalidDatasetPreparationBoardFilesPageSize = "invalid_dataset_preparation_board_files_page_size";
+    public const string DatasetPreparationNotFound = "dataset_preparation_not_found";
+    public const string DatasetPreparationSourceNotFound = "dataset_preparation_source_not_found";
+    public const string DatasetPreparationArtifactsNotReady = "dataset_preparation_artifacts_not_ready";
+    public const string DatasetPreparationBoardFilesReadFailed = "dataset_preparation_board_files_read_failed";
+}

--- a/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardFilesQuery.cs
+++ b/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardFilesQuery.cs
@@ -1,0 +1,10 @@
+using MediatR;
+
+namespace Sudoku.Application.Datasets;
+
+public sealed record GetDatasetPreparationBoardFilesQuery(
+    string? PreparationName,
+    string? SourceName,
+    int? Page,
+    int? PageSize)
+    : IRequest<GetDatasetPreparationBoardFilesQueryResultDto>;

--- a/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardFilesQueryHandler.cs
+++ b/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardFilesQueryHandler.cs
@@ -1,0 +1,105 @@
+using MediatR;
+using Sudoku.Application.Abstractions;
+using Sudoku.Models.Datasets;
+
+namespace Sudoku.Application.Datasets;
+
+public sealed class GetDatasetPreparationBoardFilesQueryHandler
+    : IRequestHandler<GetDatasetPreparationBoardFilesQuery, GetDatasetPreparationBoardFilesQueryResultDto>
+{
+    private readonly IDatasetPreparationsGateway _datasetPreparationsGateway;
+    private readonly IDatasetPreparationArtifactsGateway _datasetPreparationArtifactsGateway;
+
+    public GetDatasetPreparationBoardFilesQueryHandler(
+        IDatasetPreparationsGateway datasetPreparationsGateway,
+        IDatasetPreparationArtifactsGateway datasetPreparationArtifactsGateway)
+    {
+        _datasetPreparationsGateway = datasetPreparationsGateway;
+        _datasetPreparationArtifactsGateway = datasetPreparationArtifactsGateway;
+    }
+
+    public async Task<GetDatasetPreparationBoardFilesQueryResultDto> Handle(
+        GetDatasetPreparationBoardFilesQuery request,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.PreparationName)
+            || string.IsNullOrWhiteSpace(request.SourceName)
+            || !request.Page.HasValue
+            || !request.PageSize.HasValue
+            || request.Page.Value < 1
+            || request.PageSize.Value < 1)
+        {
+            throw new InvalidOperationException(
+                "GetDatasetPreparationBoardFilesQuery must be validated before handler execution.");
+        }
+
+        var preparationName = request.PreparationName.Trim();
+        var sourceName = request.SourceName.Trim();
+        var page = request.Page.Value;
+        var pageSize = request.PageSize.Value;
+
+        var metadata = await _datasetPreparationsGateway.GetByNameAsync(preparationName, cancellationToken);
+        if (metadata is null)
+        {
+            throw new DatasetPreparationNotFoundException(preparationName);
+        }
+
+        EnsurePreparationCompleted(metadata);
+
+        var boardSources = await _datasetPreparationArtifactsGateway.GetSourceFolderNamesAsync(
+            preparationName,
+            "board",
+            cancellationToken);
+        EnsureBoardSourceExists(metadata.PreparationName, sourceName, boardSources);
+
+        var boardFolderNames = await _datasetPreparationArtifactsGateway.GetBoardFileNamesAsync(
+            preparationName,
+            sourceName,
+            cancellationToken);
+
+        var pageItems = Paginate(boardFolderNames, page, pageSize)
+            .Select(boardFolderName => new DatasetPreparationBoardFileListItemDto(boardFolderName))
+            .ToArray();
+
+        return new GetDatasetPreparationBoardFilesQueryResultDto(
+            PreparationName: metadata.PreparationName,
+            SourceName: sourceName,
+            Items: pageItems,
+            Page: page,
+            PageSize: pageSize,
+            TotalCount: boardFolderNames.Count);
+    }
+
+    private static void EnsurePreparationCompleted(DatasetPreparationMetadataDto metadata)
+    {
+        if (!string.Equals(metadata.Status, DatasetPreparationStatus.Completed, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new DatasetPreparationArtifactsNotReadyException(metadata.PreparationName, metadata.Status);
+        }
+    }
+
+    private static void EnsureBoardSourceExists(
+        string preparationName,
+        string sourceName,
+        IReadOnlyList<string> boardSources)
+    {
+        if (!boardSources.Contains(sourceName, StringComparer.Ordinal))
+        {
+            throw new DatasetPreparationSourceNotFoundException(preparationName, sourceName);
+        }
+    }
+
+    private static IReadOnlyList<string> Paginate(IReadOnlyList<string> items, int page, int pageSize)
+    {
+        var skip = (page - 1) * pageSize;
+        if (skip >= items.Count)
+        {
+            return [];
+        }
+
+        return items
+            .Skip(skip)
+            .Take(pageSize)
+            .ToArray();
+    }
+}

--- a/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardFilesQueryResultDto.cs
+++ b/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardFilesQueryResultDto.cs
@@ -1,0 +1,9 @@
+namespace Sudoku.Application.Datasets;
+
+public sealed record GetDatasetPreparationBoardFilesQueryResultDto(
+    string PreparationName,
+    string SourceName,
+    IReadOnlyList<DatasetPreparationBoardFileListItemDto> Items,
+    int Page,
+    int PageSize,
+    int TotalCount);

--- a/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardFilesQueryValidator.cs
+++ b/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardFilesQueryValidator.cs
@@ -1,0 +1,76 @@
+using FluentValidation;
+using FluentValidation.Results;
+
+namespace Sudoku.Application.Datasets;
+
+public sealed class GetDatasetPreparationBoardFilesQueryValidator
+    : AbstractValidator<GetDatasetPreparationBoardFilesQuery>
+{
+    public const int MaxPageSize = 200;
+
+    public GetDatasetPreparationBoardFilesQueryValidator()
+    {
+        RuleFor(query => query.PreparationName)
+            .Custom((preparationName, context) => DatasetPreparationNameValidationRules.Validate(
+                preparationName,
+                context,
+                nameof(GetDatasetPreparationBoardFilesQuery.PreparationName),
+                GetDatasetPreparationBoardFilesErrorTypes.InvalidDatasetPreparationName));
+
+        RuleFor(query => query.SourceName)
+            .Custom((sourceName, context) => DatasetPreparationSourceNameValidationRules.Validate(
+                sourceName,
+                context,
+                nameof(GetDatasetPreparationBoardFilesQuery.SourceName),
+                GetDatasetPreparationBoardFilesErrorTypes.InvalidDatasetPreparationSourceName));
+
+        RuleFor(query => query.Page)
+            .Custom(ValidatePage);
+
+        RuleFor(query => query.PageSize)
+            .Custom(ValidatePageSize);
+    }
+
+    private static void ValidatePage(
+        int? page,
+        ValidationContext<GetDatasetPreparationBoardFilesQuery> context)
+    {
+        if (!page.HasValue || page.Value < 1)
+        {
+            context.AddFailure(CreateFailure(
+                nameof(GetDatasetPreparationBoardFilesQuery.Page),
+                GetDatasetPreparationBoardFilesErrorTypes.InvalidDatasetPreparationBoardFilesPage,
+                "Parametr 'page' musi być większy lub równy 1."));
+        }
+    }
+
+    private static void ValidatePageSize(
+        int? pageSize,
+        ValidationContext<GetDatasetPreparationBoardFilesQuery> context)
+    {
+        if (!pageSize.HasValue || pageSize.Value < 1)
+        {
+            context.AddFailure(CreateFailure(
+                nameof(GetDatasetPreparationBoardFilesQuery.PageSize),
+                GetDatasetPreparationBoardFilesErrorTypes.InvalidDatasetPreparationBoardFilesPageSize,
+                "Parametr 'pageSize' musi być większy lub równy 1."));
+            return;
+        }
+
+        if (pageSize.Value > MaxPageSize)
+        {
+            context.AddFailure(CreateFailure(
+                nameof(GetDatasetPreparationBoardFilesQuery.PageSize),
+                GetDatasetPreparationBoardFilesErrorTypes.InvalidDatasetPreparationBoardFilesPageSize,
+                $"Parametr 'pageSize' nie może być większy niż {MaxPageSize}."));
+        }
+    }
+
+    private static ValidationFailure CreateFailure(string propertyName, string errorCode, string message)
+    {
+        return new ValidationFailure(propertyName, message)
+        {
+            ErrorCode = errorCode
+        };
+    }
+}

--- a/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardImageErrorTypes.cs
+++ b/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardImageErrorTypes.cs
@@ -1,0 +1,13 @@
+namespace Sudoku.Application.Datasets;
+
+public static class GetDatasetPreparationBoardImageErrorTypes
+{
+    public const string InvalidDatasetPreparationName = "invalid_dataset_preparation_name";
+    public const string InvalidDatasetPreparationSourceName = "invalid_dataset_preparation_source_name";
+    public const string InvalidDatasetPreparationBoardFolderName = "invalid_dataset_preparation_board_folder_name";
+    public const string DatasetPreparationNotFound = "dataset_preparation_not_found";
+    public const string DatasetPreparationSourceNotFound = "dataset_preparation_source_not_found";
+    public const string DatasetPreparationBoardFileNotFound = "dataset_preparation_board_file_not_found";
+    public const string DatasetPreparationArtifactsNotReady = "dataset_preparation_artifacts_not_ready";
+    public const string DatasetPreparationBoardImageReadFailed = "dataset_preparation_board_image_read_failed";
+}

--- a/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardImageQuery.cs
+++ b/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardImageQuery.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace Sudoku.Application.Datasets;
+
+public sealed record GetDatasetPreparationBoardImageQuery(
+    string? PreparationName,
+    string? SourceName,
+    string? BoardFolderName)
+    : IRequest<GetDatasetPreparationBoardImageQueryResultDto>;

--- a/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardImageQueryHandler.cs
+++ b/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardImageQueryHandler.cs
@@ -1,0 +1,119 @@
+using MediatR;
+using Sudoku.Application.Abstractions;
+using Sudoku.Models.Datasets;
+
+namespace Sudoku.Application.Datasets;
+
+public sealed class GetDatasetPreparationBoardImageQueryHandler
+    : IRequestHandler<GetDatasetPreparationBoardImageQuery, GetDatasetPreparationBoardImageQueryResultDto>
+{
+    private const string BoardSourceType = "board";
+    private const string BoardImageMimeType = "image/png";
+
+    private readonly IDatasetPreparationsGateway _datasetPreparationsGateway;
+    private readonly IDatasetPreparationArtifactsGateway _datasetPreparationArtifactsGateway;
+
+    public GetDatasetPreparationBoardImageQueryHandler(
+        IDatasetPreparationsGateway datasetPreparationsGateway,
+        IDatasetPreparationArtifactsGateway datasetPreparationArtifactsGateway)
+    {
+        _datasetPreparationsGateway = datasetPreparationsGateway;
+        _datasetPreparationArtifactsGateway = datasetPreparationArtifactsGateway;
+    }
+
+    public async Task<GetDatasetPreparationBoardImageQueryResultDto> Handle(
+        GetDatasetPreparationBoardImageQuery request,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.PreparationName)
+            || string.IsNullOrWhiteSpace(request.SourceName)
+            || string.IsNullOrWhiteSpace(request.BoardFolderName))
+        {
+            throw new InvalidOperationException(
+                "GetDatasetPreparationBoardImageQuery must be validated before handler execution.");
+        }
+
+        var preparationName = request.PreparationName.Trim();
+        var sourceName = request.SourceName.Trim();
+        var boardFolderName = request.BoardFolderName.Trim();
+
+        var metadata = await _datasetPreparationsGateway.GetByNameAsync(preparationName, cancellationToken);
+        if (metadata is null)
+        {
+            throw new DatasetPreparationNotFoundException(preparationName);
+        }
+
+        EnsurePreparationCompleted(metadata);
+
+        var boardSources = await _datasetPreparationArtifactsGateway.GetSourceFolderNamesAsync(
+            preparationName,
+            BoardSourceType,
+            cancellationToken);
+        EnsureBoardSourceExists(metadata.PreparationName, sourceName, boardSources);
+
+        var boardFolderNames = await _datasetPreparationArtifactsGateway.GetBoardFileNamesAsync(
+            preparationName,
+            sourceName,
+            cancellationToken);
+        EnsureBoardFolderExists(metadata.PreparationName, sourceName, boardFolderName, boardFolderNames);
+
+        var base64 = await ReadArtifactAsBase64Async(
+            preparationName,
+            sourceName,
+            boardFolderName,
+            cancellationToken);
+
+        return new GetDatasetPreparationBoardImageQueryResultDto(
+            MimeType: BoardImageMimeType,
+            Base64: base64);
+    }
+
+    private static void EnsurePreparationCompleted(DatasetPreparationMetadataDto metadata)
+    {
+        if (!string.Equals(metadata.Status, DatasetPreparationStatus.Completed, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new DatasetPreparationArtifactsNotReadyException(metadata.PreparationName, metadata.Status);
+        }
+    }
+
+    private static void EnsureBoardSourceExists(
+        string preparationName,
+        string sourceName,
+        IReadOnlyList<string> boardSources)
+    {
+        if (!boardSources.Contains(sourceName, StringComparer.Ordinal))
+        {
+            throw new DatasetPreparationSourceNotFoundException(preparationName, sourceName);
+        }
+    }
+
+    private static void EnsureBoardFolderExists(
+        string preparationName,
+        string sourceName,
+        string boardFolderName,
+        IReadOnlyList<string> boardFolderNames)
+    {
+        if (!boardFolderNames.Contains(boardFolderName, StringComparer.Ordinal))
+        {
+            throw new DatasetPreparationBoardFileNotFoundException(preparationName, sourceName, boardFolderName);
+        }
+    }
+
+    private async Task<string> ReadArtifactAsBase64Async(
+        string preparationName,
+        string sourceName,
+        string boardFolderName,
+        CancellationToken cancellationToken)
+    {
+        await using var artifactStream = await _datasetPreparationArtifactsGateway.OpenBoardArtifactReadAsync(
+            preparationName,
+            sourceName,
+            boardFolderName,
+            DatasetPreparationBoardArtifactNames.CorrectedBoardFileName,
+            cancellationToken);
+        await using var buffer = new MemoryStream();
+        await artifactStream.CopyToAsync(buffer, cancellationToken);
+
+        return Convert.ToBase64String(buffer.ToArray());
+    }
+}

--- a/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardImageQueryResultDto.cs
+++ b/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardImageQueryResultDto.cs
@@ -1,0 +1,5 @@
+namespace Sudoku.Application.Datasets;
+
+public sealed record GetDatasetPreparationBoardImageQueryResultDto(
+    string MimeType,
+    string Base64);

--- a/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardImageQueryValidator.cs
+++ b/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationBoardImageQueryValidator.cs
@@ -1,0 +1,31 @@
+using FluentValidation;
+
+namespace Sudoku.Application.Datasets;
+
+public sealed class GetDatasetPreparationBoardImageQueryValidator
+    : AbstractValidator<GetDatasetPreparationBoardImageQuery>
+{
+    public GetDatasetPreparationBoardImageQueryValidator()
+    {
+        RuleFor(query => query.PreparationName)
+            .Custom((preparationName, context) => DatasetPreparationNameValidationRules.Validate(
+                preparationName,
+                context,
+                nameof(GetDatasetPreparationBoardImageQuery.PreparationName),
+                GetDatasetPreparationBoardImageErrorTypes.InvalidDatasetPreparationName));
+
+        RuleFor(query => query.SourceName)
+            .Custom((sourceName, context) => DatasetPreparationSourceNameValidationRules.Validate(
+                sourceName,
+                context,
+                nameof(GetDatasetPreparationBoardImageQuery.SourceName),
+                GetDatasetPreparationBoardImageErrorTypes.InvalidDatasetPreparationSourceName));
+
+        RuleFor(query => query.BoardFolderName)
+            .Custom((boardFolderName, context) => DatasetPreparationBoardFolderNameValidationRules.Validate(
+                boardFolderName,
+                context,
+                nameof(GetDatasetPreparationBoardImageQuery.BoardFolderName),
+                GetDatasetPreparationBoardImageErrorTypes.InvalidDatasetPreparationBoardFolderName));
+    }
+}

--- a/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationDetailsQueryValidator.cs
+++ b/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationDetailsQueryValidator.cs
@@ -1,52 +1,16 @@
 using FluentValidation;
-using FluentValidation.Results;
-
 namespace Sudoku.Application.Datasets;
 
 public sealed class GetDatasetPreparationDetailsQueryValidator
     : AbstractValidator<GetDatasetPreparationDetailsQuery>
 {
-    private const int MaxPreparationNameLength = 160;
-
     public GetDatasetPreparationDetailsQueryValidator()
     {
         RuleFor(query => query.PreparationName)
-            .Custom(ValidatePreparationName);
-    }
-
-    private static void ValidatePreparationName(
-        string? preparationName,
-        ValidationContext<GetDatasetPreparationDetailsQuery> context)
-    {
-        if (string.IsNullOrWhiteSpace(preparationName))
-        {
-            context.AddFailure(CreateFailure("Pole 'preparationName' jest wymagane."));
-            return;
-        }
-
-        var trimmedPreparationName = preparationName.Trim();
-        if (trimmedPreparationName.Length > MaxPreparationNameLength)
-        {
-            context.AddFailure(CreateFailure(
-                $"Pole 'preparationName' nie może być dłuższe niż {MaxPreparationNameLength} znaków."));
-        }
-
-        if (trimmedPreparationName.Contains("..", StringComparison.Ordinal)
-            || trimmedPreparationName.Contains('/', StringComparison.Ordinal)
-            || trimmedPreparationName.Contains('\\', StringComparison.Ordinal)
-            || trimmedPreparationName.Contains(':', StringComparison.Ordinal)
-            || trimmedPreparationName.Any(char.IsControl)
-            || trimmedPreparationName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
-        {
-            context.AddFailure(CreateFailure("Pole 'preparationName' zawiera niedozwolone znaki."));
-        }
-    }
-
-    private static ValidationFailure CreateFailure(string message)
-    {
-        return new ValidationFailure(nameof(GetDatasetPreparationDetailsQuery.PreparationName), message)
-        {
-            ErrorCode = GetDatasetPreparationDetailsErrorTypes.InvalidDatasetPreparationName
-        };
+            .Custom((preparationName, context) => DatasetPreparationNameValidationRules.Validate(
+                preparationName,
+                context,
+                nameof(GetDatasetPreparationDetailsQuery.PreparationName),
+                GetDatasetPreparationDetailsErrorTypes.InvalidDatasetPreparationName));
     }
 }

--- a/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationFoldersErrorTypes.cs
+++ b/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationFoldersErrorTypes.cs
@@ -1,0 +1,10 @@
+namespace Sudoku.Application.Datasets;
+
+public static class GetDatasetPreparationFoldersErrorTypes
+{
+    public const string InvalidDatasetPreparationName = "invalid_dataset_preparation_name";
+    public const string InvalidDatasetPreparationType = "invalid_dataset_preparation_type";
+    public const string DatasetPreparationNotFound = "dataset_preparation_not_found";
+    public const string DatasetPreparationArtifactsNotReady = "dataset_preparation_artifacts_not_ready";
+    public const string DatasetPreparationFoldersReadFailed = "dataset_preparation_folders_read_failed";
+}

--- a/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationFoldersQuery.cs
+++ b/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationFoldersQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+
+namespace Sudoku.Application.Datasets;
+
+public sealed record GetDatasetPreparationFoldersQuery(string? PreparationName, string? Type)
+    : IRequest<GetDatasetPreparationFoldersQueryResultDto>;

--- a/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationFoldersQueryHandler.cs
+++ b/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationFoldersQueryHandler.cs
@@ -1,0 +1,61 @@
+using MediatR;
+using Sudoku.Application.Abstractions;
+using Sudoku.Models.Datasets;
+
+namespace Sudoku.Application.Datasets;
+
+public sealed class GetDatasetPreparationFoldersQueryHandler
+    : IRequestHandler<GetDatasetPreparationFoldersQuery, GetDatasetPreparationFoldersQueryResultDto>
+{
+    private readonly IDatasetPreparationsGateway _datasetPreparationsGateway;
+    private readonly IDatasetPreparationArtifactsGateway _datasetPreparationArtifactsGateway;
+
+    public GetDatasetPreparationFoldersQueryHandler(
+        IDatasetPreparationsGateway datasetPreparationsGateway,
+        IDatasetPreparationArtifactsGateway datasetPreparationArtifactsGateway)
+    {
+        _datasetPreparationsGateway = datasetPreparationsGateway;
+        _datasetPreparationArtifactsGateway = datasetPreparationArtifactsGateway;
+    }
+
+    public async Task<GetDatasetPreparationFoldersQueryResultDto> Handle(
+        GetDatasetPreparationFoldersQuery request,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.PreparationName) || string.IsNullOrWhiteSpace(request.Type))
+        {
+            throw new InvalidOperationException(
+                "GetDatasetPreparationFoldersQuery must be validated before handler execution.");
+        }
+
+        var preparationName = request.PreparationName.Trim();
+        var type = request.Type.Trim().ToLowerInvariant();
+
+        var metadata = await _datasetPreparationsGateway.GetByNameAsync(preparationName, cancellationToken);
+        if (metadata is null)
+        {
+            throw new DatasetPreparationNotFoundException(preparationName);
+        }
+
+        EnsurePreparationCompleted(metadata);
+
+        var items = await _datasetPreparationArtifactsGateway.GetSourceFolderNamesAsync(
+            preparationName,
+            type,
+            cancellationToken);
+
+        return new GetDatasetPreparationFoldersQueryResultDto(
+            PreparationName: metadata.PreparationName,
+            Type: type,
+            Items: items,
+            TotalCount: items.Count);
+    }
+
+    private static void EnsurePreparationCompleted(DatasetPreparationMetadataDto metadata)
+    {
+        if (!string.Equals(metadata.Status, DatasetPreparationStatus.Completed, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new DatasetPreparationArtifactsNotReadyException(metadata.PreparationName, metadata.Status);
+        }
+    }
+}

--- a/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationFoldersQueryResultDto.cs
+++ b/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationFoldersQueryResultDto.cs
@@ -1,0 +1,7 @@
+namespace Sudoku.Application.Datasets;
+
+public sealed record GetDatasetPreparationFoldersQueryResultDto(
+    string PreparationName,
+    string Type,
+    IReadOnlyList<string> Items,
+    int TotalCount);

--- a/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationFoldersQueryValidator.cs
+++ b/src/Backend/Sudoku/Application/Datasets/GetDatasetPreparationFoldersQueryValidator.cs
@@ -1,0 +1,47 @@
+using FluentValidation;
+using FluentValidation.Results;
+
+namespace Sudoku.Application.Datasets;
+
+public sealed class GetDatasetPreparationFoldersQueryValidator
+    : AbstractValidator<GetDatasetPreparationFoldersQuery>
+{
+    public GetDatasetPreparationFoldersQueryValidator()
+    {
+        RuleFor(query => query.PreparationName)
+            .Custom((preparationName, context) => DatasetPreparationNameValidationRules.Validate(
+                preparationName,
+                context,
+                nameof(GetDatasetPreparationFoldersQuery.PreparationName),
+                GetDatasetPreparationFoldersErrorTypes.InvalidDatasetPreparationName));
+
+        RuleFor(query => query.Type)
+            .Custom(ValidateType);
+    }
+
+    private static void ValidateType(
+        string? type,
+        ValidationContext<GetDatasetPreparationFoldersQuery> context)
+    {
+        if (string.IsNullOrWhiteSpace(type))
+        {
+            context.AddFailure(CreateTypeFailure("Pole 'type' jest wymagane."));
+            return;
+        }
+
+        var trimmedType = type.Trim();
+        if (!string.Equals(trimmedType, "board", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(trimmedType, "digit", StringComparison.OrdinalIgnoreCase))
+        {
+            context.AddFailure(CreateTypeFailure("Pole 'type' musi mieć wartość 'board' albo 'digit'."));
+        }
+    }
+
+    private static ValidationFailure CreateTypeFailure(string message)
+    {
+        return new ValidationFailure(nameof(GetDatasetPreparationFoldersQuery.Type), message)
+        {
+            ErrorCode = GetDatasetPreparationFoldersErrorTypes.InvalidDatasetPreparationType
+        };
+    }
+}

--- a/src/Backend/Sudoku/Infrastructure/DependencyInjection.cs
+++ b/src/Backend/Sudoku/Infrastructure/DependencyInjection.cs
@@ -68,6 +68,7 @@ public static class DependencyInjection
 
         services.AddTransient<IFileStorageGateway, LocalFileStorageGateway>();
         services.AddTransient<IDatasetPreparationsGateway, DatasetPreparationsGateway>();
+        services.AddTransient<IDatasetPreparationArtifactsGateway, DatasetPreparationArtifactsGateway>();
         services.AddTransient<IProcessedDatasetsGateway, ProcessedDatasetsGateway>();
         services.AddTransient<IModelsRegistryGateway, ModelsRegistryGateway>();
         services.AddTransient<IActiveModelPointerGateway, ActiveModelPointerGateway>();

--- a/src/Backend/Sudoku/Infrastructure/Storage/DatasetPreparationArtifactsGateway.cs
+++ b/src/Backend/Sudoku/Infrastructure/Storage/DatasetPreparationArtifactsGateway.cs
@@ -1,0 +1,290 @@
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using Sudoku.Application.Abstractions;
+using Sudoku.Application.Datasets;
+
+namespace Sudoku.Infrastructure.Storage;
+
+public sealed class DatasetPreparationArtifactsGateway : IDatasetPreparationArtifactsGateway
+{
+    private const string BoardSourceType = "board";
+    private const string DigitSourceType = "digit";
+    private const string ProcessedPreparationsDirectoryName = "preparations";
+    private const string FoldersManifestFileName = "folders.json";
+    private const string BoardFilesManifestFileName = "file.json";
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly IFileStorageGateway _fileStorageGateway;
+    private readonly DatasetsPreparationOptions _datasetsPreparationOptions;
+
+    public DatasetPreparationArtifactsGateway(
+        IFileStorageGateway fileStorageGateway,
+        IOptions<DatasetsPreparationOptions> datasetsPreparationOptions)
+    {
+        _fileStorageGateway = fileStorageGateway;
+        _datasetsPreparationOptions = datasetsPreparationOptions.Value;
+    }
+
+    public async Task<IReadOnlyList<string>> GetSourceFolderNamesAsync(
+        string preparationName,
+        string sourceType,
+        CancellationToken cancellationToken = default)
+    {
+        var sourceDirectoryPath = await ResolveSourceDirectoryPathAsync(
+            preparationName,
+            sourceType,
+            cancellationToken);
+        await using var stream = await _fileStorageGateway.OpenReadAsync(
+            sourceDirectoryPath,
+            FoldersManifestFileName,
+            cancellationToken);
+
+        var items = await JsonSerializer.DeserializeAsync<string[]>(
+            stream,
+            JsonSerializerOptions,
+            cancellationToken);
+
+        if (items is null)
+        {
+            throw new InvalidDataException(
+                $"Manifest folderów preparation '{preparationName}' dla typu '{sourceType}' ma nieprawidłową zawartość.");
+        }
+
+        if (items.Any(string.IsNullOrWhiteSpace))
+        {
+            throw new InvalidDataException(
+                $"Manifest folderów preparation '{preparationName}' dla typu '{sourceType}' zawiera puste wpisy.");
+        }
+
+        return items;
+    }
+
+    public async Task<IReadOnlyList<string>> GetBoardFileNamesAsync(
+        string preparationName,
+        string sourceName,
+        CancellationToken cancellationToken = default)
+    {
+        var boardSourceDirectoryPath = await ResolveBoardSourceDirectoryPathAsync(
+            preparationName,
+            sourceName,
+            cancellationToken);
+        await using var stream = await _fileStorageGateway.OpenReadAsync(
+            boardSourceDirectoryPath,
+            BoardFilesManifestFileName,
+            cancellationToken);
+
+        var items = await JsonSerializer.DeserializeAsync<string[]>(
+            stream,
+            JsonSerializerOptions,
+            cancellationToken);
+
+        if (items is null)
+        {
+            throw new InvalidDataException(
+                $"Manifest plików plansz preparation '{preparationName}' dla źródła '{sourceName}' ma nieprawidłową zawartość.");
+        }
+
+        if (items.Any(string.IsNullOrWhiteSpace))
+        {
+            throw new InvalidDataException(
+                $"Manifest plików plansz preparation '{preparationName}' dla źródła '{sourceName}' zawiera puste wpisy.");
+        }
+
+        return items;
+    }
+
+    public Task<Stream> OpenBoardArtifactReadAsync(
+        string preparationName,
+        string sourceName,
+        string boardFolderName,
+        string artifactFileName,
+        CancellationToken cancellationToken = default)
+    {
+        return OpenBoardArtifactReadInternalAsync(
+            preparationName,
+            sourceName,
+            boardFolderName,
+            artifactFileName,
+            cancellationToken);
+    }
+
+    public async Task ReplaceBoardFileNamesAsync(
+        string preparationName,
+        string sourceName,
+        IReadOnlyList<string> boardFileNames,
+        CancellationToken cancellationToken = default)
+    {
+        var boardSourceDirectoryPath = await ResolveBoardSourceDirectoryPathAsync(
+            preparationName,
+            sourceName,
+            cancellationToken);
+        await using var payloadStream = new MemoryStream(
+            JsonSerializer.SerializeToUtf8Bytes(boardFileNames, JsonSerializerOptions));
+
+        await _fileStorageGateway.ReplaceAsync(
+            boardSourceDirectoryPath,
+            BoardFilesManifestFileName,
+            payloadStream,
+            cancellationToken);
+    }
+
+    public Task DeleteBoardDirectoryAsync(
+        string preparationName,
+        string sourceName,
+        string boardFolderName,
+        CancellationToken cancellationToken = default)
+    {
+        return DeleteBoardDirectoryInternalAsync(
+            preparationName,
+            sourceName,
+            boardFolderName,
+            cancellationToken);
+    }
+
+    private async Task<Stream> OpenBoardArtifactReadInternalAsync(
+        string preparationName,
+        string sourceName,
+        string boardFolderName,
+        string artifactFileName,
+        CancellationToken cancellationToken)
+    {
+        var boardArtifactDirectoryPath = await ResolveBoardArtifactDirectoryPathAsync(
+            preparationName,
+            sourceName,
+            boardFolderName,
+            cancellationToken);
+
+        return await _fileStorageGateway.OpenReadAsync(
+            boardArtifactDirectoryPath,
+            artifactFileName,
+            cancellationToken);
+    }
+
+    private async Task DeleteBoardDirectoryInternalAsync(
+        string preparationName,
+        string sourceName,
+        string boardFolderName,
+        CancellationToken cancellationToken)
+    {
+        var boardSourceDirectoryPath = await ResolveBoardSourceDirectoryPathAsync(
+            preparationName,
+            sourceName,
+            cancellationToken);
+
+        await _fileStorageGateway.DeleteDirectoryAsync(
+            boardSourceDirectoryPath,
+            boardFolderName,
+            cancellationToken);
+    }
+
+    private async Task<string> ResolveSourceDirectoryPathAsync(
+        string preparationName,
+        string sourceType,
+        CancellationToken cancellationToken)
+    {
+        var sourceDirectoryName = MapSourceTypeDirectoryName(sourceType);
+
+        foreach (var preparationArtifactsRootPath in GetPreparationArtifactsRootCandidates(preparationName))
+        {
+            var sourceDirectoryPath = Path.Combine(preparationArtifactsRootPath, sourceDirectoryName);
+            if (await _fileStorageGateway.FileExistsAsync(
+                    sourceDirectoryPath,
+                    FoldersManifestFileName,
+                    cancellationToken))
+            {
+                return sourceDirectoryPath;
+            }
+        }
+
+        return Path.Combine(BuildPreparationMetadataRootPath(preparationName), sourceDirectoryName);
+    }
+
+    private async Task<string> ResolveBoardSourceDirectoryPathAsync(
+        string preparationName,
+        string sourceName,
+        CancellationToken cancellationToken)
+    {
+        foreach (var preparationArtifactsRootPath in GetPreparationArtifactsRootCandidates(preparationName))
+        {
+            var boardSourceDirectoryPath = Path.Combine(
+                preparationArtifactsRootPath,
+                BoardSourceType,
+                sourceName);
+            if (await _fileStorageGateway.FileExistsAsync(
+                    boardSourceDirectoryPath,
+                    BoardFilesManifestFileName,
+                    cancellationToken))
+            {
+                return boardSourceDirectoryPath;
+            }
+        }
+
+        return Path.Combine(
+            BuildPreparationMetadataRootPath(preparationName),
+            BoardSourceType,
+            sourceName);
+    }
+
+    private async Task<string> ResolveBoardArtifactDirectoryPathAsync(
+        string preparationName,
+        string sourceName,
+        string boardFolderName,
+        CancellationToken cancellationToken)
+    {
+        var boardSourceDirectoryPath = await ResolveBoardSourceDirectoryPathAsync(
+            preparationName,
+            sourceName,
+            cancellationToken);
+
+        return Path.Combine(
+            boardSourceDirectoryPath,
+            boardFolderName);
+    }
+
+    private IEnumerable<string> GetPreparationArtifactsRootCandidates(string preparationName)
+    {
+        var seenPaths = new HashSet<string>(StringComparer.Ordinal);
+        var candidatePaths =
+            new[]
+            {
+                BuildPreparationMetadataRootPath(preparationName),
+                BuildProcessedPreparationArtifactsRootPath(preparationName)
+            };
+
+        foreach (var candidatePath in candidatePaths.Select(Path.GetFullPath))
+        {
+            if (seenPaths.Add(candidatePath))
+            {
+                yield return candidatePath;
+            }
+        }
+    }
+
+    private string BuildPreparationMetadataRootPath(string preparationName)
+    {
+        return Path.Combine(_datasetsPreparationOptions.PreparationsDirectoryPath, preparationName);
+    }
+
+    private string BuildProcessedPreparationArtifactsRootPath(string preparationName)
+    {
+        return Path.Combine(
+            _datasetsPreparationOptions.ProcessedDatasetsDirectoryPath,
+            ProcessedPreparationsDirectoryName,
+            preparationName);
+    }
+
+    private static string MapSourceTypeDirectoryName(string sourceType)
+    {
+        if (string.Equals(sourceType, BoardSourceType, StringComparison.OrdinalIgnoreCase))
+        {
+            return BoardSourceType;
+        }
+
+        if (string.Equals(sourceType, DigitSourceType, StringComparison.OrdinalIgnoreCase))
+        {
+            return DigitSourceType;
+        }
+
+        throw new InvalidOperationException($"Nieobsługiwany typ preparation artifacts: '{sourceType}'.");
+    }
+}

--- a/src/Backend/Sudoku/Sudoku/Contracts/DatasetPreparationBoardFileListItemApiResponse.cs
+++ b/src/Backend/Sudoku/Sudoku/Contracts/DatasetPreparationBoardFileListItemApiResponse.cs
@@ -1,0 +1,5 @@
+namespace Sudoku.Contracts;
+
+public sealed record DatasetPreparationBoardFileListItemApiResponse(
+    string BoardFolderName,
+    string ImageEndpoint);

--- a/src/Backend/Sudoku/Sudoku/Contracts/DatasetPreparationBoardFilesApiResponse.cs
+++ b/src/Backend/Sudoku/Sudoku/Contracts/DatasetPreparationBoardFilesApiResponse.cs
@@ -1,0 +1,9 @@
+namespace Sudoku.Contracts;
+
+public sealed record DatasetPreparationBoardFilesApiResponse(
+    string PreparationName,
+    string SourceName,
+    IReadOnlyList<DatasetPreparationBoardFileListItemApiResponse> Items,
+    int Page,
+    int PageSize,
+    int TotalCount);

--- a/src/Backend/Sudoku/Sudoku/Contracts/DatasetPreparationFoldersApiResponse.cs
+++ b/src/Backend/Sudoku/Sudoku/Contracts/DatasetPreparationFoldersApiResponse.cs
@@ -1,0 +1,7 @@
+namespace Sudoku.Contracts;
+
+public sealed record DatasetPreparationFoldersApiResponse(
+    string PreparationName,
+    string Type,
+    IReadOnlyList<string> Items,
+    int TotalCount);

--- a/src/Backend/Sudoku/Sudoku/Contracts/DeleteDatasetPreparationBoardFileApiResponse.cs
+++ b/src/Backend/Sudoku/Sudoku/Contracts/DeleteDatasetPreparationBoardFileApiResponse.cs
@@ -1,0 +1,8 @@
+namespace Sudoku.Contracts;
+
+public sealed record DeleteDatasetPreparationBoardFileApiResponse(
+    string PreparationName,
+    string SourceName,
+    string BoardFolderName,
+    bool Deleted,
+    int RemainingItemsCount);

--- a/src/Backend/Sudoku/Sudoku/Controllers/DatasetsController.cs
+++ b/src/Backend/Sudoku/Sudoku/Controllers/DatasetsController.cs
@@ -150,6 +150,522 @@ public sealed class DatasetsController : ControllerBase
     }
 
     [Authorize]
+    [HttpGet("preparations/{preparationName}/board/folders")]
+    [ProducesResponseType(typeof(DatasetPreparationFoldersApiResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetPreparationBoardFoldersAsync(
+        [FromRoute] string? preparationName,
+        CancellationToken cancellationToken)
+    {
+        const string type = "board";
+
+        _logger.LogInformation(
+            "Rozpoczęto odczyt listy folderów preparation. PreparationName={PreparationName}, Type={Type}.",
+            preparationName,
+            type);
+
+        try
+        {
+            var result = await _sender.Send(
+                new GetDatasetPreparationFoldersQuery(preparationName, type),
+                cancellationToken);
+            var response = ToDatasetPreparationFoldersApiResponse(result);
+
+            _logger.LogInformation(
+                "Zakończono odczyt listy folderów preparation. PreparationName={PreparationName}, Type={Type}, TotalCount={TotalCount}.",
+                response.PreparationName,
+                response.Type,
+                response.TotalCount);
+
+            return Ok(response);
+        }
+        catch (ValidationException exception)
+        {
+            return MapDatasetPreparationFoldersValidationError(exception);
+        }
+        catch (DatasetPreparationNotFoundException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Nie znaleziono przygotowania datasetu dla odczytu folderów. PreparationName={PreparationName}, Type={Type}, ErrorType={ErrorType}.",
+                preparationName,
+                type,
+                GetDatasetPreparationFoldersErrorTypes.DatasetPreparationNotFound);
+
+            return NotFound(new ErrorApiResponse(
+                ErrorType: GetDatasetPreparationFoldersErrorTypes.DatasetPreparationNotFound,
+                Message: exception.Message));
+        }
+        catch (DatasetPreparationArtifactsNotReadyException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Przygotowanie datasetu nie jest gotowe do odczytu folderów. PreparationName={PreparationName}, Type={Type}, Status={Status}, ErrorType={ErrorType}.",
+                exception.PreparationName,
+                type,
+                exception.Status,
+                GetDatasetPreparationFoldersErrorTypes.DatasetPreparationArtifactsNotReady);
+
+            return Conflict(new ErrorApiResponse(
+                ErrorType: GetDatasetPreparationFoldersErrorTypes.DatasetPreparationArtifactsNotReady,
+                Message: exception.Message));
+        }
+        catch (Exception exception) when (exception is IOException
+                                         or UnauthorizedAccessException
+                                         or InvalidDataException
+                                         or JsonException
+                                         or FileStorageItemNotFoundException)
+        {
+            _logger.LogError(
+                exception,
+                "Nie udało się odczytać listy folderów preparation. PreparationName={PreparationName}, Type={Type}, ErrorType={ErrorType}.",
+                preparationName,
+                type,
+                GetDatasetPreparationFoldersErrorTypes.DatasetPreparationFoldersReadFailed);
+
+            return StatusCode(
+                StatusCodes.Status500InternalServerError,
+                new ErrorApiResponse(
+                    ErrorType: GetDatasetPreparationFoldersErrorTypes.DatasetPreparationFoldersReadFailed,
+                    Message: "Nie udało się odczytać listy folderów preparation."));
+        }
+    }
+
+    [Authorize]
+    [HttpGet("preparations/{preparationName}/digit/folders")]
+    [ProducesResponseType(typeof(DatasetPreparationFoldersApiResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetPreparationDigitFoldersAsync(
+        [FromRoute] string? preparationName,
+        CancellationToken cancellationToken)
+    {
+        const string type = "digit";
+
+        _logger.LogInformation(
+            "Rozpoczęto odczyt listy folderów preparation. PreparationName={PreparationName}, Type={Type}.",
+            preparationName,
+            type);
+
+        try
+        {
+            var result = await _sender.Send(
+                new GetDatasetPreparationFoldersQuery(preparationName, type),
+                cancellationToken);
+            var response = ToDatasetPreparationFoldersApiResponse(result);
+
+            _logger.LogInformation(
+                "Zakończono odczyt listy folderów preparation. PreparationName={PreparationName}, Type={Type}, TotalCount={TotalCount}.",
+                response.PreparationName,
+                response.Type,
+                response.TotalCount);
+
+            return Ok(response);
+        }
+        catch (ValidationException exception)
+        {
+            return MapDatasetPreparationFoldersValidationError(exception);
+        }
+        catch (DatasetPreparationNotFoundException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Nie znaleziono przygotowania datasetu dla odczytu folderów. PreparationName={PreparationName}, Type={Type}, ErrorType={ErrorType}.",
+                preparationName,
+                type,
+                GetDatasetPreparationFoldersErrorTypes.DatasetPreparationNotFound);
+
+            return NotFound(new ErrorApiResponse(
+                ErrorType: GetDatasetPreparationFoldersErrorTypes.DatasetPreparationNotFound,
+                Message: exception.Message));
+        }
+        catch (DatasetPreparationArtifactsNotReadyException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Przygotowanie datasetu nie jest gotowe do odczytu folderów. PreparationName={PreparationName}, Type={Type}, Status={Status}, ErrorType={ErrorType}.",
+                exception.PreparationName,
+                type,
+                exception.Status,
+                GetDatasetPreparationFoldersErrorTypes.DatasetPreparationArtifactsNotReady);
+
+            return Conflict(new ErrorApiResponse(
+                ErrorType: GetDatasetPreparationFoldersErrorTypes.DatasetPreparationArtifactsNotReady,
+                Message: exception.Message));
+        }
+        catch (Exception exception) when (exception is IOException
+                                         or UnauthorizedAccessException
+                                         or InvalidDataException
+                                         or JsonException
+                                         or FileStorageItemNotFoundException)
+        {
+            _logger.LogError(
+                exception,
+                "Nie udało się odczytać listy folderów preparation. PreparationName={PreparationName}, Type={Type}, ErrorType={ErrorType}.",
+                preparationName,
+                type,
+                GetDatasetPreparationFoldersErrorTypes.DatasetPreparationFoldersReadFailed);
+
+            return StatusCode(
+                StatusCodes.Status500InternalServerError,
+                new ErrorApiResponse(
+                    ErrorType: GetDatasetPreparationFoldersErrorTypes.DatasetPreparationFoldersReadFailed,
+                    Message: "Nie udało się odczytać listy folderów preparation."));
+        }
+    }
+
+    [Authorize]
+    [HttpGet("preparations/{preparationName}/board/{sourceName}/files")]
+    [ProducesResponseType(typeof(DatasetPreparationBoardFilesApiResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetPreparationBoardFilesAsync(
+        [FromRoute] string? preparationName,
+        [FromRoute] string? sourceName,
+        [FromQuery] int? page,
+        [FromQuery] int? pageSize,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Rozpoczęto odczyt listy plansz preparation. PreparationName={PreparationName}, SourceName={SourceName}, Page={Page}, PageSize={PageSize}.",
+            preparationName,
+            sourceName,
+            page,
+            pageSize);
+
+        try
+        {
+            var result = await _sender.Send(
+                new GetDatasetPreparationBoardFilesQuery(preparationName, sourceName, page, pageSize),
+                cancellationToken);
+            var response = ToDatasetPreparationBoardFilesApiResponse(result);
+
+            _logger.LogInformation(
+                "Zakończono odczyt listy plansz preparation. PreparationName={PreparationName}, SourceName={SourceName}, Page={Page}, PageSize={PageSize}, TotalCount={TotalCount}, ReturnedItemsCount={ReturnedItemsCount}.",
+                response.PreparationName,
+                response.SourceName,
+                response.Page,
+                response.PageSize,
+                response.TotalCount,
+                response.Items.Count);
+
+            return Ok(response);
+        }
+        catch (ValidationException exception)
+        {
+            return MapDatasetPreparationBoardFilesValidationError(exception);
+        }
+        catch (DatasetPreparationNotFoundException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Nie znaleziono przygotowania datasetu dla odczytu listy plansz. PreparationName={PreparationName}, SourceName={SourceName}, ErrorType={ErrorType}.",
+                preparationName,
+                sourceName,
+                GetDatasetPreparationBoardFilesErrorTypes.DatasetPreparationNotFound);
+
+            return NotFound(new ErrorApiResponse(
+                ErrorType: GetDatasetPreparationBoardFilesErrorTypes.DatasetPreparationNotFound,
+                Message: exception.Message));
+        }
+        catch (DatasetPreparationSourceNotFoundException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Nie znaleziono źródła board dla odczytu listy plansz. PreparationName={PreparationName}, SourceName={SourceName}, ErrorType={ErrorType}.",
+                exception.PreparationName,
+                exception.SourceName,
+                GetDatasetPreparationBoardFilesErrorTypes.DatasetPreparationSourceNotFound);
+
+            return NotFound(new ErrorApiResponse(
+                ErrorType: GetDatasetPreparationBoardFilesErrorTypes.DatasetPreparationSourceNotFound,
+                Message: exception.Message));
+        }
+        catch (DatasetPreparationArtifactsNotReadyException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Przygotowanie datasetu nie jest gotowe do odczytu listy plansz. PreparationName={PreparationName}, SourceName={SourceName}, Status={Status}, ErrorType={ErrorType}.",
+                exception.PreparationName,
+                sourceName,
+                exception.Status,
+                GetDatasetPreparationBoardFilesErrorTypes.DatasetPreparationArtifactsNotReady);
+
+            return Conflict(new ErrorApiResponse(
+                ErrorType: GetDatasetPreparationBoardFilesErrorTypes.DatasetPreparationArtifactsNotReady,
+                Message: exception.Message));
+        }
+        catch (Exception exception) when (exception is IOException
+                                         or UnauthorizedAccessException
+                                         or InvalidDataException
+                                         or JsonException
+                                         or FileStorageItemNotFoundException)
+        {
+            _logger.LogError(
+                exception,
+                "Nie udało się odczytać listy plansz preparation. PreparationName={PreparationName}, SourceName={SourceName}, ErrorType={ErrorType}.",
+                preparationName,
+                sourceName,
+                GetDatasetPreparationBoardFilesErrorTypes.DatasetPreparationBoardFilesReadFailed);
+
+            return StatusCode(
+                StatusCodes.Status500InternalServerError,
+                new ErrorApiResponse(
+                    ErrorType: GetDatasetPreparationBoardFilesErrorTypes.DatasetPreparationBoardFilesReadFailed,
+                    Message: "Nie udało się odczytać listy plansz preparation."));
+        }
+    }
+
+    [Authorize]
+    [HttpGet("preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}/image")]
+    [ProducesResponseType(typeof(ImageApiResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetPreparationBoardImageAsync(
+        [FromRoute] string? preparationName,
+        [FromRoute] string? sourceName,
+        [FromRoute] string? boardFolderName,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Rozpoczęto odczyt obrazu planszy preparation. PreparationName={PreparationName}, SourceName={SourceName}, BoardFolderName={BoardFolderName}.",
+            preparationName,
+            sourceName,
+            boardFolderName);
+
+        try
+        {
+            var result = await _sender.Send(
+                new GetDatasetPreparationBoardImageQuery(preparationName, sourceName, boardFolderName),
+                cancellationToken);
+            var response = ToImageApiResponse(result);
+
+            _logger.LogInformation(
+                "Zakończono odczyt obrazu planszy preparation. PreparationName={PreparationName}, SourceName={SourceName}, BoardFolderName={BoardFolderName}, MimeType={MimeType}.",
+                preparationName,
+                sourceName,
+                boardFolderName,
+                response.MimeType);
+
+            return Ok(response);
+        }
+        catch (ValidationException exception)
+        {
+            return MapDatasetPreparationBoardImageValidationError(exception);
+        }
+        catch (DatasetPreparationNotFoundException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Nie znaleziono przygotowania datasetu dla odczytu obrazu planszy. PreparationName={PreparationName}, SourceName={SourceName}, BoardFolderName={BoardFolderName}, ErrorType={ErrorType}.",
+                preparationName,
+                sourceName,
+                boardFolderName,
+                GetDatasetPreparationBoardImageErrorTypes.DatasetPreparationNotFound);
+
+            return NotFound(new ErrorApiResponse(
+                ErrorType: GetDatasetPreparationBoardImageErrorTypes.DatasetPreparationNotFound,
+                Message: exception.Message));
+        }
+        catch (DatasetPreparationSourceNotFoundException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Nie znaleziono źródła board dla odczytu obrazu planszy. PreparationName={PreparationName}, SourceName={SourceName}, BoardFolderName={BoardFolderName}, ErrorType={ErrorType}.",
+                exception.PreparationName,
+                exception.SourceName,
+                boardFolderName,
+                GetDatasetPreparationBoardImageErrorTypes.DatasetPreparationSourceNotFound);
+
+            return NotFound(new ErrorApiResponse(
+                ErrorType: GetDatasetPreparationBoardImageErrorTypes.DatasetPreparationSourceNotFound,
+                Message: exception.Message));
+        }
+        catch (DatasetPreparationBoardFileNotFoundException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Nie znaleziono planszy dla odczytu obrazu preparation. PreparationName={PreparationName}, SourceName={SourceName}, BoardFolderName={BoardFolderName}, ErrorType={ErrorType}.",
+                exception.PreparationName,
+                exception.SourceName,
+                exception.BoardFolderName,
+                GetDatasetPreparationBoardImageErrorTypes.DatasetPreparationBoardFileNotFound);
+
+            return NotFound(new ErrorApiResponse(
+                ErrorType: GetDatasetPreparationBoardImageErrorTypes.DatasetPreparationBoardFileNotFound,
+                Message: exception.Message));
+        }
+        catch (DatasetPreparationArtifactsNotReadyException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Przygotowanie datasetu nie jest gotowe do odczytu obrazu planszy. PreparationName={PreparationName}, SourceName={SourceName}, BoardFolderName={BoardFolderName}, Status={Status}, ErrorType={ErrorType}.",
+                exception.PreparationName,
+                sourceName,
+                boardFolderName,
+                exception.Status,
+                GetDatasetPreparationBoardImageErrorTypes.DatasetPreparationArtifactsNotReady);
+
+            return Conflict(new ErrorApiResponse(
+                ErrorType: GetDatasetPreparationBoardImageErrorTypes.DatasetPreparationArtifactsNotReady,
+                Message: exception.Message));
+        }
+        catch (Exception exception) when (exception is IOException
+                                         or UnauthorizedAccessException
+                                         or InvalidDataException
+                                         or JsonException
+                                         or FileStorageItemNotFoundException)
+        {
+            _logger.LogError(
+                exception,
+                "Nie udało się odczytać obrazu planszy preparation. PreparationName={PreparationName}, SourceName={SourceName}, BoardFolderName={BoardFolderName}, ErrorType={ErrorType}.",
+                preparationName,
+                sourceName,
+                boardFolderName,
+                GetDatasetPreparationBoardImageErrorTypes.DatasetPreparationBoardImageReadFailed);
+
+            return StatusCode(
+                StatusCodes.Status500InternalServerError,
+                new ErrorApiResponse(
+                    ErrorType: GetDatasetPreparationBoardImageErrorTypes.DatasetPreparationBoardImageReadFailed,
+                    Message: "Nie udało się odczytać obrazu planszy preparation."));
+        }
+    }
+
+    [Authorize]
+    [HttpDelete("preparations/{preparationName}/board/{sourceName}/files/{boardFolderName}")]
+    [ProducesResponseType(typeof(DeleteDatasetPreparationBoardFileApiResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> DeletePreparationBoardFileAsync(
+        [FromRoute] string? preparationName,
+        [FromRoute] string? sourceName,
+        [FromRoute] string? boardFolderName,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Rozpoczęto usuwanie planszy preparation. PreparationName={PreparationName}, SourceName={SourceName}, BoardFolderName={BoardFolderName}.",
+            preparationName,
+            sourceName,
+            boardFolderName);
+
+        try
+        {
+            var result = await _sender.Send(
+                new DeleteDatasetPreparationBoardFileCommand(preparationName, sourceName, boardFolderName),
+                cancellationToken);
+            var response = ToDeleteDatasetPreparationBoardFileApiResponse(result);
+
+            _logger.LogInformation(
+                "Zakończono usuwanie planszy preparation. PreparationName={PreparationName}, SourceName={SourceName}, BoardFolderName={BoardFolderName}, Deleted={Deleted}, RemainingItemsCount={RemainingItemsCount}.",
+                response.PreparationName,
+                response.SourceName,
+                response.BoardFolderName,
+                response.Deleted,
+                response.RemainingItemsCount);
+
+            return Ok(response);
+        }
+        catch (ValidationException exception)
+        {
+            return MapDeleteDatasetPreparationBoardFileValidationError(exception);
+        }
+        catch (DatasetPreparationNotFoundException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Nie znaleziono przygotowania datasetu dla usunięcia planszy. PreparationName={PreparationName}, SourceName={SourceName}, BoardFolderName={BoardFolderName}, ErrorType={ErrorType}.",
+                preparationName,
+                sourceName,
+                boardFolderName,
+                DeleteDatasetPreparationBoardFileErrorTypes.DatasetPreparationNotFound);
+
+            return NotFound(new ErrorApiResponse(
+                ErrorType: DeleteDatasetPreparationBoardFileErrorTypes.DatasetPreparationNotFound,
+                Message: exception.Message));
+        }
+        catch (DatasetPreparationSourceNotFoundException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Nie znaleziono źródła board dla usunięcia planszy. PreparationName={PreparationName}, SourceName={SourceName}, BoardFolderName={BoardFolderName}, ErrorType={ErrorType}.",
+                exception.PreparationName,
+                exception.SourceName,
+                boardFolderName,
+                DeleteDatasetPreparationBoardFileErrorTypes.DatasetPreparationSourceNotFound);
+
+            return NotFound(new ErrorApiResponse(
+                ErrorType: DeleteDatasetPreparationBoardFileErrorTypes.DatasetPreparationSourceNotFound,
+                Message: exception.Message));
+        }
+        catch (DatasetPreparationBoardFileNotFoundException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Nie znaleziono planszy do usunięcia. PreparationName={PreparationName}, SourceName={SourceName}, BoardFolderName={BoardFolderName}, ErrorType={ErrorType}.",
+                exception.PreparationName,
+                exception.SourceName,
+                exception.BoardFolderName,
+                DeleteDatasetPreparationBoardFileErrorTypes.DatasetPreparationBoardFileNotFound);
+
+            return NotFound(new ErrorApiResponse(
+                ErrorType: DeleteDatasetPreparationBoardFileErrorTypes.DatasetPreparationBoardFileNotFound,
+                Message: exception.Message));
+        }
+        catch (DatasetPreparationArtifactsNotReadyException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Przygotowanie datasetu nie jest gotowe do usunięcia planszy. PreparationName={PreparationName}, SourceName={SourceName}, BoardFolderName={BoardFolderName}, Status={Status}, ErrorType={ErrorType}.",
+                exception.PreparationName,
+                sourceName,
+                boardFolderName,
+                exception.Status,
+                DeleteDatasetPreparationBoardFileErrorTypes.DatasetPreparationArtifactsNotReady);
+
+            return Conflict(new ErrorApiResponse(
+                ErrorType: DeleteDatasetPreparationBoardFileErrorTypes.DatasetPreparationArtifactsNotReady,
+                Message: exception.Message));
+        }
+        catch (Exception exception) when (exception is IOException
+                                         or UnauthorizedAccessException
+                                         or InvalidDataException
+                                         or JsonException
+                                         or FileStorageItemNotFoundException)
+        {
+            _logger.LogError(
+                exception,
+                "Nie udało się usunąć planszy preparation. PreparationName={PreparationName}, SourceName={SourceName}, BoardFolderName={BoardFolderName}, ErrorType={ErrorType}.",
+                preparationName,
+                sourceName,
+                boardFolderName,
+                DeleteDatasetPreparationBoardFileErrorTypes.DatasetPreparationBoardFileDeleteFailed);
+
+            return StatusCode(
+                StatusCodes.Status500InternalServerError,
+                new ErrorApiResponse(
+                    ErrorType: DeleteDatasetPreparationBoardFileErrorTypes.DatasetPreparationBoardFileDeleteFailed,
+                    Message: "Nie udało się usunąć planszy preparation."));
+        }
+    }
+
+    [Authorize]
     [HttpPost("preparations")]
     [ProducesResponseType(typeof(DatasetPreparationApiResponse), StatusCodes.Status202Accepted)]
     [ProducesResponseType(typeof(ErrorApiResponse), StatusCodes.Status400BadRequest)]
@@ -398,6 +914,35 @@ public sealed class DatasetsController : ControllerBase
             Warnings: result.Warnings);
     }
 
+    private static DatasetPreparationFoldersApiResponse ToDatasetPreparationFoldersApiResponse(
+        GetDatasetPreparationFoldersQueryResultDto result)
+    {
+        return new DatasetPreparationFoldersApiResponse(
+            PreparationName: result.PreparationName,
+            Type: result.Type,
+            Items: result.Items,
+            TotalCount: result.TotalCount);
+    }
+
+    private static DatasetPreparationBoardFilesApiResponse ToDatasetPreparationBoardFilesApiResponse(
+        GetDatasetPreparationBoardFilesQueryResultDto result)
+    {
+        return new DatasetPreparationBoardFilesApiResponse(
+            PreparationName: result.PreparationName,
+            SourceName: result.SourceName,
+            Items: result.Items
+                .Select(item => new DatasetPreparationBoardFileListItemApiResponse(
+                    BoardFolderName: item.BoardFolderName,
+                    ImageEndpoint: BuildDatasetPreparationBoardImageEndpoint(
+                        result.PreparationName,
+                        result.SourceName,
+                        item.BoardFolderName)))
+                .ToArray(),
+            Page: result.Page,
+            PageSize: result.PageSize,
+            TotalCount: result.TotalCount);
+    }
+
     private static DatasetPreparationListItemApiResponse ToDatasetPreparationListItemApiResponse(
         DatasetPreparationListItemDto item)
     {
@@ -407,6 +952,24 @@ public sealed class DatasetsController : ControllerBase
             Status: item.Status,
             BoardSourcesCount: item.BoardSourcesCount,
             DigitSourcesCount: item.DigitSourcesCount);
+    }
+
+    private static ImageApiResponse ToImageApiResponse(GetDatasetPreparationBoardImageQueryResultDto result)
+    {
+        return new ImageApiResponse(
+            MimeType: result.MimeType,
+            Base64: result.Base64);
+    }
+
+    private static DeleteDatasetPreparationBoardFileApiResponse ToDeleteDatasetPreparationBoardFileApiResponse(
+        DeleteDatasetPreparationBoardFileCommandResultDto result)
+    {
+        return new DeleteDatasetPreparationBoardFileApiResponse(
+            PreparationName: result.PreparationName,
+            SourceName: result.SourceName,
+            BoardFolderName: result.BoardFolderName,
+            Deleted: result.Deleted,
+            RemainingItemsCount: result.RemainingItemsCount);
     }
 
     private static IActionResult MapValidationError(ValidationException exception)
@@ -454,5 +1017,69 @@ public sealed class DatasetsController : ControllerBase
         {
             StatusCode = StatusCodes.Status400BadRequest
         };
+    }
+
+    private static IActionResult MapDatasetPreparationFoldersValidationError(ValidationException exception)
+    {
+        var failure = exception.Errors.FirstOrDefault();
+        var errorType = failure?.ErrorCode ?? GetDatasetPreparationFoldersErrorTypes.InvalidDatasetPreparationName;
+        var message = failure?.ErrorMessage ?? "Nieprawidłowe parametry odczytu folderów preparation.";
+
+        return new ObjectResult(new ErrorApiResponse(
+            ErrorType: errorType,
+            Message: message))
+        {
+            StatusCode = StatusCodes.Status400BadRequest
+        };
+    }
+
+    private static IActionResult MapDatasetPreparationBoardFilesValidationError(ValidationException exception)
+    {
+        var failure = exception.Errors.FirstOrDefault();
+        var errorType = failure?.ErrorCode ?? GetDatasetPreparationBoardFilesErrorTypes.InvalidDatasetPreparationName;
+        var message = failure?.ErrorMessage ?? "Nieprawidłowe parametry odczytu listy plansz preparation.";
+
+        return new ObjectResult(new ErrorApiResponse(
+            ErrorType: errorType,
+            Message: message))
+        {
+            StatusCode = StatusCodes.Status400BadRequest
+        };
+    }
+
+    private static IActionResult MapDatasetPreparationBoardImageValidationError(ValidationException exception)
+    {
+        var failure = exception.Errors.FirstOrDefault();
+        var errorType = failure?.ErrorCode ?? GetDatasetPreparationBoardImageErrorTypes.InvalidDatasetPreparationName;
+        var message = failure?.ErrorMessage ?? "Nieprawidłowe parametry odczytu obrazu planszy preparation.";
+
+        return new ObjectResult(new ErrorApiResponse(
+            ErrorType: errorType,
+            Message: message))
+        {
+            StatusCode = StatusCodes.Status400BadRequest
+        };
+    }
+
+    private static IActionResult MapDeleteDatasetPreparationBoardFileValidationError(ValidationException exception)
+    {
+        var failure = exception.Errors.FirstOrDefault();
+        var errorType = failure?.ErrorCode ?? DeleteDatasetPreparationBoardFileErrorTypes.InvalidDatasetPreparationName;
+        var message = failure?.ErrorMessage ?? "Nieprawidłowe parametry usuwania planszy preparation.";
+
+        return new ObjectResult(new ErrorApiResponse(
+            ErrorType: errorType,
+            Message: message))
+        {
+            StatusCode = StatusCodes.Status400BadRequest
+        };
+    }
+
+    private static string BuildDatasetPreparationBoardImageEndpoint(
+        string preparationName,
+        string sourceName,
+        string boardFolderName)
+    {
+        return $"/api/datasets/preparations/{Uri.EscapeDataString(preparationName)}/board/{Uri.EscapeDataString(sourceName)}/files/{Uri.EscapeDataString(boardFolderName)}/image";
     }
 }

--- a/src/Frontend/src/App.tsx
+++ b/src/Frontend/src/App.tsx
@@ -199,11 +199,13 @@ export default function App() {
       ? "UC-11 — Przeglad kandydatow raw"
       : datasetsStep === "uc17"
         ? "UC-17 — Przygotowanie datasetu"
-      : datasetsStep === "uc12"
-        ? "UC-12 — Legacy: budowa datasetu processed"
-        : datasetsStep === "uc06"
-          ? "UC-06 — Start i monitoring treningu"
-          : "UC-08 — Katalog runow i modeli";
+        : datasetsStep === "uc18"
+          ? "UC-18 — Przeglad zrodel preparation"
+          : datasetsStep === "uc12"
+            ? "UC-12 — Legacy: budowa datasetu processed"
+            : datasetsStep === "uc06"
+              ? "UC-06 — Start i monitoring treningu"
+              : "UC-08 — Katalog runow i modeli";
 
   async function handleAdminLoginSubmit() {
     if (!adminPassword.trim()) {

--- a/src/Frontend/src/api/datasetPreparations.ts
+++ b/src/Frontend/src/api/datasetPreparations.ts
@@ -1,16 +1,25 @@
 import type {
+  DeleteDatasetPreparationBoardFileApiResponse,
+  DatasetPreparationBoardFileListItemApiResponse,
+  DatasetPreparationBoardFilesApiResponse,
   CreateDatasetPreparationApiEntry,
   DatasetPreparationApiResponse,
+  DatasetPreparationFoldersApiResponse,
   DatasetPreparationListItemApiResponse,
   DatasetPreparationsListApiResponse,
+  ImageApiResponse,
   DatasetPreparationSourceApiResponse,
 } from "../types/api";
 import {
   fetchJson,
   JsonApiError,
 } from "./shared/fetchJson";
+import { isImageApiResponse } from "./shared/isImageApiResponse";
+import { resolveUc18BoardImageRequestUrl } from "../features/uc18/domain/resolveUc18BoardImageRequestUrl";
 
 export class DatasetPreparationsApiError extends JsonApiError {}
+
+export type DatasetPreparationFolderType = "board" | "digit";
 
 function buildAuthHeaders(accessToken?: string | null): HeadersInit {
   if (!accessToken) {
@@ -92,6 +101,77 @@ function isDatasetPreparationsListApiResponse(
   );
 }
 
+function isDatasetPreparationFoldersApiResponse(
+  value: unknown
+): value is DatasetPreparationFoldersApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+
+  return (
+    typeof record.preparationName === "string" &&
+    typeof record.type === "string" &&
+    Array.isArray(record.items) &&
+    record.items.every((item) => typeof item === "string") &&
+    typeof record.totalCount === "number"
+  );
+}
+
+export function isDatasetPreparationBoardFileListItemApiResponse(
+  value: unknown
+): value is DatasetPreparationBoardFileListItemApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+
+  return (
+    typeof record.boardFolderName === "string" &&
+    typeof record.imageEndpoint === "string"
+  );
+}
+
+export function isDatasetPreparationBoardFilesApiResponse(
+  value: unknown
+): value is DatasetPreparationBoardFilesApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+
+  return (
+    typeof record.preparationName === "string" &&
+    typeof record.sourceName === "string" &&
+    Array.isArray(record.items) &&
+    record.items.every(isDatasetPreparationBoardFileListItemApiResponse) &&
+    typeof record.page === "number" &&
+    typeof record.pageSize === "number" &&
+    typeof record.totalCount === "number"
+  );
+}
+
+export function isDeleteDatasetPreparationBoardFileApiResponse(
+  value: unknown
+): value is DeleteDatasetPreparationBoardFileApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+
+  return (
+    typeof record.preparationName === "string" &&
+    typeof record.sourceName === "string" &&
+    typeof record.boardFolderName === "string" &&
+    typeof record.deleted === "boolean" &&
+    typeof record.remainingItemsCount === "number"
+  );
+}
+
 export async function createDatasetPreparation(
   apiBaseUrl: string,
   entry: CreateDatasetPreparationApiEntry,
@@ -113,7 +193,7 @@ export async function createDatasetPreparation(
     expectedStatus: 202,
     validateResponse: isDatasetPreparationApiResponse,
     invalidResponseMessage:
-      "Backend zwrócił niepoprawny kształt DatasetPreparationApiResponse.",
+      "Backend zwrocil niepoprawny ksztalt DatasetPreparationApiResponse.",
     errorFactory: (message, status, errorType) =>
       new DatasetPreparationsApiError(message, status, errorType),
   });
@@ -140,7 +220,7 @@ export async function getDatasetPreparations(
     expectedStatus: 200,
     validateResponse: isDatasetPreparationsListApiResponse,
     invalidResponseMessage:
-      "Backend zwrócił niepoprawny kształt DatasetPreparationsListApiResponse.",
+      "Backend zwrocil niepoprawny ksztalt DatasetPreparationsListApiResponse.",
     errorFactory: (message, status, errorType) =>
       new DatasetPreparationsApiError(message, status, errorType),
   });
@@ -167,7 +247,141 @@ export async function getDatasetPreparationDetails(
     expectedStatus: 200,
     validateResponse: isDatasetPreparationApiResponse,
     invalidResponseMessage:
-      "Backend zwrócił niepoprawny kształt DatasetPreparationApiResponse.",
+      "Backend zwrocil niepoprawny ksztalt DatasetPreparationApiResponse.",
+    errorFactory: (message, status, errorType) =>
+      new DatasetPreparationsApiError(message, status, errorType),
+  });
+}
+
+export async function getDatasetPreparationFolders(
+  apiBaseUrl: string,
+  preparationName: string,
+  folderType: DatasetPreparationFolderType,
+  accessToken?: string | null,
+  signal?: AbortSignal
+): Promise<DatasetPreparationFoldersApiResponse> {
+  const encodedPreparationName = encodeURIComponent(preparationName);
+
+  return fetchJson<
+    DatasetPreparationFoldersApiResponse,
+    DatasetPreparationsApiError
+  >({
+    url: `${apiBaseUrl}/datasets/preparations/${encodedPreparationName}/${folderType}/folders`,
+    init: {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        ...buildAuthHeaders(accessToken),
+      },
+      signal,
+    },
+    expectedStatus: 200,
+    validateResponse: isDatasetPreparationFoldersApiResponse,
+    invalidResponseMessage:
+      "Backend zwrocil niepoprawny ksztalt DatasetPreparationFoldersApiResponse.",
+    errorFactory: (message, status, errorType) =>
+      new DatasetPreparationsApiError(message, status, errorType),
+  });
+}
+
+export async function getDatasetPreparationBoardFiles(
+  apiBaseUrl: string,
+  params: {
+    preparationName: string;
+    sourceName: string;
+    page: number;
+    pageSize: number;
+  },
+  accessToken?: string | null,
+  signal?: AbortSignal
+): Promise<DatasetPreparationBoardFilesApiResponse> {
+  const encodedPreparationName = encodeURIComponent(params.preparationName);
+  const encodedSourceName = encodeURIComponent(params.sourceName);
+  const query = new URLSearchParams({
+    page: String(params.page),
+    pageSize: String(params.pageSize),
+  });
+
+  return fetchJson<
+    DatasetPreparationBoardFilesApiResponse,
+    DatasetPreparationsApiError
+  >({
+    url: `${apiBaseUrl}/datasets/preparations/${encodedPreparationName}/board/${encodedSourceName}/files?${query.toString()}`,
+    init: {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        ...buildAuthHeaders(accessToken),
+      },
+      signal,
+    },
+    expectedStatus: 200,
+    validateResponse: isDatasetPreparationBoardFilesApiResponse,
+    invalidResponseMessage:
+      "Backend zwrocil niepoprawny ksztalt DatasetPreparationBoardFilesApiResponse.",
+    errorFactory: (message, status, errorType) =>
+      new DatasetPreparationsApiError(message, status, errorType),
+  });
+}
+
+export async function getDatasetPreparationBoardImageByEndpoint(
+  apiBaseUrl: string,
+  imageEndpoint: string,
+  accessToken?: string | null,
+  signal?: AbortSignal
+): Promise<ImageApiResponse> {
+  const url = resolveUc18BoardImageRequestUrl(apiBaseUrl, imageEndpoint);
+
+  return fetchJson<ImageApiResponse, DatasetPreparationsApiError>({
+    url,
+    init: {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        ...buildAuthHeaders(accessToken),
+      },
+      signal,
+    },
+    expectedStatus: 200,
+    validateResponse: isImageApiResponse,
+    invalidResponseMessage:
+      "Backend zwrocil niepoprawny ksztalt ImageApiResponse dla preview planszy.",
+    errorFactory: (message, status, errorType) =>
+      new DatasetPreparationsApiError(message, status, errorType),
+  });
+}
+
+export async function deleteDatasetPreparationBoardFile(
+  apiBaseUrl: string,
+  params: {
+    preparationName: string;
+    sourceName: string;
+    boardFolderName: string;
+  },
+  accessToken?: string | null,
+  signal?: AbortSignal
+): Promise<DeleteDatasetPreparationBoardFileApiResponse> {
+  const encodedPreparationName = encodeURIComponent(params.preparationName);
+  const encodedSourceName = encodeURIComponent(params.sourceName);
+  const encodedBoardFolderName = encodeURIComponent(params.boardFolderName);
+
+  return fetchJson<
+    DeleteDatasetPreparationBoardFileApiResponse,
+    DatasetPreparationsApiError
+  >({
+    url: `${apiBaseUrl}/datasets/preparations/${encodedPreparationName}/board/${encodedSourceName}/files/${encodedBoardFolderName}`,
+    init: {
+      method: "DELETE",
+      headers: {
+        Accept: "application/json",
+        ...buildAuthHeaders(accessToken),
+      },
+      signal,
+    },
+    expectedStatus: 200,
+    validateResponse: isDeleteDatasetPreparationBoardFileApiResponse,
+    invalidResponseMessage:
+      "Backend zwrocil niepoprawny ksztalt DeleteDatasetPreparationBoardFileApiResponse.",
     errorFactory: (message, status, errorType) =>
       new DatasetPreparationsApiError(message, status, errorType),
   });

--- a/src/Frontend/src/api/shared/isImageApiResponse.ts
+++ b/src/Frontend/src/api/shared/isImageApiResponse.ts
@@ -1,0 +1,13 @@
+import type { ImageApiResponse } from "../../types/api";
+
+export function isImageApiResponse(value: unknown): value is ImageApiResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+
+  return (
+    typeof record.mimeType === "string" && typeof record.base64 === "string"
+  );
+}

--- a/src/Frontend/src/app/state.ts
+++ b/src/Frontend/src/app/state.ts
@@ -217,4 +217,4 @@ export const defaultLoginState: LoginState = {
 };
 
 export type AppView = "health" | "examples" | "datasets";
-export type DatasetsStep = "uc11" | "uc17" | "uc12" | "uc06" | "uc08";
+export type DatasetsStep = "uc11" | "uc17" | "uc18" | "uc12" | "uc06" | "uc08";

--- a/src/Frontend/src/app/views/DatasetsView.tsx
+++ b/src/Frontend/src/app/views/DatasetsView.tsx
@@ -3,6 +3,7 @@ import { Uc08CatalogSection } from "../../components/Uc08CatalogSection";
 import { Uc11RawCandidatesSection } from "../../components/Uc11RawCandidatesSection";
 import { Uc12DatasetPreparationSection } from "../../components/Uc12DatasetPreparationSection";
 import { Uc17RawCandidatesSection } from "../../features/uc17/api";
+import { Uc18BoardFoldersSection } from "../../features/uc18/api";
 import type {
   TrainingRunParameterValidationResult,
 } from "../../features/uc14/domain/trainingRunParameters";
@@ -38,6 +39,12 @@ export function DatasetsView({
         accessToken={accessToken}
         onUnauthorized={onUnauthorized}
       />
+    ) : datasetsStep === "uc18" ? (
+      <Uc18BoardFoldersSection
+        apiBaseUrl={apiBaseUrl}
+        accessToken={accessToken}
+        onUnauthorized={onUnauthorized}
+      />
     ) : datasetsStep === "uc12" ? (
       <Uc12DatasetPreparationSection
         apiBaseUrl={apiBaseUrl}
@@ -66,11 +73,11 @@ export function DatasetsView({
     <>
       <section className="hero-card datasets-module-header">
         <p className="eyebrow">Workflow datasetowy</p>
-        <h2>UC-11 -&gt; UC-17 -&gt; UC-12 (legacy) -&gt; UC-06 -&gt; UC-08</h2>
+        <h2>UC-11 -&gt; UC-17 -&gt; UC-18 -&gt; UC-12 (legacy) -&gt; UC-06 -&gt; UC-08</h2>
         <p className="hero-copy">
-          Nawiguj krokami: najpierw kandydaci raw, potem przygotowanie datasetu,
-          a osobno pozostaje stary workflow `UC-12` do bezposredniego builda
-          datasetu processed.
+          Nawiguj krokami: najpierw kandydaci raw, potem przygotowanie datasetu i
+          przeglad zrodel `board`, a osobno pozostaje stary workflow `UC-12` do
+          bezposredniego builda datasetu processed.
         </p>
         <div className="datasets-stepper" role="tablist" aria-label="Kroki datasetu">
           <DatasetStepButton
@@ -84,18 +91,23 @@ export function DatasetsView({
             onClick={() => onDatasetsStepChange("uc17")}
           />
           <DatasetStepButton
+            isActive={datasetsStep === "uc18"}
+            label="3. Przeglad zrodel preparation (UC-18)"
+            onClick={() => onDatasetsStepChange("uc18")}
+          />
+          <DatasetStepButton
             isActive={datasetsStep === "uc12"}
-            label="3. Legacy: dataset processed (UC-12)"
+            label="4. Legacy: dataset processed (UC-12)"
             onClick={() => onDatasetsStepChange("uc12")}
           />
           <DatasetStepButton
             isActive={datasetsStep === "uc06"}
-            label="4. Start i monitoring treningu (UC-06)"
+            label="5. Start i monitoring treningu (UC-06)"
             onClick={() => onDatasetsStepChange("uc06")}
           />
           <DatasetStepButton
             isActive={datasetsStep === "uc08"}
-            label="5. Katalog runow i modeli (UC-08)"
+            label="6. Katalog runow i modeli (UC-08)"
             onClick={() => onDatasetsStepChange("uc08")}
           />
         </div>

--- a/src/Frontend/src/features/uc18/api/Uc18BoardFileDeleteAction.tsx
+++ b/src/Frontend/src/features/uc18/api/Uc18BoardFileDeleteAction.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+
+type Uc18BoardFileDeleteActionProps = {
+  boardFolderName: string;
+  isDeleting: boolean;
+  isDisabled: boolean;
+  error?: string | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export function Uc18BoardFileDeleteAction({
+  boardFolderName,
+  isDeleting,
+  isDisabled,
+  error,
+  onConfirm,
+  onCancel,
+}: Uc18BoardFileDeleteActionProps) {
+  const [isConfirming, setIsConfirming] = useState(false);
+
+  useEffect(() => {
+    if (isDeleting || isDisabled) {
+      setIsConfirming(false);
+    }
+  }, [isDeleting, isDisabled]);
+
+  if (isConfirming) {
+    return (
+      <div className="uc18-board-file-delete-confirmation">
+        <p className="uc18-board-file-delete-warning">
+          Usuniesz caly folder planszy <code>{boardFolderName}</code> z aktualnego
+          preparation.
+        </p>
+        <div className="uc18-board-file-delete-actions">
+          <button
+            className="danger-button"
+            type="button"
+            onClick={() => {
+              setIsConfirming(false);
+              onConfirm();
+            }}
+            disabled={isDisabled || isDeleting}
+          >
+            {isDeleting ? "Usuwanie..." : "Potwierdz usuniecie"}
+          </button>
+          <button
+            className="secondary-button"
+            type="button"
+            onClick={() => {
+              setIsConfirming(false);
+              onCancel();
+            }}
+            disabled={isDeleting}
+          >
+            Anuluj
+          </button>
+        </div>
+        {error ? <p className="uc18-board-file-delete-error">{error}</p> : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="uc18-board-file-delete-slot">
+      <button
+        className="danger-button"
+        type="button"
+        onClick={() => setIsConfirming(true)}
+        disabled={isDisabled || isDeleting}
+      >
+        {isDeleting ? "Usuwanie..." : "Usun plansze"}
+      </button>
+      {error ? <p className="uc18-board-file-delete-error">{error}</p> : null}
+    </div>
+  );
+}

--- a/src/Frontend/src/features/uc18/api/Uc18BoardFilesPanel.tsx
+++ b/src/Frontend/src/features/uc18/api/Uc18BoardFilesPanel.tsx
@@ -1,0 +1,227 @@
+import type { UseUc18BoardFilesResult } from "../application/uc18BoardFilesTypes";
+import { useUc18DeleteBoardFile } from "../application/useUc18DeleteBoardFile";
+import { Uc18BoardFileDeleteAction } from "./Uc18BoardFileDeleteAction";
+import { Uc18BoardImagePreview } from "./Uc18BoardImagePreview";
+
+type Uc18BoardFilesPanelProps = {
+  apiBaseUrl: string;
+  preparationName: string | null;
+  selectedSourceName: string | null;
+  boardFiles: UseUc18BoardFilesResult;
+  accessToken?: string | null;
+  onUnauthorized?: () => void;
+};
+
+export function Uc18BoardFilesPanel({
+  apiBaseUrl,
+  preparationName,
+  selectedSourceName,
+  boardFiles,
+  accessToken,
+  onUnauthorized,
+}: Uc18BoardFilesPanelProps) {
+  const currentPreparationName = boardFiles.preparationName ?? preparationName;
+  const currentSourceName = boardFiles.sourceName ?? selectedSourceName;
+  const deleteBoardFile = useUc18DeleteBoardFile({
+    apiBaseUrl,
+    preparationName: currentPreparationName,
+    sourceName: currentSourceName,
+    page: boardFiles.page,
+    pageSize: boardFiles.pageSize,
+    accessToken,
+    onUnauthorized,
+    loadBoardFiles: boardFiles.loadBoardFiles,
+  });
+  const shouldRenderItems =
+    (boardFiles.status === "success" ||
+      boardFiles.status === "loading" ||
+      boardFiles.status === "error") &&
+    boardFiles.items.length > 0;
+
+  return (
+    <article className="uc17-panel">
+      <div className="uc17-panel-header">
+        <div>
+          <h3>Krok 4 - Plansze `board` dla wybranego zrodla</h3>
+          <p className="muted-copy">
+            Ten panel pobiera paginowana liste logicznych plansz dla jednego zrodla
+            `board`. Renderuje nazwy folderow oraz izolowany preview obrazu per karta bez
+            budowania URL-i po stronie klienta.
+          </p>
+        </div>
+        <button
+          className="secondary-button"
+          type="button"
+          onClick={() => void boardFiles.retryLoadBoardFiles()}
+          disabled={
+            !preparationName ||
+            !selectedSourceName ||
+            boardFiles.status === "loading" ||
+            deleteBoardFile.isDeleting
+          }
+        >
+          {boardFiles.status === "loading"
+            ? "Odswiezanie..."
+            : "Odswiez liste plansz"}
+        </button>
+      </div>
+
+      {!preparationName ? (
+        <p className="muted-copy">
+          Najpierw wybierz preparation, aby przejsc do listy plansz `board`.
+        </p>
+      ) : null}
+
+      {preparationName && !selectedSourceName ? (
+        <p className="muted-copy">
+          Wybierz zrodlo `board` w poprzednim kroku. Dopiero wtedy frontend pobierze
+          paginowana liste plansz.
+        </p>
+      ) : null}
+
+      {boardFiles.status === "loading" && currentPreparationName && currentSourceName ? (
+        <p className="status-banner status-loading">
+          Pobieranie plansz `board` dla source <code>{currentSourceName}</code> z
+          preparation <code>{currentPreparationName}</code> (strona {boardFiles.page})...
+        </p>
+      ) : null}
+
+      {boardFiles.status === "error" ? (
+        <>
+          <p className="status-banner status-error">{boardFiles.error}</p>
+          {boardFiles.httpStatus === 401 ? (
+            <p className="muted-copy">
+              Sesja administracyjna zostala wyczyszczona. Zaloguj sie ponownie.
+            </p>
+          ) : null}
+          {boardFiles.httpStatus === 404 ? (
+            <p className="muted-copy">
+              Wybrane preparation albo source `board` nie jest juz dostepne. Wroc do
+              poprzedniego kroku i wybierz zrodlo ponownie.
+            </p>
+          ) : null}
+          {boardFiles.httpStatus === 400 ? (
+            <p className="muted-copy">
+              Backend odrzucil parametry paginacji albo kontraktu dla tej listy. Mozesz
+              sprobowac ponownie po odswiezeniu.
+            </p>
+          ) : null}
+          {boardFiles.httpStatus !== null && boardFiles.httpStatus >= 500 ? (
+            <p className="muted-copy">
+              Backend zwrocil blad techniczny. Jesli lista byla juz wczytana dla tego
+              zrodla, ostatni poprawny wynik zostal zachowany.
+            </p>
+          ) : null}
+        </>
+      ) : null}
+
+      {deleteBoardFile.status === "success" && deleteBoardFile.boardFolderName ? (
+        <p className="status-banner status-success">
+          Usunieto <code>{deleteBoardFile.boardFolderName}</code>. Lista plansz zostala
+          odswiezona. Pozostalo rekordow: {deleteBoardFile.remainingItemsCount ?? "?"}.
+        </p>
+      ) : null}
+
+      {deleteBoardFile.status === "error" &&
+      deleteBoardFile.httpStatus !== 404 &&
+      deleteBoardFile.error ? (
+        <p className="status-banner status-error">{deleteBoardFile.error}</p>
+      ) : null}
+
+      {currentPreparationName && currentSourceName ? (
+        <div className="uc18-summary">
+          <span className="uc17-stat-chip">
+            Preparation: <code>{currentPreparationName}</code>
+          </span>
+          <span className="uc17-stat-chip">
+            Source: <code>{currentSourceName}</code>
+          </span>
+          <span className="uc17-stat-chip">Strona: {boardFiles.page}</span>
+          <span className="uc17-stat-chip">Page size: {boardFiles.pageSize}</span>
+          <span className="uc17-stat-chip">Liczba plansz: {boardFiles.totalCount}</span>
+        </div>
+      ) : null}
+
+      {boardFiles.status === "success" && boardFiles.totalCount === 0 && currentSourceName ? (
+        <p className="status-banner status-loading">
+          To zrodlo `board` nie zawiera jeszcze zadnych plansz.
+        </p>
+      ) : null}
+
+      {shouldRenderItems ? (
+        <>
+          <ul className="uc18-board-files-list">
+            {boardFiles.items.map((item) => {
+              const isDeletingCurrentItem =
+                deleteBoardFile.deletingBoardFileKey === item.key &&
+                deleteBoardFile.isDeleting;
+              const isDeleteActionDisabled =
+                deleteBoardFile.isDeleting || boardFiles.status === "loading";
+              const deleteErrorForCurrentItem =
+                deleteBoardFile.deletingBoardFileKey === item.key
+                  ? deleteBoardFile.error
+                  : null;
+
+              return (
+                <li key={item.key} className="uc18-board-file-item">
+                  <article
+                    className={`uc18-board-file-card ${isDeletingCurrentItem ? "is-deleting" : ""}`}
+                  >
+                    <div className="uc18-board-file-copy">
+                      <strong>{item.boardFolderName}</strong>
+                      <p className="muted-copy">
+                        Folder logicznej planszy gotowy do review i ewentualnego usuniecia
+                        bez lokalnego zgadywania nowej paginacji po stronie klienta.
+                      </p>
+                      <Uc18BoardFileDeleteAction
+                        boardFolderName={item.boardFolderName}
+                        isDeleting={isDeletingCurrentItem}
+                        isDisabled={isDeleteActionDisabled}
+                        error={deleteErrorForCurrentItem}
+                        onConfirm={() => {
+                          void deleteBoardFile.deleteBoardFile(item);
+                        }}
+                        onCancel={deleteBoardFile.clearDeleteFeedback}
+                      />
+                    </div>
+                    <Uc18BoardImagePreview
+                      apiBaseUrl={apiBaseUrl}
+                      boardFile={item}
+                      accessToken={accessToken}
+                      onUnauthorized={onUnauthorized}
+                    />
+                  </article>
+                </li>
+              );
+            })}
+          </ul>
+
+          <div className="uc18-board-files-footer">
+            <p className="muted-copy">
+              Strona {boardFiles.page} z {boardFiles.totalPages}. Backend pozostaje zrodlem
+              prawdy dla kolejnosci i lacznej liczby rekordow.
+            </p>
+            <div className="uc18-board-files-pagination">
+              <button
+                className="secondary-button"
+                type="button"
+                onClick={() => void boardFiles.goToPreviousPage()}
+                disabled={!boardFiles.canGoToPreviousPage || deleteBoardFile.isDeleting}
+              >
+                Poprzednia
+              </button>
+              <button
+                className="secondary-button"
+                type="button"
+                onClick={() => void boardFiles.goToNextPage()}
+                disabled={!boardFiles.canGoToNextPage || deleteBoardFile.isDeleting}
+              >
+                Nastepna
+              </button>
+            </div>
+          </div>
+        </>
+      ) : null}
+    </article>
+  );
+}

--- a/src/Frontend/src/features/uc18/api/Uc18BoardFoldersSection.tsx
+++ b/src/Frontend/src/features/uc18/api/Uc18BoardFoldersSection.tsx
@@ -1,0 +1,380 @@
+import { useUc17DatasetPreparations } from "../../uc17/application/useUc17DatasetPreparations";
+import { useUc18BoardFiles } from "../application/useUc18BoardFiles";
+import { useUc18BoardFolders } from "../application/useUc18BoardFolders";
+import { useUc18DigitFolders } from "../application/useUc18DigitFolders";
+import { Uc18BoardFilesPanel } from "./Uc18BoardFilesPanel";
+import { Uc18DigitFoldersPanel } from "./Uc18DigitFoldersPanel";
+import { Uc18PreparationFoldersList } from "./Uc18PreparationFoldersList";
+
+type Uc18BoardFoldersSectionProps = {
+  apiBaseUrl: string;
+  accessToken?: string | null;
+  onUnauthorized?: () => void;
+};
+
+function formatTimestamp(timestampUtc: string): string {
+  const parsedDate = new Date(timestampUtc);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return timestampUtc;
+  }
+
+  return new Intl.DateTimeFormat("pl-PL", {
+    dateStyle: "medium",
+    timeStyle: "medium",
+    timeZone: "UTC",
+  }).format(parsedDate);
+}
+
+function getPreparationStatusLabel(status: string): string {
+  const labels: Record<string, string> = {
+    queued: "W kolejce",
+    running: "W trakcie",
+    completed: "Gotowe",
+    failed: "Niepowodzenie",
+  };
+
+  return labels[status] ?? status;
+}
+
+function getPreparationStatusClassName(status: string): string {
+  return status === "completed"
+    ? "is-completed"
+    : status === "failed"
+      ? "is-failed"
+      : status === "running"
+        ? "is-running"
+        : status === "queued"
+          ? "is-queued"
+          : "is-unknown";
+}
+
+export function Uc18BoardFoldersSection({
+  apiBaseUrl,
+  accessToken,
+  onUnauthorized,
+}: Uc18BoardFoldersSectionProps) {
+  const datasetPreparations = useUc17DatasetPreparations({
+    apiBaseUrl,
+    accessToken,
+    onUnauthorized,
+  });
+  const boardFolders = useUc18BoardFolders({
+    apiBaseUrl,
+    accessToken,
+    onUnauthorized,
+    preparationName: datasetPreparations.selectedPreparationName,
+  });
+  const digitFolders = useUc18DigitFolders({
+    apiBaseUrl,
+    accessToken,
+    onUnauthorized,
+    preparationName: datasetPreparations.selectedPreparationName,
+  });
+  const selectedBoardSourceName =
+    boardFolders.preparationName === datasetPreparations.selectedPreparationName
+      ? boardFolders.selectedSourceName
+      : null;
+  const boardFiles = useUc18BoardFiles({
+    apiBaseUrl,
+    accessToken,
+    onUnauthorized,
+    preparationName: datasetPreparations.selectedPreparationName,
+    sourceName: selectedBoardSourceName,
+  });
+
+  return (
+    <section className="hero-card uc18-section">
+      <p className="eyebrow">UC-18 - Przeglad zrodel przygotowania</p>
+      <h2>Wybierz preparation i przejrzyj zrodla</h2>
+      <p className="hero-copy">
+        Ten krok pobiera z backendu istniejace preparation oraz listy zrodel{" "}
+        <code>board</code> i <code>digit</code> dla wybranego rekordu, a po wyborze
+        konkretnego zrodla `board` doladowuje paginowana liste plansz. Preview obrazu{" "}
+        <code>corrected-board.png</code> pozostaje jeszcze placeholderem.
+      </p>
+
+      <article className="uc17-panel">
+        <div className="uc17-panel-header">
+          <div>
+            <h3>Krok 1 - Wybierz preparation</h3>
+            <p className="muted-copy">
+              Lista preparation pochodzi z backendu i jest punktem wejsciowym do dalszego
+              przegladu `board/folders` i `digit/folders`.
+            </p>
+          </div>
+          <button
+            className="secondary-button"
+            type="button"
+            onClick={() => void datasetPreparations.refreshPreparations()}
+            disabled={datasetPreparations.preparationsState.kind === "loading"}
+          >
+            {datasetPreparations.preparationsState.kind === "loading"
+              ? "Odswiezanie..."
+              : "Odswiez przygotowania"}
+          </button>
+        </div>
+
+        {datasetPreparations.preparationsState.kind === "loading" ? (
+          <p className="status-banner status-loading">
+            Pobieranie listy przygotowan datasetu...
+          </p>
+        ) : null}
+
+        {datasetPreparations.preparationsState.kind === "error" ? (
+          <>
+            <p className="status-banner status-error">
+              {datasetPreparations.preparationsState.error}
+            </p>
+            {datasetPreparations.preparationsState.httpStatus === 401 ? (
+              <p className="muted-copy">
+                Sesja administracyjna zostala wyczyszczona. Zaloguj sie ponownie.
+              </p>
+            ) : null}
+          </>
+        ) : null}
+
+        {datasetPreparations.preparationsState.data?.length ? (
+          <ul className="uc17-preparations-list">
+            {datasetPreparations.preparationsState.data.map((item) => {
+              const isActive =
+                datasetPreparations.selectedPreparationName === item.preparationName;
+              const isRefreshingActiveDetails =
+                isActive && datasetPreparations.detailsState.kind === "loading";
+
+              return (
+                <li
+                  key={`${item.preparationName}-${item.createdAtUtc}`}
+                  className={isActive ? "is-active" : ""}
+                >
+                  <div>
+                    <strong>{item.preparationName}</strong>
+                    <p className="muted-copy">
+                      Utworzono: {formatTimestamp(item.createdAtUtc)}
+                    </p>
+                    <p className="muted-copy">
+                      Zrodla board: {item.boardSourcesCount}, digit: {item.digitSourcesCount}
+                    </p>
+                  </div>
+                  <div className="uc17-preparation-actions">
+                    <span
+                      className={`uc17-status-badge ${getPreparationStatusClassName(item.status)}`}
+                    >
+                      {getPreparationStatusLabel(item.status)}
+                    </span>
+                    <button
+                      className="secondary-button"
+                      type="button"
+                      onClick={() =>
+                        void datasetPreparations.loadPreparationDetails(item.preparationName)
+                      }
+                      disabled={isRefreshingActiveDetails}
+                    >
+                      {isRefreshingActiveDetails
+                        ? "Odswiezanie..."
+                        : isActive
+                          ? "Odswiez szczegoly"
+                          : "Wybierz preparation"}
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        ) : datasetPreparations.preparationsState.kind === "success" ? (
+          <p className="muted-copy">Brak zapisanych przygotowan datasetu.</p>
+        ) : null}
+      </article>
+
+      <article className="uc17-panel">
+        <div className="uc17-panel-header">
+          <div>
+            <h3>Krok 2 - Kontekst wybranego preparation</h3>
+            <p className="muted-copy">
+              Szczegoly pomagaja potwierdzic, z ktorego rekordu pobierasz listy zrodel
+              `board` i `digit`.
+            </p>
+          </div>
+          <button
+            className="secondary-button"
+            type="button"
+            onClick={() => void datasetPreparations.refreshSelectedPreparation()}
+            disabled={
+              !datasetPreparations.selectedPreparationName ||
+              datasetPreparations.detailsState.kind === "loading"
+            }
+          >
+            {datasetPreparations.detailsState.kind === "loading"
+              ? "Odswiezanie..."
+              : "Odswiez szczegoly"}
+          </button>
+        </div>
+
+        {!datasetPreparations.selectedPreparationName ? (
+          <p className="muted-copy">
+            Wybierz rekord z listy przygotowan, aby pobrac jego zrodla `board` i `digit`.
+          </p>
+        ) : null}
+
+        {datasetPreparations.detailsState.kind === "loading" ? (
+          <p className="status-banner status-loading">
+            Pobieranie szczegolow przygotowania...
+          </p>
+        ) : null}
+
+        {datasetPreparations.detailsState.kind === "error" ? (
+          <>
+            <p className="status-banner status-error">
+              {datasetPreparations.detailsState.error}
+            </p>
+            {datasetPreparations.detailsState.httpStatus === 401 ? (
+              <p className="muted-copy">
+                Sesja administracyjna zostala wyczyszczona. Zaloguj sie ponownie.
+              </p>
+            ) : null}
+          </>
+        ) : null}
+
+        {datasetPreparations.detailsState.data ? (
+          <div className="uc17-details">
+            <div className="uc17-details-header">
+              <div>
+                <strong>{datasetPreparations.detailsState.data.preparationName}</strong>
+                <p className="muted-copy">
+                  Utworzono:{" "}
+                  {formatTimestamp(datasetPreparations.detailsState.data.createdAtUtc)}
+                </p>
+              </div>
+              <span
+                className={`uc17-status-badge ${getPreparationStatusClassName(
+                  datasetPreparations.detailsState.data.status
+                )}`}
+              >
+                {getPreparationStatusLabel(datasetPreparations.detailsState.data.status)}
+              </span>
+            </div>
+
+            <ul className="uc17-draft-list">
+              {datasetPreparations.detailsState.data.sources.map((source) => (
+                <li key={`${source.type}:${source.name}`}>
+                  <code>{source.name}</code> <span>({source.type})</span>
+                  <span> przygotowane: {source.preparedItemsCount}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </article>
+
+      <article className="uc17-panel">
+        <div className="uc17-panel-header">
+          <div>
+            <h3>Krok 3 - Zrodla `board`</h3>
+            <p className="muted-copy">
+              Backend zwraca tylko nazwy logicznych zrodel. Wybor przygotowuje nastepny
+              krok listowania plansz.
+            </p>
+          </div>
+          <button
+            className="secondary-button"
+            type="button"
+            onClick={() => void boardFolders.retryLoadBoardFolders()}
+            disabled={
+              !datasetPreparations.selectedPreparationName || boardFolders.status === "loading"
+            }
+          >
+            {boardFolders.status === "loading" ? "Odswiezanie..." : "Odswiez liste zrodel"}
+          </button>
+        </div>
+
+        {!datasetPreparations.selectedPreparationName ? (
+          <p className="muted-copy">
+            Najpierw wybierz preparation. Lista zrodel `board` nie jest pobierana bez
+            poprawnego <code>preparationName</code>.
+          </p>
+        ) : null}
+
+        {boardFolders.status === "loading" ? (
+          <p className="status-banner status-loading">
+            Pobieranie zrodel `board` dla preparation{" "}
+            <code>{datasetPreparations.selectedPreparationName}</code>...
+          </p>
+        ) : null}
+
+        {boardFolders.status === "error" ? (
+          <>
+            <p className="status-banner status-error">{boardFolders.error}</p>
+            {boardFolders.httpStatus === 401 ? (
+              <p className="muted-copy">
+                Sesja administracyjna zostala wyczyszczona. Zaloguj sie ponownie.
+              </p>
+            ) : null}
+            {boardFolders.httpStatus === 404 ? (
+              <p className="muted-copy">
+                Wybrane preparation nie jest juz dostepne. Wybierz inny rekord z listy.
+              </p>
+            ) : null}
+          </>
+        ) : null}
+
+        {boardFolders.preparationName ? (
+          <div className="uc18-summary">
+            <span className="uc17-stat-chip">
+              Preparation: <code>{boardFolders.preparationName}</code>
+            </span>
+            <span className="uc17-stat-chip">Liczba zrodel board: {boardFolders.totalCount}</span>
+            <span className="uc17-stat-chip">
+              Aktywne zrodlo:{" "}
+              {boardFolders.selectedSourceName ? (
+                <code>{boardFolders.selectedSourceName}</code>
+              ) : (
+                "brak"
+              )}
+            </span>
+          </div>
+        ) : null}
+
+        {boardFolders.status === "success" && boardFolders.totalCount === 0 ? (
+          <p className="status-banner status-loading">
+            To preparation nie ma jeszcze zadnych zrodel `board`.
+          </p>
+        ) : null}
+
+        {(boardFolders.status === "success" ||
+          boardFolders.status === "loading" ||
+          boardFolders.status === "error") &&
+        boardFolders.folders.length > 0 ? (
+          <Uc18PreparationFoldersList
+            mode="selectable"
+            folders={boardFolders.folders}
+            selectedSourceName={boardFolders.selectedSourceName}
+            onSelect={boardFolders.selectBoardSource}
+            emptyMessage="Brak zrodel `board` dla wybranego preparation."
+            disabled={boardFolders.status === "loading"}
+          />
+        ) : null}
+
+        {boardFolders.selectedFolder ? (
+          <p className="muted-copy">
+            Wybrane zrodlo <code>{boardFolders.selectedFolder.folderName}</code> jest gotowe
+            do dalszego listowania plansz w kolejnym kroku `UC-18`.
+          </p>
+        ) : null}
+      </article>
+
+      <Uc18BoardFilesPanel
+        apiBaseUrl={apiBaseUrl}
+        preparationName={datasetPreparations.selectedPreparationName}
+        selectedSourceName={selectedBoardSourceName}
+        boardFiles={boardFiles}
+        accessToken={accessToken}
+        onUnauthorized={onUnauthorized}
+      />
+
+      <Uc18DigitFoldersPanel
+        preparationName={datasetPreparations.selectedPreparationName}
+        digitFolders={digitFolders}
+      />
+    </section>
+  );
+}

--- a/src/Frontend/src/features/uc18/api/Uc18BoardImagePreview.tsx
+++ b/src/Frontend/src/features/uc18/api/Uc18BoardImagePreview.tsx
@@ -1,0 +1,98 @@
+import { useUc18BoardImage } from "../application/useUc18BoardImage";
+import type { Uc18BoardFile } from "../domain/uc18BoardFile";
+
+type Uc18BoardImagePreviewProps = {
+  apiBaseUrl: string;
+  boardFile: Uc18BoardFile;
+  accessToken?: string | null;
+  onUnauthorized?: () => void;
+};
+
+export function Uc18BoardImagePreview({
+  apiBaseUrl,
+  boardFile,
+  accessToken,
+  onUnauthorized,
+}: Uc18BoardImagePreviewProps) {
+  const boardImage = useUc18BoardImage({
+    apiBaseUrl,
+    imageEndpoint: boardFile.imageEndpoint,
+    preparationName: boardFile.preparationName,
+    sourceName: boardFile.sourceName,
+    boardFolderName: boardFile.boardFolderName,
+    accessToken,
+    onUnauthorized,
+  });
+  const altText = `Preview planszy ${boardFile.boardFolderName} ze zrodla ${boardFile.sourceName} i preparation ${boardFile.preparationName}.`;
+
+  return (
+    <div className="uc18-board-file-preview">
+      <span className="uc18-board-file-preview-label">Preview obrazu</span>
+
+      {boardImage.status === "loading" || boardImage.status === "idle" ? (
+        <div
+          className="uc18-board-image-state is-loading"
+          aria-live="polite"
+          aria-busy="true"
+        >
+          <div className="uc18-board-image-skeleton" aria-hidden="true" />
+          <p className="muted-copy">
+            Ladowanie <code>corrected-board.png</code> dla{" "}
+            <code>{boardFile.boardFolderName}</code>...
+          </p>
+        </div>
+      ) : null}
+
+      {boardImage.status === "error" ? (
+        <div className="uc18-board-image-state is-error" aria-live="polite">
+          <p className="muted-copy">
+            Nie udalo sie zaladowac preview dla{" "}
+            <code>{boardFile.boardFolderName}</code>.
+          </p>
+          {boardImage.httpStatus === 404 ? (
+            <p className="muted-copy">
+              Backend nie znalazl juz tego obrazu. Rekord listy pozostaje widoczny, ale
+              preview wymaga ponowienia po odswiezeniu danych.
+            </p>
+          ) : null}
+          {boardImage.httpStatus === 401 ? (
+            <p className="muted-copy">
+              Sesja administracyjna wygasla. Zaloguj sie ponownie i sprobuj jeszcze raz.
+            </p>
+          ) : null}
+          {boardImage.httpStatus !== null &&
+          boardImage.httpStatus >= 500 ? (
+            <p className="muted-copy">
+              Backend zwrocil blad techniczny dla tej jednej planszy.
+            </p>
+          ) : null}
+          {boardImage.error ? (
+            <p className="uc18-board-image-error-text">{boardImage.error}</p>
+          ) : null}
+          <button
+            className="secondary-button"
+            type="button"
+            onClick={() => void boardImage.retryLoadBoardImage()}
+          >
+            Ponow ladowanie preview
+          </button>
+        </div>
+      ) : null}
+
+      {boardImage.status === "success" && boardImage.imageDataUrl ? (
+        <div className="uc18-board-image-state is-success">
+          <img
+            className="uc18-board-image"
+            src={boardImage.imageDataUrl}
+            alt={altText}
+            loading="lazy"
+          />
+          <p className="muted-copy">
+            Preview <code>corrected-board.png</code> dla{" "}
+            <code>{boardFile.boardFolderName}</code>.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/Frontend/src/features/uc18/api/Uc18DigitFoldersPanel.tsx
+++ b/src/Frontend/src/features/uc18/api/Uc18DigitFoldersPanel.tsx
@@ -1,0 +1,93 @@
+import type { UseUc18DigitFoldersResult } from "../application/uc18DigitFoldersTypes";
+import { Uc18PreparationFoldersList } from "./Uc18PreparationFoldersList";
+
+type Uc18DigitFoldersPanelProps = {
+  preparationName: string | null;
+  digitFolders: UseUc18DigitFoldersResult;
+};
+
+export function Uc18DigitFoldersPanel({
+  preparationName,
+  digitFolders,
+}: Uc18DigitFoldersPanelProps) {
+  return (
+    <article className="uc17-panel">
+      <div className="uc17-panel-header">
+        <div>
+          <h3>Krok 5 - Zrodla `digit`</h3>
+          <p className="muted-copy">
+            Ten panel ma charakter informacyjny. Backend zwraca liste logicznych zrodel
+            `digit`, ale ten krok nie prowadzi do osobnego preview ani usuwania probek.
+          </p>
+        </div>
+        <button
+          className="secondary-button"
+          type="button"
+          onClick={() => void digitFolders.retryLoadDigitFolders()}
+          disabled={!preparationName || digitFolders.status === "loading"}
+        >
+          {digitFolders.status === "loading"
+            ? "Odswiezanie..."
+            : "Odswiez liste digit"}
+        </button>
+      </div>
+
+      {!preparationName ? (
+        <p className="muted-copy">
+          Najpierw wybierz preparation. Lista zrodel `digit` nie jest pobierana bez
+          poprawnego <code>preparationName</code>.
+        </p>
+      ) : null}
+
+      {digitFolders.status === "loading" ? (
+        <p className="status-banner status-loading">
+          Pobieranie zrodel `digit` dla preparation <code>{preparationName}</code>...
+        </p>
+      ) : null}
+
+      {digitFolders.status === "error" ? (
+        <>
+          <p className="status-banner status-error">{digitFolders.error}</p>
+          {digitFolders.httpStatus === 401 ? (
+            <p className="muted-copy">
+              Sesja administracyjna zostala wyczyszczona. Zaloguj sie ponownie.
+            </p>
+          ) : null}
+          {digitFolders.httpStatus === 404 ? (
+            <p className="muted-copy">
+              Wybrane preparation nie jest juz dostepne. Wybierz inny rekord z listy.
+            </p>
+          ) : null}
+        </>
+      ) : null}
+
+      {digitFolders.preparationName ? (
+        <div className="uc18-summary">
+          <span className="uc17-stat-chip">
+            Preparation: <code>{digitFolders.preparationName}</code>
+          </span>
+          <span className="uc17-stat-chip">Liczba zrodel digit: {digitFolders.totalCount}</span>
+          <span className="uc17-stat-chip">Tryb: tylko odczyt</span>
+        </div>
+      ) : null}
+
+      {digitFolders.status === "success" && digitFolders.totalCount === 0 ? (
+        <p className="status-banner status-loading">
+          To preparation nie ma jeszcze zadnych zrodel `digit`.
+        </p>
+      ) : null}
+
+      {(digitFolders.status === "success" ||
+        digitFolders.status === "loading" ||
+        digitFolders.status === "error") &&
+      digitFolders.folders.length > 0 ? (
+        <Uc18PreparationFoldersList
+          mode="readonly"
+          folders={digitFolders.folders}
+          emptyMessage="Brak zrodel `digit` dla wybranego preparation."
+          itemHint="Zrodlo digit nalezace do wybranego preparation."
+        />
+      ) : null}
+    </article>
+  );
+}

--- a/src/Frontend/src/features/uc18/api/Uc18PreparationFoldersList.tsx
+++ b/src/Frontend/src/features/uc18/api/Uc18PreparationFoldersList.tsx
@@ -1,0 +1,93 @@
+import type { Uc18PreparationFolder } from "../domain/uc18PreparationFolder";
+
+type Uc18PreparationFoldersListBaseProps = {
+  folders: Uc18PreparationFolder[];
+  emptyMessage?: string;
+};
+
+type Uc18SelectablePreparationFoldersListProps =
+  Uc18PreparationFoldersListBaseProps & {
+    mode: "selectable";
+    selectedSourceName: string | null;
+    onSelect: (sourceName: string) => void;
+    disabled?: boolean;
+  };
+
+type Uc18ReadonlyPreparationFoldersListProps =
+  Uc18PreparationFoldersListBaseProps & {
+    mode: "readonly";
+    itemHint?: string;
+  };
+
+type Uc18PreparationFoldersListProps =
+  | Uc18SelectablePreparationFoldersListProps
+  | Uc18ReadonlyPreparationFoldersListProps;
+
+type Uc18PreparationFolderCardProps = {
+  folder: Uc18PreparationFolder;
+  hint: string;
+};
+
+function Uc18PreparationFolderCard({ folder, hint }: Uc18PreparationFolderCardProps) {
+  return (
+    <div className="uc18-folder-card is-readonly">
+      <span>
+        <strong>{folder.folderName}</strong>
+      </span>
+      <span className="muted-copy">{hint}</span>
+    </div>
+  );
+}
+
+export function Uc18PreparationFoldersList({
+  folders,
+  emptyMessage = "Brak zrodel dla wybranego preparation.",
+  ...props
+}: Uc18PreparationFoldersListProps) {
+  if (folders.length === 0) {
+    return <p className="muted-copy">{emptyMessage}</p>;
+  }
+
+  if (props.mode === "readonly") {
+    const itemHint = props.itemHint ?? "Widok tylko do odczytu.";
+
+    return (
+      <ul className="uc18-folders-list">
+        {folders.map((folder) => (
+          <li key={folder.key}>
+            <Uc18PreparationFolderCard folder={folder} hint={itemHint} />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  const { disabled = false, selectedSourceName, onSelect } = props;
+
+  return (
+    <ul className="uc18-folders-list">
+      {folders.map((folder) => {
+        const isSelected = selectedSourceName === folder.folderName;
+
+        return (
+          <li key={folder.key}>
+            <button
+              className={`uc18-folder-button ${isSelected ? "is-active" : ""}`}
+              type="button"
+              onClick={() => onSelect(folder.folderName)}
+              aria-pressed={isSelected}
+              disabled={disabled}
+            >
+              <span>
+                <strong>{folder.folderName}</strong>
+              </span>
+              <span className="muted-copy">
+                {isSelected ? "Wybrane zrodlo do dalszego przegladu" : "Wybierz zrodlo"}
+              </span>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/Frontend/src/features/uc18/api/index.ts
+++ b/src/Frontend/src/features/uc18/api/index.ts
@@ -1,0 +1,1 @@
+export { Uc18BoardFoldersSection } from "./Uc18BoardFoldersSection";

--- a/src/Frontend/src/features/uc18/application/uc18BoardFilesReducer.ts
+++ b/src/Frontend/src/features/uc18/application/uc18BoardFilesReducer.ts
@@ -1,0 +1,74 @@
+import type {
+  Uc18BoardFilesAction,
+  Uc18BoardFilesState,
+} from "./uc18BoardFilesTypes";
+
+export function uc18BoardFilesReducer(
+  state: Uc18BoardFilesState,
+  action: Uc18BoardFilesAction
+): Uc18BoardFilesState {
+  switch (action.type) {
+    case "stateReset":
+      return {
+        status: "idle",
+        preparationName: null,
+        sourceName: null,
+        items: [],
+        page: 1,
+        pageSize: state.pageSize,
+        totalCount: 0,
+        error: null,
+        errorType: null,
+        httpStatus: null,
+      };
+    case "loadStarted": {
+      const isSameScope =
+        state.preparationName === action.preparationName &&
+        state.sourceName === action.sourceName;
+
+      return {
+        ...state,
+        status: "loading",
+        preparationName: action.preparationName,
+        sourceName: action.sourceName,
+        items: isSameScope ? state.items : [],
+        page: action.page,
+        pageSize: action.pageSize,
+        totalCount: isSameScope ? state.totalCount : 0,
+        error: null,
+        errorType: null,
+        httpStatus: null,
+      };
+    }
+    case "loadSucceeded":
+      return {
+        ...state,
+        status: "success",
+        preparationName: action.preparationName,
+        sourceName: action.sourceName,
+        items: action.items,
+        page: action.page,
+        pageSize: action.pageSize,
+        totalCount: action.totalCount,
+        error: null,
+        errorType: null,
+        httpStatus: 200,
+      };
+    case "loadFailed":
+      return {
+        ...state,
+        status: "error",
+        preparationName: action.preparationName,
+        sourceName: action.sourceName,
+        items: action.clearItems ? [] : state.items,
+        page: action.page,
+        pageSize: action.pageSize,
+        totalCount: action.clearItems ? 0 : state.totalCount,
+        error: action.error,
+        errorType: action.errorType,
+        httpStatus: action.httpStatus,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/Frontend/src/features/uc18/application/uc18BoardFilesTypes.ts
+++ b/src/Frontend/src/features/uc18/application/uc18BoardFilesTypes.ts
@@ -1,0 +1,98 @@
+import type { Uc18BoardFile } from "../domain/uc18BoardFile";
+
+export const defaultUc18BoardFilesPage = 1;
+export const defaultUc18BoardFilesPageSize = 24;
+
+export type Uc18BoardFilesStatus = "idle" | "loading" | "success" | "error";
+
+export type Uc18BoardFilesState = {
+  status: Uc18BoardFilesStatus;
+  preparationName: string | null;
+  sourceName: string | null;
+  items: Uc18BoardFile[];
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  error: string | null;
+  errorType: string | null;
+  httpStatus: number | null;
+};
+
+export type Uc18BoardFilesAction =
+  | {
+      type: "stateReset";
+    }
+  | {
+      type: "loadStarted";
+      preparationName: string;
+      sourceName: string;
+      page: number;
+      pageSize: number;
+    }
+  | {
+      type: "loadSucceeded";
+      preparationName: string;
+      sourceName: string;
+      items: Uc18BoardFile[];
+      page: number;
+      pageSize: number;
+      totalCount: number;
+    }
+  | {
+      type: "loadFailed";
+      preparationName: string;
+      sourceName: string;
+      page: number;
+      pageSize: number;
+      error: string;
+      errorType: string | null;
+      httpStatus: number | null;
+      clearItems: boolean;
+    };
+
+export type UseUc18BoardFilesOptions = {
+  apiBaseUrl: string;
+  preparationName: string | null;
+  sourceName: string | null;
+  accessToken?: string | null;
+  onUnauthorized?: () => void;
+};
+
+export type UseUc18BoardFilesResult = {
+  status: Uc18BoardFilesStatus;
+  preparationName: string | null;
+  sourceName: string | null;
+  items: Uc18BoardFile[];
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  totalPages: number;
+  error: string | null;
+  errorType: string | null;
+  httpStatus: number | null;
+  canGoToPreviousPage: boolean;
+  canGoToNextPage: boolean;
+  loadBoardFiles: (
+    preparationName: string,
+    sourceName: string,
+    page?: number,
+    pageSize?: number
+  ) => Promise<void>;
+  retryLoadBoardFiles: () => Promise<void>;
+  goToPage: (page: number) => Promise<void>;
+  goToNextPage: () => Promise<void>;
+  goToPreviousPage: () => Promise<void>;
+};
+
+export const defaultUc18BoardFilesState: Uc18BoardFilesState = {
+  status: "idle",
+  preparationName: null,
+  sourceName: null,
+  items: [],
+  page: defaultUc18BoardFilesPage,
+  pageSize: defaultUc18BoardFilesPageSize,
+  totalCount: 0,
+  error: null,
+  errorType: null,
+  httpStatus: null,
+};

--- a/src/Frontend/src/features/uc18/application/uc18BoardFoldersReducer.ts
+++ b/src/Frontend/src/features/uc18/application/uc18BoardFoldersReducer.ts
@@ -1,0 +1,67 @@
+import type {
+  Uc18BoardFoldersAction,
+  Uc18BoardFoldersState,
+} from "./uc18BoardFoldersTypes";
+
+export function uc18BoardFoldersReducer(
+  state: Uc18BoardFoldersState,
+  action: Uc18BoardFoldersAction
+): Uc18BoardFoldersState {
+  switch (action.type) {
+    case "stateReset":
+      return {
+        status: "idle",
+        preparationName: null,
+        folders: [],
+        totalCount: 0,
+        selectedSourceName: null,
+        error: null,
+        errorType: null,
+        httpStatus: null,
+      };
+    case "loadStarted": {
+      const isSamePreparation = state.preparationName === action.preparationName;
+
+      return {
+        ...state,
+        status: "loading",
+        preparationName: action.preparationName,
+        folders: isSamePreparation ? state.folders : [],
+        totalCount: isSamePreparation ? state.totalCount : 0,
+        selectedSourceName: isSamePreparation ? state.selectedSourceName : null,
+        error: null,
+        errorType: null,
+        httpStatus: null,
+      };
+    }
+    case "loadSucceeded":
+      return {
+        ...state,
+        status: "success",
+        preparationName: action.preparationName,
+        folders: action.folders,
+        totalCount: action.totalCount,
+        selectedSourceName: action.selectedSourceName,
+        error: null,
+        errorType: null,
+        httpStatus: 200,
+      };
+    case "loadFailed":
+      return {
+        ...state,
+        status: "error",
+        preparationName: action.preparationName,
+        selectedSourceName: action.clearSelection ? null : state.selectedSourceName,
+        error: action.error,
+        errorType: action.errorType,
+        httpStatus: action.httpStatus,
+      };
+    case "selectionChanged":
+      return {
+        ...state,
+        selectedSourceName: action.sourceName,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/Frontend/src/features/uc18/application/uc18BoardFoldersTypes.ts
+++ b/src/Frontend/src/features/uc18/application/uc18BoardFoldersTypes.ts
@@ -1,0 +1,75 @@
+import type { Uc18PreparationFolder } from "../domain/uc18PreparationFolder";
+
+export type Uc18BoardFoldersStatus = "idle" | "loading" | "success" | "error";
+
+export type Uc18BoardFoldersState = {
+  status: Uc18BoardFoldersStatus;
+  preparationName: string | null;
+  folders: Uc18PreparationFolder[];
+  totalCount: number;
+  selectedSourceName: string | null;
+  error: string | null;
+  errorType: string | null;
+  httpStatus: number | null;
+};
+
+export type Uc18BoardFoldersAction =
+  | {
+      type: "stateReset";
+    }
+  | {
+      type: "loadStarted";
+      preparationName: string;
+    }
+  | {
+      type: "loadSucceeded";
+      preparationName: string;
+      folders: Uc18PreparationFolder[];
+      totalCount: number;
+      selectedSourceName: string | null;
+    }
+  | {
+      type: "loadFailed";
+      preparationName: string;
+      error: string;
+      errorType: string | null;
+      httpStatus: number | null;
+      clearSelection: boolean;
+    }
+  | {
+      type: "selectionChanged";
+      sourceName: string;
+    };
+
+export type UseUc18BoardFoldersOptions = {
+  apiBaseUrl: string;
+  preparationName: string | null;
+  accessToken?: string | null;
+  onUnauthorized?: () => void;
+};
+
+export type UseUc18BoardFoldersResult = {
+  status: Uc18BoardFoldersStatus;
+  preparationName: string | null;
+  folders: Uc18PreparationFolder[];
+  selectedSourceName: string | null;
+  selectedFolder: Uc18PreparationFolder | null;
+  error: string | null;
+  errorType: string | null;
+  httpStatus: number | null;
+  totalCount: number;
+  loadBoardFolders: (preparationName: string) => Promise<void>;
+  retryLoadBoardFolders: () => Promise<void>;
+  selectBoardSource: (sourceName: string) => void;
+};
+
+export const defaultUc18BoardFoldersState: Uc18BoardFoldersState = {
+  status: "idle",
+  preparationName: null,
+  folders: [],
+  totalCount: 0,
+  selectedSourceName: null,
+  error: null,
+  errorType: null,
+  httpStatus: null,
+};

--- a/src/Frontend/src/features/uc18/application/uc18BoardImageReducer.ts
+++ b/src/Frontend/src/features/uc18/application/uc18BoardImageReducer.ts
@@ -1,0 +1,58 @@
+import type {
+  Uc18BoardImageAction,
+  Uc18BoardImageState,
+} from "./uc18BoardImageTypes";
+
+export function uc18BoardImageReducer(
+  state: Uc18BoardImageState,
+  action: Uc18BoardImageAction
+): Uc18BoardImageState {
+  switch (action.type) {
+    case "stateReset":
+      return {
+        status: "idle",
+        requestKey: null,
+        imageDataUrl: null,
+        error: null,
+        errorType: null,
+        httpStatus: null,
+      };
+    case "loadStarted":
+      return {
+        status: "loading",
+        requestKey: action.requestKey,
+        imageDataUrl: null,
+        error: null,
+        errorType: null,
+        httpStatus: null,
+      };
+    case "loadSucceeded":
+      if (state.requestKey !== action.requestKey) {
+        return state;
+      }
+
+      return {
+        status: "success",
+        requestKey: action.requestKey,
+        imageDataUrl: action.imageDataUrl,
+        error: null,
+        errorType: null,
+        httpStatus: 200,
+      };
+    case "loadFailed":
+      if (state.requestKey !== action.requestKey) {
+        return state;
+      }
+
+      return {
+        status: "error",
+        requestKey: action.requestKey,
+        imageDataUrl: null,
+        error: action.error,
+        errorType: action.errorType,
+        httpStatus: action.httpStatus,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/Frontend/src/features/uc18/application/uc18BoardImageTypes.ts
+++ b/src/Frontend/src/features/uc18/application/uc18BoardImageTypes.ts
@@ -1,0 +1,61 @@
+export type Uc18BoardImageStatus = "idle" | "loading" | "success" | "error";
+
+export type Uc18BoardImageState = {
+  status: Uc18BoardImageStatus;
+  requestKey: string | null;
+  imageDataUrl: string | null;
+  error: string | null;
+  errorType: string | null;
+  httpStatus: number | null;
+};
+
+export type Uc18BoardImageAction =
+  | {
+      type: "stateReset";
+    }
+  | {
+      type: "loadStarted";
+      requestKey: string;
+    }
+  | {
+      type: "loadSucceeded";
+      requestKey: string;
+      imageDataUrl: string;
+    }
+  | {
+      type: "loadFailed";
+      requestKey: string;
+      error: string;
+      errorType: string | null;
+      httpStatus: number | null;
+    };
+
+export type UseUc18BoardImageOptions = {
+  apiBaseUrl: string;
+  imageEndpoint: string;
+  preparationName: string;
+  sourceName: string;
+  boardFolderName: string;
+  accessToken?: string | null;
+  onUnauthorized?: () => void;
+};
+
+export type UseUc18BoardImageResult = {
+  status: Uc18BoardImageStatus;
+  requestKey: string | null;
+  imageDataUrl: string | null;
+  error: string | null;
+  errorType: string | null;
+  httpStatus: number | null;
+  loadBoardImage: () => Promise<void>;
+  retryLoadBoardImage: () => Promise<void>;
+};
+
+export const defaultUc18BoardImageState: Uc18BoardImageState = {
+  status: "idle",
+  requestKey: null,
+  imageDataUrl: null,
+  error: null,
+  errorType: null,
+  httpStatus: null,
+};

--- a/src/Frontend/src/features/uc18/application/uc18DeleteBoardFileReducer.ts
+++ b/src/Frontend/src/features/uc18/application/uc18DeleteBoardFileReducer.ts
@@ -1,0 +1,57 @@
+import type {
+  Uc18DeleteBoardFileAction,
+  Uc18DeleteBoardFileState,
+} from "./uc18DeleteBoardFileTypes";
+
+export function uc18DeleteBoardFileReducer(
+  state: Uc18DeleteBoardFileState,
+  action: Uc18DeleteBoardFileAction
+): Uc18DeleteBoardFileState {
+  switch (action.type) {
+    case "stateReset":
+      return {
+        status: "idle",
+        boardFileKey: null,
+        boardFolderName: null,
+        remainingItemsCount: null,
+        error: null,
+        errorType: null,
+        httpStatus: null,
+      };
+    case "deleteStarted":
+      return {
+        ...state,
+        status: "deleting",
+        boardFileKey: action.boardFileKey,
+        boardFolderName: action.boardFolderName,
+        remainingItemsCount: null,
+        error: null,
+        errorType: null,
+        httpStatus: null,
+      };
+    case "deleteSucceeded":
+      return {
+        ...state,
+        status: "success",
+        boardFileKey: action.boardFileKey,
+        boardFolderName: action.boardFolderName,
+        remainingItemsCount: action.remainingItemsCount,
+        error: null,
+        errorType: null,
+        httpStatus: 200,
+      };
+    case "deleteFailed":
+      return {
+        ...state,
+        status: "error",
+        boardFileKey: action.boardFileKey,
+        boardFolderName: action.boardFolderName,
+        remainingItemsCount: null,
+        error: action.error,
+        errorType: action.errorType,
+        httpStatus: action.httpStatus,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/Frontend/src/features/uc18/application/uc18DeleteBoardFileTypes.ts
+++ b/src/Frontend/src/features/uc18/application/uc18DeleteBoardFileTypes.ts
@@ -1,0 +1,77 @@
+import type { Uc18BoardFile } from "../domain/uc18BoardFile";
+
+export type Uc18DeleteBoardFileStatus = "idle" | "deleting" | "success" | "error";
+
+export type Uc18DeleteBoardFileState = {
+  status: Uc18DeleteBoardFileStatus;
+  boardFileKey: string | null;
+  boardFolderName: string | null;
+  remainingItemsCount: number | null;
+  error: string | null;
+  errorType: string | null;
+  httpStatus: number | null;
+};
+
+export type Uc18DeleteBoardFileAction =
+  | {
+      type: "stateReset";
+    }
+  | {
+      type: "deleteStarted";
+      boardFileKey: string;
+      boardFolderName: string;
+    }
+  | {
+      type: "deleteSucceeded";
+      boardFileKey: string;
+      boardFolderName: string;
+      remainingItemsCount: number;
+    }
+  | {
+      type: "deleteFailed";
+      boardFileKey: string | null;
+      boardFolderName: string | null;
+      error: string;
+      errorType: string | null;
+      httpStatus: number | null;
+    };
+
+export type UseUc18DeleteBoardFileOptions = {
+  apiBaseUrl: string;
+  preparationName: string | null;
+  sourceName: string | null;
+  page: number;
+  pageSize: number;
+  accessToken?: string | null;
+  onUnauthorized?: () => void;
+  loadBoardFiles: (
+    preparationName: string,
+    sourceName: string,
+    page?: number,
+    pageSize?: number
+  ) => Promise<void>;
+};
+
+export type UseUc18DeleteBoardFileResult = {
+  status: Uc18DeleteBoardFileStatus;
+  deletingBoardFileKey: string | null;
+  boardFolderName: string | null;
+  remainingItemsCount: number | null;
+  error: string | null;
+  errorType: string | null;
+  httpStatus: number | null;
+  isDeleting: boolean;
+  deleteBoardFile: (boardFile: Uc18BoardFile) => Promise<boolean>;
+  retryDeleteBoardFile: (boardFile: Uc18BoardFile) => Promise<boolean>;
+  clearDeleteFeedback: () => void;
+};
+
+export const defaultUc18DeleteBoardFileState: Uc18DeleteBoardFileState = {
+  status: "idle",
+  boardFileKey: null,
+  boardFolderName: null,
+  remainingItemsCount: null,
+  error: null,
+  errorType: null,
+  httpStatus: null,
+};

--- a/src/Frontend/src/features/uc18/application/uc18DigitFoldersReducer.ts
+++ b/src/Frontend/src/features/uc18/application/uc18DigitFoldersReducer.ts
@@ -1,0 +1,58 @@
+import type {
+  Uc18DigitFoldersAction,
+  Uc18DigitFoldersState,
+} from "./uc18DigitFoldersTypes";
+
+export function uc18DigitFoldersReducer(
+  state: Uc18DigitFoldersState,
+  action: Uc18DigitFoldersAction
+): Uc18DigitFoldersState {
+  switch (action.type) {
+    case "stateReset":
+      return {
+        status: "idle",
+        preparationName: null,
+        folders: [],
+        totalCount: 0,
+        error: null,
+        errorType: null,
+        httpStatus: null,
+      };
+    case "loadStarted": {
+      const isSamePreparation = state.preparationName === action.preparationName;
+
+      return {
+        ...state,
+        status: "loading",
+        preparationName: action.preparationName,
+        folders: isSamePreparation ? state.folders : [],
+        totalCount: isSamePreparation ? state.totalCount : 0,
+        error: null,
+        errorType: null,
+        httpStatus: null,
+      };
+    }
+    case "loadSucceeded":
+      return {
+        ...state,
+        status: "success",
+        preparationName: action.preparationName,
+        folders: action.folders,
+        totalCount: action.totalCount,
+        error: null,
+        errorType: null,
+        httpStatus: 200,
+      };
+    case "loadFailed":
+      return {
+        ...state,
+        status: "error",
+        preparationName: action.preparationName,
+        error: action.error,
+        errorType: action.errorType,
+        httpStatus: action.httpStatus,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/Frontend/src/features/uc18/application/uc18DigitFoldersTypes.ts
+++ b/src/Frontend/src/features/uc18/application/uc18DigitFoldersTypes.ts
@@ -1,0 +1,64 @@
+import type { Uc18PreparationFolder } from "../domain/uc18PreparationFolder";
+
+export type Uc18DigitFoldersStatus = "idle" | "loading" | "success" | "error";
+
+export type Uc18DigitFoldersState = {
+  status: Uc18DigitFoldersStatus;
+  preparationName: string | null;
+  folders: Uc18PreparationFolder[];
+  totalCount: number;
+  error: string | null;
+  errorType: string | null;
+  httpStatus: number | null;
+};
+
+export type Uc18DigitFoldersAction =
+  | {
+      type: "stateReset";
+    }
+  | {
+      type: "loadStarted";
+      preparationName: string;
+    }
+  | {
+      type: "loadSucceeded";
+      preparationName: string;
+      folders: Uc18PreparationFolder[];
+      totalCount: number;
+    }
+  | {
+      type: "loadFailed";
+      preparationName: string;
+      error: string;
+      errorType: string | null;
+      httpStatus: number | null;
+    };
+
+export type UseUc18DigitFoldersOptions = {
+  apiBaseUrl: string;
+  preparationName: string | null;
+  accessToken?: string | null;
+  onUnauthorized?: () => void;
+};
+
+export type UseUc18DigitFoldersResult = {
+  status: Uc18DigitFoldersStatus;
+  preparationName: string | null;
+  folders: Uc18PreparationFolder[];
+  totalCount: number;
+  error: string | null;
+  errorType: string | null;
+  httpStatus: number | null;
+  loadDigitFolders: (preparationName: string) => Promise<void>;
+  retryLoadDigitFolders: () => Promise<void>;
+};
+
+export const defaultUc18DigitFoldersState: Uc18DigitFoldersState = {
+  status: "idle",
+  preparationName: null,
+  folders: [],
+  totalCount: 0,
+  error: null,
+  errorType: null,
+  httpStatus: null,
+};

--- a/src/Frontend/src/features/uc18/application/useUc18BoardFiles.ts
+++ b/src/Frontend/src/features/uc18/application/useUc18BoardFiles.ts
@@ -1,0 +1,343 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+
+import {
+  DatasetPreparationsApiError,
+  getDatasetPreparationBoardFiles,
+} from "../../../api/datasetPreparations";
+import { mapDatasetPreparationBoardFilesToDomain } from "../domain/mapDatasetPreparationBoardFilesToDomain";
+import { resolveUc18BoardFilesPageAfterLoad } from "../domain/resolveUc18BoardFilesPageAfterLoad";
+import { uc18BoardFilesReducer } from "./uc18BoardFilesReducer";
+import {
+  defaultUc18BoardFilesPage,
+  defaultUc18BoardFilesPageSize,
+  defaultUc18BoardFilesState,
+  type UseUc18BoardFilesOptions,
+  type UseUc18BoardFilesResult,
+} from "./uc18BoardFilesTypes";
+
+export function useUc18BoardFiles({
+  apiBaseUrl,
+  preparationName,
+  sourceName,
+  accessToken,
+  onUnauthorized,
+}: UseUc18BoardFilesOptions): UseUc18BoardFilesResult {
+  const [state, dispatch] = useReducer(
+    uc18BoardFilesReducer,
+    defaultUc18BoardFilesState
+  );
+  const activeControllerRef = useRef<AbortController | null>(null);
+
+  const loadBoardFiles = useCallback(
+    async (
+      nextPreparationName: string,
+      nextSourceName: string,
+      requestedPage = defaultUc18BoardFilesPage,
+      requestedPageSize = defaultUc18BoardFilesPageSize,
+      allowPageFallback = true
+    ) => {
+      const normalizedPreparationName = nextPreparationName.trim();
+      const normalizedSourceName = nextSourceName.trim();
+      const normalizedPage = Math.max(1, Math.floor(requestedPage));
+      const normalizedPageSize = Math.max(1, Math.floor(requestedPageSize));
+
+      if (!normalizedPreparationName || !normalizedSourceName) {
+        activeControllerRef.current?.abort();
+        dispatch({ type: "stateReset" });
+        return;
+      }
+
+      activeControllerRef.current?.abort();
+
+      const controller = new AbortController();
+      activeControllerRef.current = controller;
+
+      console.info("[UC-18] Start ladowania listy plansz board.", {
+        page: normalizedPage,
+        pageSize: normalizedPageSize,
+        preparationName: normalizedPreparationName,
+        sourceName: normalizedSourceName,
+      });
+      dispatch({
+        type: "loadStarted",
+        preparationName: normalizedPreparationName,
+        sourceName: normalizedSourceName,
+        page: normalizedPage,
+        pageSize: normalizedPageSize,
+      });
+
+      try {
+        const response = await getDatasetPreparationBoardFiles(
+          apiBaseUrl,
+          {
+            preparationName: normalizedPreparationName,
+            sourceName: normalizedSourceName,
+            page: normalizedPage,
+            pageSize: normalizedPageSize,
+          },
+          accessToken,
+          controller.signal
+        );
+
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        const items = mapDatasetPreparationBoardFilesToDomain(
+          response,
+          normalizedPreparationName,
+          normalizedSourceName
+        );
+        const pageResolution = resolveUc18BoardFilesPageAfterLoad(
+          normalizedPage,
+          response.page,
+          response.pageSize,
+          response.totalCount,
+          items.length
+        );
+
+        if (allowPageFallback && pageResolution.shouldReloadLastPage) {
+          console.warn("[UC-18] Odswiezam ostatnia dostepna strone listy plansz board.", {
+            lastPage: pageResolution.lastPage,
+            page: normalizedPage,
+            pageSize: pageResolution.responsePageSize,
+            preparationName: normalizedPreparationName,
+            sourceName: normalizedSourceName,
+            totalCount: response.totalCount,
+          });
+
+          await loadBoardFiles(
+            normalizedPreparationName,
+            normalizedSourceName,
+            pageResolution.lastPage,
+            pageResolution.responsePageSize,
+            false
+          );
+          return;
+        }
+
+        console.info("[UC-18] Zaladowano liste plansz board.", {
+          page: response.page,
+          pageSize: response.pageSize,
+          preparationName: normalizedPreparationName,
+          sourceName: normalizedSourceName,
+          totalCount: response.totalCount,
+        });
+        dispatch({
+          type: "loadSucceeded",
+          preparationName: normalizedPreparationName,
+          sourceName: normalizedSourceName,
+          items,
+          page: response.page,
+          pageSize: response.pageSize,
+          totalCount: response.totalCount,
+        });
+      } catch (error) {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        let clearItems = false;
+
+        if (error instanceof DatasetPreparationsApiError) {
+          if (error.status === 401) {
+            console.warn("[UC-18] Sesja administracyjna wygasla podczas ladowania listy plansz.", {
+              errorType: error.errorType ?? null,
+              httpStatus: error.status,
+              page: normalizedPage,
+              pageSize: normalizedPageSize,
+              preparationName: normalizedPreparationName,
+              sourceName: normalizedSourceName,
+            });
+            onUnauthorized?.();
+          } else if (error.status === 404) {
+            clearItems = true;
+            console.warn("[UC-18] Wybrane preparation lub source board nie jest juz dostepne.", {
+              errorType: error.errorType ?? null,
+              httpStatus: error.status,
+              page: normalizedPage,
+              pageSize: normalizedPageSize,
+              preparationName: normalizedPreparationName,
+              sourceName: normalizedSourceName,
+            });
+          } else if (error.status === 400) {
+            console.warn("[UC-18] Backend odrzucil request listy plansz board.", {
+              errorType: error.errorType ?? null,
+              httpStatus: error.status,
+              page: normalizedPage,
+              pageSize: normalizedPageSize,
+              preparationName: normalizedPreparationName,
+              sourceName: normalizedSourceName,
+            });
+          } else if (error.status >= 500) {
+            console.error("[UC-18] Backend zwrocil blad podczas ladowania listy plansz.", {
+              errorType: error.errorType ?? null,
+              httpStatus: error.status,
+              page: normalizedPage,
+              pageSize: normalizedPageSize,
+              preparationName: normalizedPreparationName,
+              sourceName: normalizedSourceName,
+            });
+          }
+        } else if (error instanceof Error) {
+          console.error("[UC-18] Nie udalo sie przetworzyc odpowiedzi listy plansz board.", {
+            message: error.message,
+            page: normalizedPage,
+            pageSize: normalizedPageSize,
+            preparationName: normalizedPreparationName,
+            sourceName: normalizedSourceName,
+          });
+        }
+
+        dispatch({
+          type: "loadFailed",
+          preparationName: normalizedPreparationName,
+          sourceName: normalizedSourceName,
+          page: normalizedPage,
+          pageSize: normalizedPageSize,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Nie udalo sie pobrac listy plansz board.",
+          errorType:
+            error instanceof DatasetPreparationsApiError ? error.errorType ?? null : null,
+          httpStatus:
+            error instanceof DatasetPreparationsApiError ? error.status : null,
+          clearItems,
+        });
+      } finally {
+        if (activeControllerRef.current === controller) {
+          activeControllerRef.current = null;
+        }
+      }
+    },
+    [accessToken, apiBaseUrl, onUnauthorized]
+  );
+
+  const retryLoadBoardFiles = useCallback(async () => {
+    const retryPreparationName = preparationName?.trim() || state.preparationName;
+    const retrySourceName = sourceName?.trim() || state.sourceName;
+
+    if (!retryPreparationName || !retrySourceName) {
+      return;
+    }
+
+    console.info("[UC-18] Reczne odswiezenie listy plansz board.", {
+      page: state.page,
+      pageSize: state.pageSize,
+      preparationName: retryPreparationName,
+      sourceName: retrySourceName,
+    });
+    await loadBoardFiles(retryPreparationName, retrySourceName, state.page, state.pageSize);
+  }, [
+    loadBoardFiles,
+    preparationName,
+    sourceName,
+    state.page,
+    state.pageSize,
+    state.preparationName,
+    state.sourceName,
+  ]);
+
+  const goToPage = useCallback(
+    async (page: number) => {
+      const targetPreparationName = preparationName?.trim() || state.preparationName;
+      const targetSourceName = sourceName?.trim() || state.sourceName;
+      const nextPage = Math.max(1, Math.floor(page));
+
+      if (!targetPreparationName || !targetSourceName) {
+        return;
+      }
+
+      console.info("[UC-18] Zmieniam strone listy plansz board.", {
+        nextPage,
+        pageSize: state.pageSize,
+        preparationName: targetPreparationName,
+        sourceName: targetSourceName,
+      });
+      await loadBoardFiles(
+        targetPreparationName,
+        targetSourceName,
+        nextPage,
+        state.pageSize
+      );
+    },
+    [
+      loadBoardFiles,
+      preparationName,
+      sourceName,
+      state.pageSize,
+      state.preparationName,
+      state.sourceName,
+    ]
+  );
+
+  const goToNextPage = useCallback(async () => {
+    const totalPages = Math.max(1, Math.ceil(state.totalCount / state.pageSize));
+
+    if (state.page >= totalPages) {
+      return;
+    }
+
+    await goToPage(state.page + 1);
+  }, [goToPage, state.page, state.pageSize, state.totalCount]);
+
+  const goToPreviousPage = useCallback(async () => {
+    if (state.page <= 1) {
+      return;
+    }
+
+    await goToPage(state.page - 1);
+  }, [goToPage, state.page]);
+
+  useEffect(() => {
+    const normalizedPreparationName = preparationName?.trim() ?? "";
+    const normalizedSourceName = sourceName?.trim() ?? "";
+
+    if (!normalizedPreparationName || !normalizedSourceName) {
+      activeControllerRef.current?.abort();
+      dispatch({ type: "stateReset" });
+      return;
+    }
+
+    void loadBoardFiles(
+      normalizedPreparationName,
+      normalizedSourceName,
+      defaultUc18BoardFilesPage,
+      defaultUc18BoardFilesPageSize
+    );
+  }, [loadBoardFiles, preparationName, sourceName]);
+
+  useEffect(() => {
+    return () => {
+      activeControllerRef.current?.abort();
+    };
+  }, []);
+
+  const totalPages = useMemo(
+    () => Math.max(1, Math.ceil(state.totalCount / state.pageSize)),
+    [state.pageSize, state.totalCount]
+  );
+
+  return {
+    status: state.status,
+    preparationName: state.preparationName,
+    sourceName: state.sourceName,
+    items: state.items,
+    page: state.page,
+    pageSize: state.pageSize,
+    totalCount: state.totalCount,
+    totalPages,
+    error: state.error,
+    errorType: state.errorType,
+    httpStatus: state.httpStatus,
+    canGoToPreviousPage: state.page > 1 && state.status !== "loading",
+    canGoToNextPage:
+      state.totalCount > 0 && state.page < totalPages && state.status !== "loading",
+    loadBoardFiles,
+    retryLoadBoardFiles,
+    goToPage,
+    goToNextPage,
+    goToPreviousPage,
+  };
+}

--- a/src/Frontend/src/features/uc18/application/useUc18BoardFolders.ts
+++ b/src/Frontend/src/features/uc18/application/useUc18BoardFolders.ts
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+
+import {
+  DatasetPreparationsApiError,
+  getDatasetPreparationFolders,
+} from "../../../api/datasetPreparations";
+import { mapDatasetPreparationFoldersToDomain } from "../domain/mapDatasetPreparationFoldersToDomain";
+import { reconcileSelectedPreparationFolder } from "../domain/reconcileSelectedPreparationFolder";
+import { uc18BoardFoldersReducer } from "./uc18BoardFoldersReducer";
+import {
+  defaultUc18BoardFoldersState,
+  type UseUc18BoardFoldersOptions,
+} from "./uc18BoardFoldersTypes";
+
+export function useUc18BoardFolders({
+  apiBaseUrl,
+  preparationName,
+  accessToken,
+  onUnauthorized,
+}: UseUc18BoardFoldersOptions) {
+  const [state, dispatch] = useReducer(
+    uc18BoardFoldersReducer,
+    defaultUc18BoardFoldersState
+  );
+  const activeControllerRef = useRef<AbortController | null>(null);
+  const loadedPreparationNameRef = useRef<string | null>(state.preparationName);
+  const selectedSourceNameRef = useRef<string | null>(state.selectedSourceName);
+
+  useEffect(() => {
+    loadedPreparationNameRef.current = state.preparationName;
+  }, [state.preparationName]);
+
+  useEffect(() => {
+    selectedSourceNameRef.current = state.selectedSourceName;
+  }, [state.selectedSourceName]);
+
+  const loadBoardFolders = useCallback(
+    async (nextPreparationName: string) => {
+      const normalizedPreparationName = nextPreparationName.trim();
+
+      if (!normalizedPreparationName) {
+        activeControllerRef.current?.abort();
+        dispatch({ type: "stateReset" });
+        return;
+      }
+
+      activeControllerRef.current?.abort();
+
+      const controller = new AbortController();
+      activeControllerRef.current = controller;
+
+      if (loadedPreparationNameRef.current !== normalizedPreparationName) {
+        selectedSourceNameRef.current = null;
+      }
+      loadedPreparationNameRef.current = normalizedPreparationName;
+
+      console.info("[UC-18] Start ladowania zrodel board.", {
+        preparationName: normalizedPreparationName,
+        type: "board",
+      });
+      dispatch({
+        type: "loadStarted",
+        preparationName: normalizedPreparationName,
+      });
+
+      try {
+        const response = await getDatasetPreparationFolders(
+          apiBaseUrl,
+          normalizedPreparationName,
+          "board",
+          accessToken,
+          controller.signal
+        );
+
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        const folders = mapDatasetPreparationFoldersToDomain(response, "board");
+        const previousSelectedSourceName =
+          loadedPreparationNameRef.current === normalizedPreparationName
+            ? selectedSourceNameRef.current
+            : null;
+        const reconciledSelection = reconcileSelectedPreparationFolder(
+          previousSelectedSourceName,
+          folders
+        );
+
+        if (reconciledSelection.wasRemoved) {
+          console.warn("[UC-18] Usunieto nieaktualne wybrane zrodlo po odswiezeniu.", {
+            preparationName: normalizedPreparationName,
+            removedSelection: true,
+            type: "board",
+          });
+        }
+
+        console.info("[UC-18] Zaladowano zrodla board.", {
+          preparationName: normalizedPreparationName,
+          totalCount: response.totalCount,
+          type: "board",
+        });
+
+        dispatch({
+          type: "loadSucceeded",
+          preparationName: normalizedPreparationName,
+          folders,
+          totalCount: response.totalCount,
+          selectedSourceName: reconciledSelection.selectedSourceName,
+        });
+      } catch (error) {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        let clearSelection = false;
+
+        if (error instanceof DatasetPreparationsApiError) {
+          if (error.status === 401) {
+            console.warn("[UC-18] Sesja administracyjna wygasla podczas ladowania zrodel.", {
+              errorType: error.errorType ?? null,
+              httpStatus: error.status,
+              preparationName: normalizedPreparationName,
+              type: "board",
+            });
+            onUnauthorized?.();
+          } else if (error.status === 404) {
+            clearSelection = true;
+            console.warn("[UC-18] Wybrane preparation nie jest juz dostepne.", {
+              errorType: error.errorType ?? null,
+              httpStatus: error.status,
+              preparationName: normalizedPreparationName,
+              type: "board",
+            });
+          } else if (error.status >= 500) {
+            console.error("[UC-18] Backend zwrocil blad podczas ladowania zrodel.", {
+              errorType: error.errorType ?? null,
+              httpStatus: error.status,
+              preparationName: normalizedPreparationName,
+              type: "board",
+            });
+          }
+        } else if (error instanceof Error) {
+          console.error("[UC-18] Nie udalo sie przetworzyc odpowiedzi zrodel board.", {
+            message: error.message,
+            preparationName: normalizedPreparationName,
+            type: "board",
+          });
+        }
+
+        dispatch({
+          type: "loadFailed",
+          preparationName: normalizedPreparationName,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Nie udalo sie pobrac listy zrodel board.",
+          errorType:
+            error instanceof DatasetPreparationsApiError ? error.errorType ?? null : null,
+          httpStatus:
+            error instanceof DatasetPreparationsApiError ? error.status : null,
+          clearSelection,
+        });
+      } finally {
+        if (activeControllerRef.current === controller) {
+          activeControllerRef.current = null;
+        }
+      }
+    },
+    [accessToken, apiBaseUrl, onUnauthorized]
+  );
+
+  const retryLoadBoardFolders = useCallback(async () => {
+    const sourcePreparationName = preparationName?.trim() || state.preparationName;
+    if (!sourcePreparationName) {
+      return;
+    }
+
+    console.info("[UC-18] Reczne odswiezenie listy zrodel board.", {
+      preparationName: sourcePreparationName,
+      type: "board",
+    });
+    await loadBoardFolders(sourcePreparationName);
+  }, [loadBoardFolders, preparationName, state.preparationName]);
+
+  const selectBoardSource = useCallback((sourceName: string) => {
+    dispatch({
+      type: "selectionChanged",
+      sourceName,
+    });
+  }, []);
+
+  useEffect(() => {
+    const normalizedPreparationName = preparationName?.trim() ?? "";
+
+    if (!normalizedPreparationName) {
+      activeControllerRef.current?.abort();
+      dispatch({ type: "stateReset" });
+      return;
+    }
+
+    void loadBoardFolders(normalizedPreparationName);
+  }, [loadBoardFolders, preparationName]);
+
+  useEffect(() => {
+    return () => {
+      activeControllerRef.current?.abort();
+    };
+  }, []);
+
+  const selectedFolder = useMemo(
+    () =>
+      state.selectedSourceName === null
+        ? null
+        : state.folders.find((folder) => folder.folderName === state.selectedSourceName) ??
+          null,
+    [state.folders, state.selectedSourceName]
+  );
+
+  return {
+    status: state.status,
+    preparationName: state.preparationName,
+    folders: state.folders,
+    selectedSourceName: state.selectedSourceName,
+    selectedFolder,
+    error: state.error,
+    errorType: state.errorType,
+    httpStatus: state.httpStatus,
+    totalCount: state.totalCount,
+    loadBoardFolders,
+    retryLoadBoardFolders,
+    selectBoardSource,
+  };
+}

--- a/src/Frontend/src/features/uc18/application/useUc18BoardImage.ts
+++ b/src/Frontend/src/features/uc18/application/useUc18BoardImage.ts
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+
+import {
+  DatasetPreparationsApiError,
+  getDatasetPreparationBoardImageByEndpoint,
+} from "../../../api/datasetPreparations";
+import { toImageDataUrl } from "../../../shared/images/toImageDataUrl";
+import { toUc18BoardImageRequestKey } from "../domain/toUc18BoardImageRequestKey";
+import { uc18BoardImageReducer } from "./uc18BoardImageReducer";
+import {
+  defaultUc18BoardImageState,
+  type UseUc18BoardImageOptions,
+  type UseUc18BoardImageResult,
+} from "./uc18BoardImageTypes";
+
+export function useUc18BoardImage({
+  apiBaseUrl,
+  imageEndpoint,
+  preparationName,
+  sourceName,
+  boardFolderName,
+  accessToken,
+  onUnauthorized,
+}: UseUc18BoardImageOptions): UseUc18BoardImageResult {
+  const [state, dispatch] = useReducer(
+    uc18BoardImageReducer,
+    defaultUc18BoardImageState
+  );
+  const activeControllerRef = useRef<AbortController | null>(null);
+
+  const requestKey = useMemo(
+    () =>
+      toUc18BoardImageRequestKey({
+        preparationName,
+        sourceName,
+        boardFolderName,
+      }),
+    [boardFolderName, preparationName, sourceName]
+  );
+
+  const loadBoardImage = useCallback(async () => {
+    const normalizedEndpoint = imageEndpoint.trim();
+
+    if (!normalizedEndpoint) {
+      activeControllerRef.current?.abort();
+      console.warn("[UC-18] Brak endpointu preview planszy.", {
+        boardFolderName,
+        preparationName,
+        sourceName,
+      });
+      dispatch({
+        type: "loadStarted",
+        requestKey,
+      });
+      dispatch({
+        type: "loadFailed",
+        requestKey,
+        error: "Brak endpointu preview.",
+        errorType: null,
+        httpStatus: null,
+      });
+      return;
+    }
+
+    activeControllerRef.current?.abort();
+
+    const controller = new AbortController();
+    activeControllerRef.current = controller;
+
+    dispatch({
+      type: "loadStarted",
+      requestKey,
+    });
+
+    try {
+      const response = await getDatasetPreparationBoardImageByEndpoint(
+        apiBaseUrl,
+        normalizedEndpoint,
+        accessToken,
+        controller.signal
+      );
+
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      dispatch({
+        type: "loadSucceeded",
+        requestKey,
+        imageDataUrl: toImageDataUrl(response),
+      });
+    } catch (error) {
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      if (error instanceof DatasetPreparationsApiError) {
+        if (error.status === 401) {
+          console.warn("[UC-18] Sesja administracyjna wygasla podczas ladowania preview planszy.", {
+            boardFolderName,
+            errorType: error.errorType ?? null,
+            httpStatus: error.status,
+            preparationName,
+            sourceName,
+          });
+          onUnauthorized?.();
+        } else if (error.status === 403 || error.status === 404) {
+          console.warn("[UC-18] Nie udalo sie pobrac preview planszy.", {
+            boardFolderName,
+            errorType: error.errorType ?? null,
+            httpStatus: error.status,
+            preparationName,
+            sourceName,
+          });
+        } else if (error.status >= 500) {
+          console.error("[UC-18] Backend zwrocil blad podczas ladowania preview planszy.", {
+            boardFolderName,
+            errorType: error.errorType ?? null,
+            httpStatus: error.status,
+            preparationName,
+            sourceName,
+          });
+        }
+      } else if (error instanceof Error) {
+        console.error("[UC-18] Nie udalo sie przetworzyc preview planszy.", {
+          boardFolderName,
+          message: error.message,
+          preparationName,
+          sourceName,
+        });
+      }
+
+      dispatch({
+        type: "loadFailed",
+        requestKey,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Nie udalo sie pobrac preview planszy.",
+        errorType:
+          error instanceof DatasetPreparationsApiError ? error.errorType ?? null : null,
+        httpStatus:
+          error instanceof DatasetPreparationsApiError ? error.status : null,
+      });
+    } finally {
+      if (activeControllerRef.current === controller) {
+        activeControllerRef.current = null;
+      }
+    }
+  }, [
+    accessToken,
+    apiBaseUrl,
+    boardFolderName,
+    imageEndpoint,
+    onUnauthorized,
+    preparationName,
+    requestKey,
+    sourceName,
+  ]);
+
+  const retryLoadBoardImage = useCallback(async () => {
+    console.info("[UC-18] Reczne ponowienie ladowania preview planszy.", {
+      boardFolderName,
+      preparationName,
+      sourceName,
+    });
+    await loadBoardImage();
+  }, [boardFolderName, loadBoardImage, preparationName, sourceName]);
+
+  useEffect(() => {
+    void loadBoardImage();
+  }, [loadBoardImage]);
+
+  useEffect(() => {
+    return () => {
+      activeControllerRef.current?.abort();
+    };
+  }, []);
+
+  return {
+    status: state.status,
+    requestKey: state.requestKey,
+    imageDataUrl: state.imageDataUrl,
+    error: state.error,
+    errorType: state.errorType,
+    httpStatus: state.httpStatus,
+    loadBoardImage,
+    retryLoadBoardImage,
+  };
+}

--- a/src/Frontend/src/features/uc18/application/useUc18DeleteBoardFile.ts
+++ b/src/Frontend/src/features/uc18/application/useUc18DeleteBoardFile.ts
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useReducer, useRef } from "react";
+
+import {
+  DatasetPreparationsApiError,
+  deleteDatasetPreparationBoardFile,
+} from "../../../api/datasetPreparations";
+import { isUc18BoardFileWithinScope } from "../domain/isUc18BoardFileWithinScope";
+import type { Uc18BoardFile } from "../domain/uc18BoardFile";
+import { uc18DeleteBoardFileReducer } from "./uc18DeleteBoardFileReducer";
+import {
+  defaultUc18DeleteBoardFileState,
+  type UseUc18DeleteBoardFileOptions,
+  type UseUc18DeleteBoardFileResult,
+} from "./uc18DeleteBoardFileTypes";
+
+export function useUc18DeleteBoardFile({
+  apiBaseUrl,
+  preparationName,
+  sourceName,
+  page,
+  pageSize,
+  accessToken,
+  onUnauthorized,
+  loadBoardFiles,
+}: UseUc18DeleteBoardFileOptions): UseUc18DeleteBoardFileResult {
+  const [state, dispatch] = useReducer(
+    uc18DeleteBoardFileReducer,
+    defaultUc18DeleteBoardFileState
+  );
+  const activeControllerRef = useRef<AbortController | null>(null);
+
+  const clearDeleteFeedback = useCallback(() => {
+    dispatch({ type: "stateReset" });
+  }, []);
+
+  const deleteBoardFile = useCallback(
+    async (boardFile: Uc18BoardFile) => {
+      const normalizedPreparationName = preparationName?.trim() ?? "";
+      const normalizedSourceName = sourceName?.trim() ?? "";
+
+      if (!normalizedPreparationName || !normalizedSourceName) {
+        console.warn("[UC-18] Odrzucono delete planszy bez aktywnego scope'u.", {
+          boardFolderName: boardFile.boardFolderName,
+          preparationName: normalizedPreparationName || null,
+          sourceName: normalizedSourceName || null,
+        });
+        dispatch({
+          type: "deleteFailed",
+          boardFileKey: boardFile.key,
+          boardFolderName: boardFile.boardFolderName,
+          error: "Brak aktywnego preparation albo source do usuniecia planszy.",
+          errorType: null,
+          httpStatus: null,
+        });
+        return false;
+      }
+
+      if (
+        !isUc18BoardFileWithinScope(
+          boardFile,
+          normalizedPreparationName,
+          normalizedSourceName
+        )
+      ) {
+        console.warn("[UC-18] Odrzucono delete planszy spoza aktywnego scope'u.", {
+          boardFolderName: boardFile.boardFolderName,
+          preparationName: normalizedPreparationName,
+          sourceName: normalizedSourceName,
+        });
+        dispatch({
+          type: "deleteFailed",
+          boardFileKey: boardFile.key,
+          boardFolderName: boardFile.boardFolderName,
+          error: "Klikniety rekord nie nalezy do aktualnej listy plansz.",
+          errorType: null,
+          httpStatus: null,
+        });
+        return false;
+      }
+
+      activeControllerRef.current?.abort();
+
+      const controller = new AbortController();
+      activeControllerRef.current = controller;
+
+      console.info("[UC-18] Start usuwania planszy board.", {
+        boardFolderName: boardFile.boardFolderName,
+        page,
+        pageSize,
+        preparationName: normalizedPreparationName,
+        sourceName: normalizedSourceName,
+      });
+      dispatch({
+        type: "deleteStarted",
+        boardFileKey: boardFile.key,
+        boardFolderName: boardFile.boardFolderName,
+      });
+
+      try {
+        const response = await deleteDatasetPreparationBoardFile(
+          apiBaseUrl,
+          {
+            preparationName: normalizedPreparationName,
+            sourceName: normalizedSourceName,
+            boardFolderName: boardFile.boardFolderName,
+          },
+          accessToken,
+          controller.signal
+        );
+
+        if (controller.signal.aborted) {
+          return false;
+        }
+
+        if (response.deleted !== true) {
+          throw new Error(
+            "Backend zwrocil niespojny kontrakt delete dla planszy board."
+          );
+        }
+
+        console.info("[UC-18] Usunieto plansze board, odswiezam liste.", {
+          boardFolderName: response.boardFolderName,
+          page,
+          pageSize,
+          preparationName: normalizedPreparationName,
+          remainingItemsCount: response.remainingItemsCount,
+          sourceName: normalizedSourceName,
+        });
+        await loadBoardFiles(
+          normalizedPreparationName,
+          normalizedSourceName,
+          page,
+          pageSize
+        );
+
+        dispatch({
+          type: "deleteSucceeded",
+          boardFileKey: boardFile.key,
+          boardFolderName: response.boardFolderName,
+          remainingItemsCount: response.remainingItemsCount,
+        });
+        return true;
+      } catch (error) {
+        if (controller.signal.aborted) {
+          return false;
+        }
+
+        let shouldReloadAfterFailure = false;
+
+        if (error instanceof DatasetPreparationsApiError) {
+          if (error.status === 401) {
+            console.warn("[UC-18] Sesja administracyjna wygasla podczas usuwania planszy.", {
+              boardFolderName: boardFile.boardFolderName,
+              errorType: error.errorType ?? null,
+              httpStatus: error.status,
+              page,
+              pageSize,
+              preparationName: normalizedPreparationName,
+              sourceName: normalizedSourceName,
+            });
+            onUnauthorized?.();
+          } else if (error.status === 404) {
+            shouldReloadAfterFailure = true;
+            console.warn("[UC-18] Usuwana plansza nie jest juz dostepna, wykonuje reconcile listy.", {
+              boardFolderName: boardFile.boardFolderName,
+              errorType: error.errorType ?? null,
+              httpStatus: error.status,
+              page,
+              pageSize,
+              preparationName: normalizedPreparationName,
+              sourceName: normalizedSourceName,
+            });
+          } else if (error.status === 409 || error.status === 422) {
+            console.warn("[UC-18] Backend odrzucil usuniecie planszy board.", {
+              boardFolderName: boardFile.boardFolderName,
+              errorType: error.errorType ?? null,
+              httpStatus: error.status,
+              page,
+              pageSize,
+              preparationName: normalizedPreparationName,
+              sourceName: normalizedSourceName,
+            });
+          } else if (error.status >= 500) {
+            console.error("[UC-18] Backend zwrocil blad podczas usuwania planszy board.", {
+              boardFolderName: boardFile.boardFolderName,
+              errorType: error.errorType ?? null,
+              httpStatus: error.status,
+              page,
+              pageSize,
+              preparationName: normalizedPreparationName,
+              sourceName: normalizedSourceName,
+            });
+          }
+        } else if (error instanceof Error) {
+          console.error("[UC-18] Nie udalo sie przetworzyc odpowiedzi delete planszy board.", {
+            boardFolderName: boardFile.boardFolderName,
+            message: error.message,
+            page,
+            pageSize,
+            preparationName: normalizedPreparationName,
+            sourceName: normalizedSourceName,
+          });
+        }
+
+        dispatch({
+          type: "deleteFailed",
+          boardFileKey: boardFile.key,
+          boardFolderName: boardFile.boardFolderName,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Nie udalo sie usunac planszy board.",
+          errorType:
+            error instanceof DatasetPreparationsApiError ? error.errorType ?? null : null,
+          httpStatus:
+            error instanceof DatasetPreparationsApiError ? error.status : null,
+        });
+
+        if (shouldReloadAfterFailure) {
+          await loadBoardFiles(
+            normalizedPreparationName,
+            normalizedSourceName,
+            page,
+            pageSize
+          );
+        }
+
+        return false;
+      } finally {
+        if (activeControllerRef.current === controller) {
+          activeControllerRef.current = null;
+        }
+      }
+    },
+    [
+      accessToken,
+      apiBaseUrl,
+      loadBoardFiles,
+      onUnauthorized,
+      page,
+      pageSize,
+      preparationName,
+      sourceName,
+    ]
+  );
+
+  const retryDeleteBoardFile = useCallback(
+    async (boardFile: Uc18BoardFile) => {
+      return deleteBoardFile(boardFile);
+    },
+    [deleteBoardFile]
+  );
+
+  useEffect(() => {
+    dispatch({ type: "stateReset" });
+  }, [preparationName, sourceName]);
+
+  useEffect(() => {
+    return () => {
+      activeControllerRef.current?.abort();
+    };
+  }, []);
+
+  return {
+    status: state.status,
+    deletingBoardFileKey: state.boardFileKey,
+    boardFolderName: state.boardFolderName,
+    remainingItemsCount: state.remainingItemsCount,
+    error: state.error,
+    errorType: state.errorType,
+    httpStatus: state.httpStatus,
+    isDeleting: state.status === "deleting",
+    deleteBoardFile,
+    retryDeleteBoardFile,
+    clearDeleteFeedback,
+  };
+}

--- a/src/Frontend/src/features/uc18/application/useUc18DigitFolders.ts
+++ b/src/Frontend/src/features/uc18/application/useUc18DigitFolders.ts
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useReducer, useRef } from "react";
+
+import {
+  DatasetPreparationsApiError,
+  getDatasetPreparationFolders,
+} from "../../../api/datasetPreparations";
+import { mapDatasetPreparationFoldersToDomain } from "../domain/mapDatasetPreparationFoldersToDomain";
+import { uc18DigitFoldersReducer } from "./uc18DigitFoldersReducer";
+import {
+  defaultUc18DigitFoldersState,
+  type UseUc18DigitFoldersOptions,
+} from "./uc18DigitFoldersTypes";
+
+export function useUc18DigitFolders({
+  apiBaseUrl,
+  preparationName,
+  accessToken,
+  onUnauthorized,
+}: UseUc18DigitFoldersOptions) {
+  const [state, dispatch] = useReducer(
+    uc18DigitFoldersReducer,
+    defaultUc18DigitFoldersState
+  );
+  const activeControllerRef = useRef<AbortController | null>(null);
+
+  const loadDigitFolders = useCallback(
+    async (nextPreparationName: string) => {
+      const normalizedPreparationName = nextPreparationName.trim();
+
+      if (!normalizedPreparationName) {
+        activeControllerRef.current?.abort();
+        dispatch({ type: "stateReset" });
+        return;
+      }
+
+      activeControllerRef.current?.abort();
+
+      const controller = new AbortController();
+      activeControllerRef.current = controller;
+
+      console.info("[UC-18] Start ladowania zrodel digit.", {
+        preparationName: normalizedPreparationName,
+        type: "digit",
+      });
+      dispatch({
+        type: "loadStarted",
+        preparationName: normalizedPreparationName,
+      });
+
+      try {
+        const response = await getDatasetPreparationFolders(
+          apiBaseUrl,
+          normalizedPreparationName,
+          "digit",
+          accessToken,
+          controller.signal
+        );
+
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        const folders = mapDatasetPreparationFoldersToDomain(response, "digit");
+
+        console.info("[UC-18] Zaladowano zrodla digit.", {
+          preparationName: normalizedPreparationName,
+          totalCount: response.totalCount,
+          type: "digit",
+        });
+
+        dispatch({
+          type: "loadSucceeded",
+          preparationName: normalizedPreparationName,
+          folders,
+          totalCount: response.totalCount,
+        });
+      } catch (error) {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        if (error instanceof DatasetPreparationsApiError) {
+          if (error.status === 401) {
+            console.warn("[UC-18] Sesja administracyjna wygasla podczas ladowania zrodel.", {
+              errorType: error.errorType ?? null,
+              httpStatus: error.status,
+              preparationName: normalizedPreparationName,
+              type: "digit",
+            });
+            onUnauthorized?.();
+          } else if (error.status === 404) {
+            console.warn("[UC-18] Wybrane preparation nie jest juz dostepne.", {
+              errorType: error.errorType ?? null,
+              httpStatus: error.status,
+              preparationName: normalizedPreparationName,
+              type: "digit",
+            });
+          } else if (error.status >= 500) {
+            console.error("[UC-18] Backend zwrocil blad podczas ladowania zrodel.", {
+              errorType: error.errorType ?? null,
+              httpStatus: error.status,
+              preparationName: normalizedPreparationName,
+              type: "digit",
+            });
+          }
+        } else if (error instanceof Error) {
+          console.error("[UC-18] Nie udalo sie przetworzyc odpowiedzi zrodel digit.", {
+            message: error.message,
+            preparationName: normalizedPreparationName,
+            type: "digit",
+          });
+        }
+
+        dispatch({
+          type: "loadFailed",
+          preparationName: normalizedPreparationName,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Nie udalo sie pobrac listy zrodel digit.",
+          errorType:
+            error instanceof DatasetPreparationsApiError ? error.errorType ?? null : null,
+          httpStatus:
+            error instanceof DatasetPreparationsApiError ? error.status : null,
+        });
+      } finally {
+        if (activeControllerRef.current === controller) {
+          activeControllerRef.current = null;
+        }
+      }
+    },
+    [accessToken, apiBaseUrl, onUnauthorized]
+  );
+
+  const retryLoadDigitFolders = useCallback(async () => {
+    const sourcePreparationName = preparationName?.trim() || state.preparationName;
+    if (!sourcePreparationName) {
+      return;
+    }
+
+    console.info("[UC-18] Reczne odswiezenie listy zrodel digit.", {
+      preparationName: sourcePreparationName,
+      type: "digit",
+    });
+    await loadDigitFolders(sourcePreparationName);
+  }, [loadDigitFolders, preparationName, state.preparationName]);
+
+  useEffect(() => {
+    const normalizedPreparationName = preparationName?.trim() ?? "";
+
+    if (!normalizedPreparationName) {
+      activeControllerRef.current?.abort();
+      dispatch({ type: "stateReset" });
+      return;
+    }
+
+    void loadDigitFolders(normalizedPreparationName);
+  }, [loadDigitFolders, preparationName]);
+
+  useEffect(() => {
+    return () => {
+      activeControllerRef.current?.abort();
+    };
+  }, []);
+
+  return {
+    status: state.status,
+    preparationName: state.preparationName,
+    folders: state.folders,
+    totalCount: state.totalCount,
+    error: state.error,
+    errorType: state.errorType,
+    httpStatus: state.httpStatus,
+    loadDigitFolders,
+    retryLoadDigitFolders,
+  };
+}

--- a/src/Frontend/src/features/uc18/domain/isUc18BoardFileWithinScope.ts
+++ b/src/Frontend/src/features/uc18/domain/isUc18BoardFileWithinScope.ts
@@ -1,0 +1,12 @@
+import type { Uc18BoardFile } from "./uc18BoardFile";
+
+export function isUc18BoardFileWithinScope(
+  boardFile: Uc18BoardFile,
+  preparationName: string,
+  sourceName: string
+): boolean {
+  return (
+    boardFile.preparationName === preparationName &&
+    boardFile.sourceName === sourceName
+  );
+}

--- a/src/Frontend/src/features/uc18/domain/mapDatasetPreparationBoardFilesToDomain.ts
+++ b/src/Frontend/src/features/uc18/domain/mapDatasetPreparationBoardFilesToDomain.ts
@@ -1,0 +1,32 @@
+import type { DatasetPreparationBoardFilesApiResponse } from "../../../types/api";
+import { toUc18BoardFileKey, type Uc18BoardFile } from "./uc18BoardFile";
+
+export function mapDatasetPreparationBoardFilesToDomain(
+  response: DatasetPreparationBoardFilesApiResponse,
+  expectedPreparationName: string,
+  expectedSourceName: string
+): Uc18BoardFile[] {
+  if (response.preparationName !== expectedPreparationName) {
+    throw new Error(
+      `Backend zwrocil preparationName ${response.preparationName}, ale oczekiwano ${expectedPreparationName}.`
+    );
+  }
+
+  if (response.sourceName !== expectedSourceName) {
+    throw new Error(
+      `Backend zwrocil sourceName ${response.sourceName}, ale oczekiwano ${expectedSourceName}.`
+    );
+  }
+
+  return response.items.map((item) => ({
+    key: toUc18BoardFileKey({
+      preparationName: response.preparationName,
+      sourceName: response.sourceName,
+      boardFolderName: item.boardFolderName,
+    }),
+    preparationName: response.preparationName,
+    sourceName: response.sourceName,
+    boardFolderName: item.boardFolderName,
+    imageEndpoint: item.imageEndpoint,
+  }));
+}

--- a/src/Frontend/src/features/uc18/domain/mapDatasetPreparationFoldersToDomain.ts
+++ b/src/Frontend/src/features/uc18/domain/mapDatasetPreparationFoldersToDomain.ts
@@ -1,0 +1,32 @@
+import type { DatasetPreparationFoldersApiResponse } from "../../../types/api";
+import {
+  isUc18PreparationFolderType,
+  type Uc18PreparationFolder,
+  type Uc18PreparationFolderType,
+} from "./uc18PreparationFolder";
+import { toUc18PreparationFolderKey } from "./toUc18PreparationFolderKey";
+
+export function mapDatasetPreparationFoldersToDomain(
+  response: DatasetPreparationFoldersApiResponse,
+  expectedType: Uc18PreparationFolderType
+): Uc18PreparationFolder[] {
+  if (!isUc18PreparationFolderType(response.type)) {
+    throw new Error(`Backend zwrocil nieobslugiwany typ folderow: ${response.type}.`);
+  }
+
+  if (response.type !== expectedType) {
+    throw new Error(
+      `Backend zwrocil typ folderow ${response.type}, ale oczekiwano ${expectedType}.`
+    );
+  }
+
+  return response.items.map((folderName) => ({
+    key: toUc18PreparationFolderKey({
+      folderName,
+      type: expectedType,
+    }),
+    preparationName: response.preparationName,
+    type: expectedType,
+    folderName,
+  }));
+}

--- a/src/Frontend/src/features/uc18/domain/reconcileSelectedPreparationFolder.ts
+++ b/src/Frontend/src/features/uc18/domain/reconcileSelectedPreparationFolder.ts
@@ -1,0 +1,34 @@
+import type { Uc18PreparationFolder } from "./uc18PreparationFolder";
+
+export type ReconciledSelectedPreparationFolder = {
+  selectedSourceName: string | null;
+  wasRemoved: boolean;
+};
+
+export function reconcileSelectedPreparationFolder(
+  previousSelectedSourceName: string | null,
+  folders: Uc18PreparationFolder[]
+): ReconciledSelectedPreparationFolder {
+  if (previousSelectedSourceName === null) {
+    return {
+      selectedSourceName: null,
+      wasRemoved: false,
+    };
+  }
+
+  const stillExists = folders.some(
+    (folder) => folder.folderName === previousSelectedSourceName
+  );
+
+  if (stillExists) {
+    return {
+      selectedSourceName: previousSelectedSourceName,
+      wasRemoved: false,
+    };
+  }
+
+  return {
+    selectedSourceName: null,
+    wasRemoved: true,
+  };
+}

--- a/src/Frontend/src/features/uc18/domain/resolveUc18BoardFilesPageAfterLoad.ts
+++ b/src/Frontend/src/features/uc18/domain/resolveUc18BoardFilesPageAfterLoad.ts
@@ -1,0 +1,32 @@
+export type Uc18BoardFilesPageResolution = {
+  requestedPage: number;
+  responsePage: number;
+  responsePageSize: number;
+  lastPage: number;
+  shouldReloadLastPage: boolean;
+};
+
+export function resolveUc18BoardFilesPageAfterLoad(
+  requestedPage: number,
+  responsePage: number,
+  responsePageSize: number,
+  totalCount: number,
+  itemsCount: number
+): Uc18BoardFilesPageResolution {
+  const safePageSize = responsePageSize > 0 ? responsePageSize : 1;
+  const lastPage = Math.max(1, Math.ceil(totalCount / safePageSize));
+  const requestedPageExceedsLastPage = totalCount > 0 && requestedPage > lastPage;
+  const backendDidNotClampToLastPage = responsePage !== lastPage;
+  const receivedEmptyOutOfRangePage =
+    itemsCount === 0 && totalCount > 0 && responsePage > lastPage;
+
+  return {
+    requestedPage,
+    responsePage,
+    responsePageSize: safePageSize,
+    lastPage,
+    shouldReloadLastPage:
+      requestedPageExceedsLastPage &&
+      (backendDidNotClampToLastPage || receivedEmptyOutOfRangePage),
+  };
+}

--- a/src/Frontend/src/features/uc18/domain/resolveUc18BoardImageRequestUrl.ts
+++ b/src/Frontend/src/features/uc18/domain/resolveUc18BoardImageRequestUrl.ts
@@ -1,0 +1,26 @@
+export function resolveUc18BoardImageRequestUrl(
+  apiBaseUrl: string,
+  imageEndpoint: string
+): string {
+  const trimmedEndpoint = imageEndpoint.trim();
+
+  if (!trimmedEndpoint) {
+    return "";
+  }
+
+  if (
+    trimmedEndpoint.startsWith("http://") ||
+    trimmedEndpoint.startsWith("https://")
+  ) {
+    return trimmedEndpoint;
+  }
+
+  if (trimmedEndpoint.startsWith("/")) {
+    return trimmedEndpoint;
+  }
+
+  const normalizedBaseUrl = apiBaseUrl.replace(/\/+$/, "");
+  const normalizedEndpoint = trimmedEndpoint.replace(/^\/+/, "");
+
+  return `${normalizedBaseUrl}/${normalizedEndpoint}`;
+}

--- a/src/Frontend/src/features/uc18/domain/toUc18BoardImageRequestKey.ts
+++ b/src/Frontend/src/features/uc18/domain/toUc18BoardImageRequestKey.ts
@@ -1,0 +1,15 @@
+import {
+  toUc18BoardFileKey,
+} from "./uc18BoardFile";
+
+export function toUc18BoardImageRequestKey(boardFile: {
+  preparationName: string;
+  sourceName: string;
+  boardFolderName: string;
+}): string {
+  return toUc18BoardFileKey({
+    preparationName: boardFile.preparationName,
+    sourceName: boardFile.sourceName,
+    boardFolderName: boardFile.boardFolderName,
+  });
+}

--- a/src/Frontend/src/features/uc18/domain/toUc18PreparationFolderKey.ts
+++ b/src/Frontend/src/features/uc18/domain/toUc18PreparationFolderKey.ts
@@ -1,0 +1,13 @@
+import type { Uc18PreparationFolderType } from "./uc18PreparationFolder";
+
+type Uc18PreparationFolderIdentity = {
+  folderName: string;
+  type: Uc18PreparationFolderType;
+};
+
+export function toUc18PreparationFolderKey({
+  folderName,
+  type,
+}: Uc18PreparationFolderIdentity): string {
+  return `${type}:${folderName}`;
+}

--- a/src/Frontend/src/features/uc18/domain/uc18BoardFile.ts
+++ b/src/Frontend/src/features/uc18/domain/uc18BoardFile.ts
@@ -1,0 +1,15 @@
+export type Uc18BoardFile = {
+  key: string;
+  preparationName: string;
+  sourceName: string;
+  boardFolderName: string;
+  imageEndpoint: string;
+};
+
+export function toUc18BoardFileKey(input: {
+  preparationName: string;
+  sourceName: string;
+  boardFolderName: string;
+}): string {
+  return `${input.preparationName}:${input.sourceName}:${input.boardFolderName}`;
+}

--- a/src/Frontend/src/features/uc18/domain/uc18PreparationFolder.ts
+++ b/src/Frontend/src/features/uc18/domain/uc18PreparationFolder.ts
@@ -1,0 +1,14 @@
+export type Uc18PreparationFolderType = "board" | "digit";
+
+export type Uc18PreparationFolder = {
+  key: string;
+  preparationName: string;
+  type: Uc18PreparationFolderType;
+  folderName: string;
+};
+
+export function isUc18PreparationFolderType(
+  value: string
+): value is Uc18PreparationFolderType {
+  return value === "board" || value === "digit";
+}

--- a/src/Frontend/src/styles/datasets.css
+++ b/src/Frontend/src/styles/datasets.css
@@ -1,6 +1,7 @@
 .datasets-module-header,
 .uc06-section,
 .uc11-section,
+.uc18-section,
 .uc17-section,
 .uc12-section,
 .uc14-aside-card {
@@ -224,9 +225,251 @@
   gap: 0.55rem;
 }
 
+.uc18-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.uc18-folders-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.uc18-folder-button,
+.uc18-folder-card {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  text-align: left;
+  padding: 0.85rem 0.95rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.58);
+  color: inherit;
+}
+
+.uc18-folder-button {
+  cursor: pointer;
+}
+
+.uc18-folder-button.is-active {
+  border-color: rgba(56, 189, 248, 0.75);
+  background: rgba(14, 116, 144, 0.18);
+}
+
+.uc18-folder-card.is-readonly {
+  border-color: rgba(74, 222, 128, 0.28);
+  background: rgba(22, 101, 52, 0.14);
+}
+
+.uc18-folder-button:disabled {
+  opacity: 0.7;
+  cursor: progress;
+}
+
+.uc18-board-files-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.uc18-board-file-item {
+  min-width: 0;
+}
+
+.uc18-board-file-card {
+  display: grid;
+  gap: 0.9rem;
+  padding: 0.95rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.58);
+  grid-template-columns: minmax(0, 1.35fr) minmax(240px, 1fr);
+}
+
+.uc18-board-file-card.is-deleting {
+  opacity: 0.76;
+  border-color: rgba(248, 113, 113, 0.42);
+  background: rgba(127, 29, 29, 0.16);
+}
+
+.uc18-board-file-copy,
+.uc18-board-file-preview,
+.uc18-board-files-footer {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.danger-button {
+  padding: 0.5rem 0.9rem;
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  border-radius: 10px;
+  background: rgba(127, 29, 29, 0.28);
+  color: #fecaca;
+  font-weight: 700;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    opacity 120ms ease;
+}
+
+.danger-button:hover:not(:disabled) {
+  background: rgba(185, 28, 28, 0.34);
+  border-color: rgba(252, 165, 165, 0.6);
+}
+
+.danger-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.uc18-board-file-delete-slot,
+.uc18-board-file-delete-confirmation {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.uc18-board-file-delete-confirmation {
+  padding: 0.75rem;
+  border: 1px solid rgba(248, 113, 113, 0.28);
+  border-radius: 10px;
+  background: rgba(127, 29, 29, 0.16);
+}
+
+.uc18-board-file-delete-warning,
+.uc18-board-file-delete-error {
+  margin: 0;
+}
+
+.uc18-board-file-delete-warning {
+  color: #fecaca;
+}
+
+.uc18-board-file-delete-error {
+  color: #fca5a5;
+  font-size: 0.88rem;
+}
+
+.uc18-board-file-delete-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.uc18-board-file-copy strong,
+.uc18-board-file-preview-label {
+  color: #e0f2fe;
+}
+
+.uc18-board-file-preview {
+  padding: 0.8rem 0.85rem;
+  border: 1px dashed rgba(56, 189, 248, 0.35);
+  border-radius: 12px;
+  background: rgba(14, 116, 144, 0.12);
+}
+
+.uc18-board-file-preview-label {
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.uc18-board-image-state {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.uc18-board-image-state p {
+  margin: 0;
+}
+
+.uc18-board-image-state.is-error {
+  border: 1px solid rgba(248, 113, 113, 0.28);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: rgba(127, 29, 29, 0.18);
+}
+
+.uc18-board-image-skeleton {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background:
+    linear-gradient(
+      110deg,
+      rgba(15, 23, 42, 0.7) 8%,
+      rgba(56, 189, 248, 0.18) 18%,
+      rgba(15, 23, 42, 0.7) 33%
+    );
+  background-size: 200% 100%;
+  animation: uc18-board-image-shimmer 1.4s linear infinite;
+}
+
+.uc18-board-image {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: contain;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(2, 6, 23, 0.72);
+}
+
+.uc18-board-image-error-text {
+  margin: 0;
+  color: #fecaca;
+  font-size: 0.9rem;
+}
+
+.uc18-board-files-footer {
+  align-items: center;
+  justify-content: space-between;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.9rem;
+}
+
+.uc18-board-files-footer p {
+  margin: 0;
+}
+
+.uc18-board-files-pagination {
+  display: inline-flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
 .uc17-details {
   display: grid;
   gap: 0.8rem;
+}
+
+@media (max-width: 860px) {
+  .uc18-board-file-card,
+  .uc18-board-files-footer {
+    grid-template-columns: 1fr;
+  }
+}
+
+@keyframes uc18-board-image-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
 }
 
 .uc17-status-badge.is-queued {

--- a/src/Frontend/src/types/api.ts
+++ b/src/Frontend/src/types/api.ts
@@ -143,6 +143,35 @@ export type DatasetPreparationsListApiResponse = {
   totalCount: number;
 };
 
+export type DatasetPreparationFoldersApiResponse = {
+  preparationName: string;
+  type: string;
+  items: string[];
+  totalCount: number;
+};
+
+export type DatasetPreparationBoardFileListItemApiResponse = {
+  boardFolderName: string;
+  imageEndpoint: string;
+};
+
+export type DatasetPreparationBoardFilesApiResponse = {
+  preparationName: string;
+  sourceName: string;
+  items: DatasetPreparationBoardFileListItemApiResponse[];
+  page: number;
+  pageSize: number;
+  totalCount: number;
+};
+
+export type DeleteDatasetPreparationBoardFileApiResponse = {
+  preparationName: string;
+  sourceName: string;
+  boardFolderName: string;
+  deleted: boolean;
+  remainingItemsCount: number;
+};
+
 export type SelectedRawDatasetSourceApiEntry = {
   name: string;
   type: string;


### PR DESCRIPTION
- Added new endpoints for retrieving details of dataset preparations, listing board and digit folders, and fetching board files and images.
- Introduced a delete endpoint for removing specific board folders from preparations.
- Enhanced existing structures to support pagination and response formatting for the new endpoints.
- Ensured all new endpoints adhere to the established API contracts and reuse existing validation and error handling mechanisms.

These changes improve the dataset preparation workflow, providing comprehensive access to preparation details and enhancing data management capabilities within the application.