### PR TITLE
Add runtime root validation and refactor paths handling in ML workflow

### DIFF
--- a/.github/workflows/ml-cd.yml
+++ b/.github/workflows/ml-cd.yml
@@ -228,6 +228,58 @@ jobs:
           )
           PY
 
+      - name: Validate ML release runtime-root independence
+        shell: bash
+        run: |
+          python - <<'PY'
+          import importlib.util
+          import os
+          import shutil
+          import tempfile
+          from pathlib import Path
+
+          release_dir = Path(os.environ["ML_RELEASE_DIR"]).resolve()
+
+          with tempfile.TemporaryDirectory() as temp_directory:
+              runtime_root = Path(temp_directory) / "ml"
+              shutil.copytree(release_dir, runtime_root)
+
+              paths_module_path = (
+                  runtime_root
+                  / "infrastructure"
+                  / "vision"
+                  / "engine"
+                  / "paths.py"
+              )
+              if not paths_module_path.exists():
+                  raise SystemExit(
+                      f"Missing engine paths module in staged release: {paths_module_path}"
+                  )
+
+              spec = importlib.util.spec_from_file_location(
+                  "runtime_engine_paths",
+                  paths_module_path,
+              )
+              if spec is None or spec.loader is None:
+                  raise SystemExit(
+                      "Could not create import spec for ML runtime paths validation."
+                  )
+
+              module = importlib.util.module_from_spec(spec)
+              spec.loader.exec_module(module)
+
+              resolved_root = module.find_runtime_root(paths_module_path.parent)
+              if resolved_root != runtime_root:
+                  raise SystemExit(
+                      "ML release runtime root validation failed. "
+                      f"Expected {runtime_root}, got {resolved_root}."
+                  )
+
+              print(
+                  f"Validated ML runtime root resolution outside repo layout: {resolved_root}"
+              )
+          PY
+
       - name: Validate ML release layout
         shell: bash
         run: |

--- a/src/MachineLearning/infrastructure/vision/engine/models.py
+++ b/src/MachineLearning/infrastructure/vision/engine/models.py
@@ -5,13 +5,13 @@ from enum import Enum
 import math
 from pathlib import Path
 
-from .paths import REPO_ROOT
+from .paths import PROJECT_ROOT
 
 
 @dataclass(slots=True)
 class ExperimentConfig:
-    dataset_root: Path = REPO_ROOT / "data" / "raw" / "boards"
-    image_path: Path = Path("/home/wojtek/projects/sudoku/data/RemoveData/image1083.jpg")
+    dataset_root: Path | None = PROJECT_ROOT / "data" / "raw" / "boards"
+    image_path: Path | None = None
     selected_dataset_index: int = 0
     preview_limit: int = 20
     max_display_size: int = 1600

--- a/src/MachineLearning/infrastructure/vision/engine/paths.py
+++ b/src/MachineLearning/infrastructure/vision/engine/paths.py
@@ -8,19 +8,40 @@ if TYPE_CHECKING:
 
 
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
+RUNTIME_ROOT_MARKERS = (
+    "api",
+    "application",
+    "infrastructure",
+    "models",
+    "requirements.txt",
+)
 
 
-def find_repo_root(start_path: Path | None = None) -> Path:
+def _looks_like_runtime_root(candidate: Path) -> bool:
+    return all((candidate / marker).exists() for marker in RUNTIME_ROOT_MARKERS)
+
+
+def find_runtime_root(start_path: Path | None = None) -> Path:
     current_path = (start_path or Path.cwd()).resolve()
+    if current_path.is_file():
+        current_path = current_path.parent
+
     for candidate in [current_path, *current_path.parents]:
-        if (candidate / ".git").exists() or (candidate / ".ai").exists():
+        if _looks_like_runtime_root(candidate):
             return candidate
+
+        nested_runtime_root = candidate / "src" / "MachineLearning"
+        if _looks_like_runtime_root(nested_runtime_root):
+            return nested_runtime_root
+
     raise FileNotFoundError(
-        "Could not locate repository root from the current working directory."
+        "Could not locate MachineLearning runtime root from the current working directory."
     )
 
 
-REPO_ROOT = find_repo_root(Path(__file__).resolve().parent)
+PROJECT_ROOT = find_runtime_root(Path(__file__).resolve().parent)
+# Backwards-compatible alias kept for older draft tooling.
+REPO_ROOT = PROJECT_ROOT
 
 
 def discover_dataset_images(dataset_root: Path) -> list[Path]:
@@ -44,7 +65,11 @@ def path_for_display(path: Path, base_path: Path) -> str:
 def resolve_active_image_path(
     config: "ExperimentConfig",
 ) -> tuple[Path, list[Path]]:
-    dataset_images = discover_dataset_images(config.dataset_root)
+    dataset_images = (
+        []
+        if config.dataset_root is None
+        else discover_dataset_images(config.dataset_root)
+    )
 
     if config.image_path is not None:
         image_path = config.image_path.resolve()
@@ -66,9 +91,15 @@ def resolve_active_image_path(
 
 __all__ = [
     "IMAGE_EXTENSIONS",
+    "PROJECT_ROOT",
     "REPO_ROOT",
     "discover_dataset_images",
     "find_repo_root",
+    "find_runtime_root",
     "path_for_display",
     "resolve_active_image_path",
 ]
+
+
+def find_repo_root(start_path: Path | None = None) -> Path:
+    return find_runtime_root(start_path)

--- a/src/MachineLearning/tests/unit/test_engine_paths.py
+++ b/src/MachineLearning/tests/unit/test_engine_paths.py
@@ -1,0 +1,33 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from infrastructure.vision.engine.paths import find_runtime_root
+
+
+class EnginePathsTests(unittest.TestCase):
+    def test_find_runtime_root_should_resolve_release_layout_without_repo_markers(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp_directory:
+            runtime_root = Path(temp_directory) / "ml"
+            engine_dir = runtime_root / "infrastructure" / "vision" / "engine"
+
+            for relative_path in (
+                "api",
+                "application",
+                "infrastructure",
+                "models",
+            ):
+                (runtime_root / relative_path).mkdir(parents=True, exist_ok=True)
+
+            engine_dir.mkdir(parents=True, exist_ok=True)
+            (runtime_root / "requirements.txt").write_text("", encoding="utf-8")
+
+            resolved_root = find_runtime_root(engine_dir)
+
+            self.assertEqual(resolved_root, runtime_root)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Introduced a new validation step in the CI/CD workflow to ensure the ML release runtime root is independent of the repository layout.
- Refactored paths handling in the `paths.py` module to improve runtime root detection and added a backwards-compatible alias for `REPO_ROOT`.
- Updated `ExperimentConfig` in `models.py` to use `PROJECT_ROOT` and allow for optional dataset and image paths, enhancing flexibility in configuration.
- These changes aim to improve the robustness and adaptability of the ML infrastructure, ensuring proper runtime environment setup.